### PR TITLE
remove TODOs in readme

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -52,8 +52,6 @@ permissions](https://cloud.google.com/bigquery/docs/batch-sql-translator#require
 The input folder is supposed to contain files with pure SQL statements (comments
 are OK). The file extension can be in any format like .txt or .sql.
 
-TODO: add instruction about how to use the metadata dumper outputs as inputs here.
-
 ## output_directory
 
 In the config, specify a local directory to store the outputs of the translation job. 


### PR DESCRIPTION
We should not put TODOs in readme since it's acting as public docs. I also don't think we would like to include metadata dumper instruction in the exemplary client, since it may increase the time to value path.