### PR TITLE
Add support for default_database and schema_search_path

### DIFF
--- a/client/batch_sql_translator.py
+++ b/client/batch_sql_translator.py
@@ -156,7 +156,11 @@ class BatchSqlTranslator:
             gcs_source_path=gcs_input_path,
             gcs_target_path=gcs_output_path,
             source_dialect=self.get_input_dialect(),
-            target_dialect=target_dialect
+            target_dialect=target_dialect,
+            source_env=bigquery_migration_v2.types.SourceEnv(
+                default_database=self.config.default_database,
+                schema_search_path=self.config.schema_search_path
+            )
         )
         if self.config.object_name_mapping_list:
             translation_config.name_mapping_list = self.config.object_name_mapping_list

--- a/client/batch_sql_translator.py
+++ b/client/batch_sql_translator.py
@@ -156,7 +156,7 @@ class BatchSqlTranslator:
             gcs_source_path=gcs_input_path,
             gcs_target_path=gcs_output_path,
             source_dialect=self.get_input_dialect(),
-            target_dialect=target_dialect,
+            target_dialect=target_dialect
         )
 
         if self.config.default_database or self.config.schema_search_path:

--- a/client/batch_sql_translator.py
+++ b/client/batch_sql_translator.py
@@ -157,11 +157,14 @@ class BatchSqlTranslator:
             gcs_target_path=gcs_output_path,
             source_dialect=self.get_input_dialect(),
             target_dialect=target_dialect,
-            source_env=bigquery_migration_v2.types.SourceEnv(
+        )
+
+        if self.config.default_database or self.config.schema_search_path:
+            translation_config.source_env = bigquery_migration_v2.types.SourceEnv(
                 default_database=self.config.default_database,
                 schema_search_path=self.config.schema_search_path
             )
-        )
+
         if self.config.object_name_mapping_list:
             translation_config.name_mapping_list = self.config.object_name_mapping_list
 

--- a/client/config.yaml
+++ b/client/config.yaml
@@ -29,12 +29,12 @@ translation_config:
   translation_type: Translation_Teradata2BQ
   location: 'us'
 
-  # The default database name to fully qualify SQL objects when their database name is missing.
-  default_database: __DEFAULT_DATABASE__
+  # [Optional field] The default database name to fully qualify SQL objects when their database name is missing.
+  # default_database: __DEFAULT_DATABASE__
 
-  # The schema search path. When SQL objects are missing schema name, translation engine will search through this list to find the value.
-  schema_search_path:
-  - __DEFAULT_SCHEMA__
+  # [Optional field] The schema search path. When SQL objects are missing schema name, translation engine will search through this list to find the value.
+  # schema_search_path:
+  #   - __DEFAULT_SCHEMA__
 
   # Set this to True (default) to clean up the temporary data in the '.tmp_processed' folder after job finishes.
   clean_up_tmp_files: False

--- a/client/config.yaml
+++ b/client/config.yaml
@@ -29,5 +29,12 @@ translation_config:
   translation_type: Translation_Teradata2BQ
   location: 'us'
 
+  # The default database name to fully qualify SQL objects when their database name is missing.
+  default_database: __DEFAULT_DATABASE__
+
+  # The schema search path. When SQL objects are missing schema name, translation engine will search through this list to find the value.
+  schema_search_path:
+  - __DEFAULT_SCHEMA__
+
   # Set this to True (default) to clean up the temporary data in the '.tmp_processed' folder after job finishes.
   clean_up_tmp_files: False

--- a/client/config_parser.py
+++ b/client/config_parser.py
@@ -67,8 +67,6 @@ class ConfigParser:
     # Config default values
     __DEFAULT_INPUT_DIR = "input"
     __DEFAULT_OUTPUT_DIR = "output"
-    __DEFAULT_DEFAULT_DATABASE = "__DEFAULT_DATABASE__"
-    __DEFAULT_SCHEMA_SEARCH_PATH = ["__DEFAULT_SCHEMA__"]
 
     # The supported task types
     __SUPPORTED_TYPES = {
@@ -109,12 +107,11 @@ class ConfigParser:
             else translation_config_input[self.__INPUT_DIR]
         config.output_directory = self.__DEFAULT_OUTPUT_DIR if self.__OUTPUT_DIR not in translation_config_input \
             else translation_config_input[self.__OUTPUT_DIR]
-        config.default_database = self.__DEFAULT_DEFAULT_DATABASE if self.__DEFAULT_DATABASE not in translation_config_input \
-            else translation_config_input[self.__DEFAULT_DATABASE]
-        config.schema_search_path = self.__DEFAULT_SCHEMA_SEARCH_PATH if self.__SCHEMA_SEARCH_PATH not in translation_config_input \
-            else translation_config_input[self.__SCHEMA_SEARCH_PATH]
         config.clean_up_tmp_files = True if self.__CLEAN_UP not in translation_config_input \
             else translation_config_input[self.__CLEAN_UP]
+
+        config.default_database = translation_config_input.get(self.__DEFAULT_DATABASE)
+        config.schema_search_path = translation_config_input.get(self.__SCHEMA_SEARCH_PATH)
 
         if not os.path.exists(config.output_directory):
             os.makedirs(config.output_directory)

--- a/client/config_parser.py
+++ b/client/config_parser.py
@@ -42,6 +42,8 @@ class TranslationConfig:
         self.translation_type = None
         self.input_directory = None
         self.output_directory = None
+        self.default_database = None
+        self.schema_search_path = None
         self.object_name_mapping_list = None
         self.clean_up_tmp_files = True
 
@@ -58,11 +60,15 @@ class ConfigParser:
     __TRANSLATION_CONFIG = "translation_config"
     __INPUT_DIR = "input_directory"
     __OUTPUT_DIR = "output_directory"
+    __DEFAULT_DATABASE = "default_database"
+    __SCHEMA_SEARCH_PATH = "schema_search_path"
     __CLEAN_UP = "clean_up_tmp_files"
 
     # Config default values
     __DEFAULT_INPUT_DIR = "input"
     __DEFAULT_OUTPUT_DIR = "output"
+    __DEFAULT_DEFAULT_DATABASE = "__DEFAULT_DATABASE__"
+    __DEFAULT_SCHEMA_SEARCH_PATH = ["__DEFAULT_SCHEMA__"]
 
     # The supported task types
     __SUPPORTED_TYPES = {
@@ -103,6 +109,10 @@ class ConfigParser:
             else translation_config_input[self.__INPUT_DIR]
         config.output_directory = self.__DEFAULT_OUTPUT_DIR if self.__OUTPUT_DIR not in translation_config_input \
             else translation_config_input[self.__OUTPUT_DIR]
+        config.default_database = self.__DEFAULT_DEFAULT_DATABASE if self.__DEFAULT_DATABASE not in translation_config_input \
+            else translation_config_input[self.__DEFAULT_DATABASE]
+        config.schema_search_path = self.__DEFAULT_SCHEMA_SEARCH_PATH if self.__SCHEMA_SEARCH_PATH not in translation_config_input \
+            else translation_config_input[self.__SCHEMA_SEARCH_PATH]
         config.clean_up_tmp_files = True if self.__CLEAN_UP not in translation_config_input \
             else translation_config_input[self.__CLEAN_UP]
 


### PR DESCRIPTION
This PR allows users to specify `default_database` and `schema_search_path` in the `config.yaml` file.

I was planning on using this in the codelab I am working on.