### PR TITLE
Hive: get fields from storage descriptor if available

### DIFF
--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.ext.hive.metastore;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -123,29 +124,40 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
             @Nonnull
             @Override
             public List<? extends Field> getFields() throws Exception {
+                if (table.getSd() != null) {
+                    List<com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.FieldSchema> cols = table.getSd().getCols();
+                    if (cols != null) {
+                        return cols.stream().map(this::toField).collect(Collectors.toList());
+                    }
+                }
                 List<Field> out = new ArrayList<>();
                 for (com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.FieldSchema field : client.get_fields(databaseName, tableName)) {
-                    out.add(new Field() {
-                        @CheckForNull
-                        @Override
-                        public String getFieldName() {
-                            return (field.isSetName() ? field.getName() : null);
-                        }
-
-                        @CheckForNull
-                        @Override
-                        public String getType() {
-                            return (field.isSetType() ? field.getType() : null);
-                        }
-
-                        @CheckForNull
-                        @Override
-                        public String getComment() {
-                            return (field.isSetComment() ? field.getComment() : null);
-                        }
-                    });
+                    out.add(toField(field));
                 }
                 return out;
+            }
+
+            @Nonnull
+            private Field toField(com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.FieldSchema field) {
+                return new Field() {
+                    @CheckForNull
+                    @Override
+                    public String getFieldName() {
+                        return (field.isSetName() ? field.getName() : null);
+                    }
+
+                    @CheckForNull
+                    @Override
+                    public String getType() {
+                        return (field.isSetType() ? field.getType() : null);
+                    }
+
+                    @CheckForNull
+                    @Override
+                    public String getComment() {
+                        return (field.isSetComment() ? field.getComment() : null);
+                    }
+                };
             }
 
             @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -124,6 +124,8 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
             @Nonnull
             @Override
             public List<? extends Field> getFields() throws Exception {
+                // If we already have a non-null Storage Descriptor let's get the columns from it, we do one less remote call and we also avoid
+                // an exception "Storage schema reading not supported" due to OpenCSVSerde based tables. If this is null we fall-back to calling get_fields.
                 if (table.getSd() != null) {
                     List<com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.FieldSchema> cols = table.getSd().getCols();
                     if (cols != null) {

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -124,6 +124,8 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
             @Nonnull
             @Override
             public List<? extends Field> getFields() throws Exception {
+                // If we already have a non-null Storage Descriptor let's get the columns from it, we do one less remote call and we also avoid
+                // an exception "Storage schema reading not supported" due to OpenCSVSerde based tables. If this is null we fall-back to calling get_fields.
                 if (table.getSd() != null) {
                     List<com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.FieldSchema> cols = table.getSd().getCols();
                     if (cols != null) {

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.ext.hive.metastore;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -123,29 +124,40 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
             @Nonnull
             @Override
             public List<? extends Field> getFields() throws Exception {
+                if (table.getSd() != null) {
+                    List<com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.FieldSchema> cols = table.getSd().getCols();
+                    if (cols != null) {
+                        return cols.stream().map(this::toField).collect(Collectors.toList());
+                    }
+                }
                 List<Field> out = new ArrayList<>();
                 for (com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.FieldSchema field : client.get_fields(databaseName, tableName)) {
-                    out.add(new Field() {
-                        @CheckForNull
-                        @Override
-                        public String getFieldName() {
-                            return (field.isSetName() ? field.getName() : null);
-                        }
-
-                        @CheckForNull
-                        @Override
-                        public String getType() {
-                            return (field.isSetType() ? field.getType() : null);
-                        }
-
-                        @CheckForNull
-                        @Override
-                        public String getComment() {
-                            return (field.isSetComment() ? field.getComment() : null);
-                        }
-                    });
+                    out.add(toField(field));
                 }
                 return out;
+            }
+
+            @Nonnull
+            private Field toField(com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.FieldSchema field) {
+                return new Field() {
+                    @CheckForNull
+                    @Override
+                    public String getFieldName() {
+                        return (field.isSetName() ? field.getName() : null);
+                    }
+
+                    @CheckForNull
+                    @Override
+                    public String getType() {
+                        return (field.isSetType() ? field.getType() : null);
+                    }
+
+                    @CheckForNull
+                    @Override
+                    public String getComment() {
+                        return (field.isSetComment() ? field.getComment() : null);
+                    }
+                };
             }
 
             @Nonnull


### PR DESCRIPTION
This should help mitigate the exception: `Storage schema reading not supported`, it also implies one less RPC (per table).

To reproduce the error:
```sql
create table some_tbl (x int) row format serde 'org.apache.hadoop.hive.serde2.OpenCSVSerde';
```