### PR TITLE
Change default output file name pattern, change product name in help.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/DefaultArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/DefaultArguments.java
@@ -86,7 +86,7 @@ public class DefaultArguments {
     }
 
     private static final String PRODUCT_GROUP = "com.google.edwmigration.dumper";
-    private static final String PRODUCT_CORE_MODULE = "compilerworks-application-dumper";
+    private static final String PRODUCT_CORE_MODULE = "dwh-migration-dumper";
 
     protected final OptionParser parser = new OptionParser();
     private final OptionSpec<?> helpOption = parser.accepts("help", "Displays command-line help.").forHelp();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -24,6 +24,6 @@ public interface LogsConnector extends Connector {
 
     @Override
     default public String getDefaultFileName() {
-        return "compilerworks-" + getName() + ".zip";
+        return "dwh-migration-" + getName() + ".zip";
     }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -24,6 +24,6 @@ public interface MetadataConnector extends Connector {
 
     @Override
     default public String getDefaultFileName() {
-        return "compilerworks-" + getName() + "-metadata.zip";
+        return "dwh-migration-" + getName() + "-metadata.zip";
     }
 }


### PR DESCRIPTION
Tool name in command line help (i.e. `--help`) and default output name pattern updated to be coherent with the repository name.