### PR TITLE
Add missing runtime dependency on jcl-over-slf4j

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -51,14 +51,16 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
 
     runtimeOnly "ch.qos.logback:logback-classic"
+    runtimeOnly "org.slf4j:jcl-over-slf4j"
 
     testFixturesApi testFixtures(project(':lib-common'))
 
     testImplementation "org.xerial:sqlite-jdbc"
-	testImplementation "org.postgresql:postgresql"
-	testImplementation "com.github.stefanbirkner:system-rules"
-	testImplementation "joda-time:joda-time"
+    testImplementation "org.postgresql:postgresql"
+    testImplementation "com.github.stefanbirkner:system-rules"
+    testImplementation "joda-time:joda-time"
 
+    sources "org.slf4j:jcl-over-slf4j:1.7.14@sources"
     sources "ch.qos.logback:logback-classic:1.2.3@sources"
 }
 

--- a/dumper/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/dumper/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -69,7 +69,8 @@ dependencies {
         implementation "com.swrve:rate-limited-logger:2.0.0"
         implementation "com.google.cloud:google-cloud-bigquery:1.126.3"
 
-		runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+        runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
+        runtimeOnly "org.slf4j:jcl-over-slf4j:$jclOverSlf4jVersion"
 
 		testFixturesApi "org.apache.commons:commons-compress:1.18"
         testFixturesApi "commons-io:commons-io:2.6"


### PR DESCRIPTION
The runtime dependency is required through `spring-jdbc`, if not provided the tool will fail as follows:
```
java.lang.ClassNotFoundException: org.apache.commons.logging.LogFactory
```