### PR TITLE
[IO] Ensure the target path directory exists before trying to write it

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
@@ -172,6 +172,7 @@ public class NetezzaMetadataConnector extends AbstractJdbcConnector implements M
         // Not documented.
         out.add(new JdbcSelectTask("nz.v_objects.csv", "SELECT * FROM system.._v_objects"));
 
+        // TODO; these might be placed in a ParallelTaskGroup?`
         // these neeed to be filtered on WHERE = dbname, or else which DB md table will contain SYSTEM data too
         for (String db : dbs) {
             // The benefit of having this reduces the amount of data in the zip file
@@ -181,7 +182,6 @@ public class NetezzaMetadataConnector extends AbstractJdbcConnector implements M
             // https://www.ibm.com/support/knowledgecenter/en/SSULQD_7.2.1/com.ibm.nz.adm.doc/t_sysadm_enable_multiple_schema.html
             String schemaPrefix = db + "..";    // We don't know what the default schema is, but it should contain the views we require.
             String filePrefix = db.toUpperCase() + "/"; // If we have databases with the same name but mismatched case, this will break.
-
             // also _v_relation_column: all attributes of a relation, Constraints and other informations
             // Undocumented?
             // TABLE_CAT,TABLE_SCHEM,TABLE_NAME,COLUMN_NAME,DATA_TYPE,TYPE_NAME,COLUMN_SIZE,BUFFER_LENGTH,DECIMAL_DIGITS,NUM_PREC_RADIX,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/FileSystemByteSink.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/FileSystemByteSink.java
@@ -39,10 +39,6 @@ public class FileSystemByteSink extends ByteSink {
 
     @Override
     public OutputStream openStream() throws IOException {
-        Path parent = path.getParent();
-        if (!Files.isDirectory(parent)) {
-            Files.createDirectory(parent);
-        }
         return Files.newOutputStream(path);
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/FileSystemByteSink.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/FileSystemByteSink.java
@@ -39,6 +39,10 @@ public class FileSystemByteSink extends ByteSink {
 
     @Override
     public OutputStream openStream() throws IOException {
+        Path parent = path.getParent();
+        if (!Files.isDirectory(parent)) {
+            Files.createDirectory(parent);
+        }
         return Files.newOutputStream(path);
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/FileSystemOutputHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/FileSystemOutputHandle.java
@@ -62,6 +62,12 @@ public class FileSystemOutputHandle implements OutputHandle {
     }
 
     @Override
+    public void prepare() throws IOException {
+        // Ensure the directory we want to write to exists
+        Files.createDirectories(targetPath.getParent());
+    }
+
+    @Override
     public void commit() throws IOException {
         if (!Files.exists(temporaryPath))
             throw new FileNotFoundException("File does not exist: " + temporaryPath + "; cannot move to " + targetPath);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/OutputHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/OutputHandle.java
@@ -46,6 +46,13 @@ public interface OutputHandle {
     public ByteSink asTemporaryByteSink();
 
     /**
+     * Ensures that the target file can be written.
+     *
+     * Call this before calling openStream() on a ByteStream acquired from this object.
+     */
+    public void prepare() throws IOException;
+
+    /**
      * Renames the temporary file to the final file.
      *
      * The stream, if any, must be closed.

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractTask.java
@@ -103,6 +103,8 @@ public abstract class AbstractTask<T> implements Task<T> {
             LOG.info("Skipping " + getName() + ": " + sink + " already exists.");
             return null;
         }
+        // Ensure that we can make this output file
+        sink.prepare();
         T result = doRun(context, sink.asTemporaryByteSink(), context.getHandle());
         sink.commit();
         return result;


### PR DESCRIPTION
The Netezza dumper would attempt to create files in a subdirectory, but the underlying virtual file system would throw an exception if there was an attempt to make a file in a subdirectory that does not exist.

This patch ensures that the parent directory exists, and should thereby avoid that bug.