### PR TITLE
Hive: test dumper with an in-memory Hive metastore

### DIFF
--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -180,6 +180,8 @@ spotless {
             // Ignore generated sources.
             if (path.contains('/build/'))
                 return false;
+            if (path.contains('hive/support/HiveServerSupport.java'))
+                return false; // Additional copyright credits
             return true;
         }
         target files;

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -66,6 +66,14 @@ dependencies {
     testImplementation "com.github.stefanbirkner:system-rules"
     testImplementation "joda-time:joda-time"
 
+    // Test Hive 3.1.2
+    testImplementation project(path: ':dumper:lib-ext-hive-metastore', configuration: 'shadow')
+    // Excluded during shadowJar step, same versions as exclusions
+    testRuntimeOnly "org.datanucleus:datanucleus-api-jdo:4.2.4"
+    testRuntimeOnly "org.datanucleus:datanucleus-core:4.1.17"
+    testRuntimeOnly "org.datanucleus:javax.jdo:3.2.0-m3"
+    testRuntimeOnly "org.datanucleus:datanucleus-rdbms:4.1.19"
+
     sources "org.slf4j:jcl-over-slf4j:1.7.14@sources"
     sources "ch.qos.logback:logback-classic:1.2.3@sources"
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -18,12 +18,6 @@ package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 
 import com.google.common.base.Joiner;
 import com.google.common.collect.Iterables;
-import java.sql.Driver;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.List;
-import javax.annotation.Nonnull;
-import javax.sql.DataSource;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
@@ -35,6 +29,13 @@ import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInp
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
+import java.io.UnsupportedEncodingException;
+import java.sql.Driver;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.sql.DataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.datasource.SimpleDriverDataSource;
@@ -123,7 +124,7 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
     }
 
     @Nonnull
-    private String makeJdbcUrlPostgresql(ConnectorArguments arguments) throws MetadataDumperUsageException {
+    private String makeJdbcUrlPostgresql(ConnectorArguments arguments) throws MetadataDumperUsageException, UnsupportedEncodingException {
         return "jdbc:postgresql://"
                 + requireNonNull(arguments.getHost(), "--host should be specified")
                 + ":"
@@ -138,7 +139,7 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
     }
 
     @Nonnull
-    private String makeJdbcUrlRedshiftSimple(ConnectorArguments arguments) throws MetadataDumperUsageException {
+    private String makeJdbcUrlRedshiftSimple(ConnectorArguments arguments) throws MetadataDumperUsageException, UnsupportedEncodingException {
         return "jdbc:redshift://"
                 + requireNonNull(arguments.getHost(), "--host should be specified")
                 + ":"
@@ -154,7 +155,7 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
     //TODO:  [cluster-id]:[region] syntax.
     // either profile, or key+ secret
     @Nonnull
-    private String makeJdbcUrlRedshiftIAM(ConnectorArguments arguments) throws MetadataDumperUsageException {
+    private String makeJdbcUrlRedshiftIAM(ConnectorArguments arguments) throws MetadataDumperUsageException, UnsupportedEncodingException {
         String url = "jdbc:redshift:iam://"
                 + requireNonNull(arguments.getHost(), "--host should be specified")
                 + ":"

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/JdbcPropBuilder.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/JdbcPropBuilder.java
@@ -16,16 +16,14 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.common.base.Joiner;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +44,7 @@ import org.slf4j.LoggerFactory;
     }
 
     @Nonnull
-    public JdbcPropBuilder propOrWarn(@Nonnull String prop, @CheckForNull String val, @Nonnull String msg) {
+    public JdbcPropBuilder propOrWarn(@Nonnull String prop, @CheckForNull String val, @Nonnull String msg) throws UnsupportedEncodingException {
         if (val == null) {
             LOG.warn(msg);
         } else {
@@ -56,7 +54,7 @@ import org.slf4j.LoggerFactory;
     }
 
     @Nonnull
-    public JdbcPropBuilder propOrError(@Nonnull String prop, @CheckForNull String val, @Nonnull String msg) throws MetadataDumperUsageException {
+    public JdbcPropBuilder propOrError(@Nonnull String prop, @CheckForNull String val, @Nonnull String msg) throws MetadataDumperUsageException, UnsupportedEncodingException {
         if (val == null) {
             LOG.error(msg);
             throw new MetadataDumperUsageException(msg);
@@ -67,7 +65,7 @@ import org.slf4j.LoggerFactory;
     }
 
     @Nonnull
-    public JdbcPropBuilder prop(@Nonnull String prop, @Nonnull String val) {
+    public JdbcPropBuilder prop(@Nonnull String prop, @Nonnull String val) throws UnsupportedEncodingException {
         if (val == null) {
             throw new InternalError("Not checked for null: " + val);
         } else {
@@ -76,8 +74,9 @@ import org.slf4j.LoggerFactory;
         return this;
     }
 
-    private void addProp(String prop, String val) {
-        props.add(prop + punctuations.charAt(1) + URLEncoder.encode(val, UTF_8));
+    private void addProp(String prop, String val) throws UnsupportedEncodingException {
+        // The encode(String, Charset) overload is JDK 10+
+        props.add(prop + punctuations.charAt(1) + URLEncoder.encode(val, "UTF-8"));
     }
 
     @Nonnull

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -16,23 +16,149 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.hive;
 
+import com.google.common.collect.Lists;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnectorTest;
-import com.google.edwmigration.dumper.application.dumper.connector.hive.HiveMetadataConnector;
+import com.google.edwmigration.dumper.application.dumper.connector.hive.support.HiveServerSupport;
+import com.google.edwmigration.dumper.application.dumper.connector.hive.support.HiveTestSchemaBuilder;
+import com.google.edwmigration.dumper.plugin.ext.jdk.progress.ConcurrentProgressMonitor;
+import com.google.edwmigration.dumper.plugin.ext.jdk.progress.ConcurrentRecordProgressMonitor;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.stream.Collectors;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
+import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- *
- * @author swapnil
+ * Run this with: > ./gradlew :dumper:app:{cleanTest,test} --tests HiveMetadataConnectorTest
+ * -Dtest.verbose=true -Dorg.gradle.java.home=/usr/lib/jvm/java-1.8.0-openjdk-amd64
  */
 @RunWith(JUnit4.class)
 public class HiveMetadataConnectorTest extends AbstractConnectorTest {
 
-    private final HiveMetadataConnector connector = new HiveMetadataConnector();
+  private static final Logger LOG = LoggerFactory.getLogger(HiveMetadataConnectorTest.class);
+  private static final boolean debug = false;
 
-    @Test
-    public void testConnector() throws Exception {
-        testConnectorDefaults(connector);
+  private final HiveMetadataConnector connector = new HiveMetadataConnector();
+
+  @Test
+  public void testConnector() throws Exception {
+    testConnectorDefaults(connector);
+  }
+
+  @Test
+  public void testLoadedHive312() throws Exception {
+
+    // Hive 3.1.2 requires java 1.8
+    Assume.assumeTrue(SystemUtils.IS_JAVA_1_8);
+
+    // with 5/5/10/1000 -> ~2 minutes
+    int NUM_SCHEMAS = 5;
+    int NUM_TABLES = 5;
+    int NUM_COLUMNS = 10;
+    int NUM_PARTITIONS = 1000;
+
+    int NUM_DUMPER_RUNS = 5; // 5 -> ~4 minutes
+    int BATCH_SIZE = 25;
+
+    List<List<String>> setupStatements =
+        HiveTestSchemaBuilder.getStatements(NUM_SCHEMAS, NUM_TABLES, NUM_COLUMNS, NUM_PARTITIONS);
+
+    try (HiveServerSupport instanceSupport = new HiveServerSupport().start()) {
+
+      // Populate Hive Metastore
+      long total = setupStatements.stream().mapToLong(Collection::size).sum();
+      try (ConcurrentProgressMonitor monitor = new ConcurrentRecordProgressMonitor(
+          "Populating Hive instance.", total)) {
+        ExecutorService executor = Executors.newFixedThreadPool(HiveServerSupport.CONCURRENCY);
+
+        for (List<String> statementList : setupStatements) {
+          executor.invokeAll(
+              Lists.partition(statementList, BATCH_SIZE).stream()
+                  .map(l -> getCallable(instanceSupport, l, monitor))
+                  .collect(Collectors.toList())
+          ).forEach(this::assertNoException);
+        }
+      }
+
+      // Run dumper many times and assert all tables are there (1 table = 1 line, JSONL)
+      for (int i = 0; i < NUM_DUMPER_RUNS; i++) {
+        String tmpPrefix = String.format("dumper-test-iteration-%d-", i);
+        Path tmpPath = Files.createTempFile(tmpPrefix, ".zip");
+        File tmpFile = tmpPath.toFile();
+
+        try {
+          MetadataDumper.main(
+              "--connector", "hiveql",
+              "--port", "" + instanceSupport.getMetastoreThriftPort(),
+              "--output", tmpFile.getAbsolutePath()
+          );
+
+          Assert.assertTrue(tmpFile.exists());
+
+          try (ZipFile zipFile = new ZipFile(tmpFile)) {
+            List<ZipArchiveEntry> entries = Collections.list(zipFile.getEntries());
+
+            entries.forEach(e -> Assert.assertFalse(e.getName().contains("exception.txt")));
+
+            List<String> tables = IOUtils.readLines(
+                zipFile.getInputStream(zipFile.getEntry("tables.jsonl")),
+                StandardCharsets.UTF_8
+            );
+
+            Assert.assertEquals("All tables should be present.",
+                NUM_SCHEMAS * NUM_TABLES, tables.size());
+
+            LOG.info("Dump verified.");
+          }
+
+        } catch (Exception e) {
+          throw new AssertionError(e);
+        } finally {
+          if (!debug) {
+            FileUtils.forceDelete(tmpFile);
+          }
+        }
+      }
     }
+  }
+
+  private void assertNoException(Future<Void> f) {
+    try {
+      f.get();
+    } catch (Exception e) {
+      Assert.fail("Exception during setup");
+    }
+  }
+
+  private Callable<Void> getCallable(
+      HiveServerSupport support,
+      List<String> batch,
+      ConcurrentProgressMonitor monitor) {
+    return () -> {
+      support.execute(batch.toArray(new String[]{}));
+      monitor.count(batch.size());
+      return null;
+    };
+  }
+
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/support/HiveServerSupport.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/support/HiveServerSupport.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ * Copyright (C) 2015-2021 Expedia, Inc. and Klarna AB.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.hive.support;
+
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTORE_FASTPATH;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.ServerSocket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.commons.io.FileUtils;
+import org.apache.derby.jdbc.EmbeddedDriver;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaStore;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
+import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
+import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge23;
+import org.apache.hive.service.Service.STATE;
+import org.apache.hive.service.server.HiveServer2;
+import org.checkerframework.checker.index.qual.Positive;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Support class to run a Hive Metastore listening on thrift.
+ */
+// This class contains some code sourced from and inspired by HiveRunner and BeeJU, specifically
+// https://github.com/klarna/HiveRunner/blob/fb00a98f37abdb779547c1c98ef6fbe54d373e0c/src/main/java/com/klarna/hiverunner/StandaloneHiveServerContext.java
+// https://github.com/ExpediaGroup/beeju/blob/a3e821b9bdb70f0e603cccb6408c319b241df66c/src/main/java/com/hotels/beeju/core/BeejuCore.java
+public class HiveServerSupport implements AutoCloseable {
+
+  public static final int CONCURRENCY = 32; // Default is min:5 max:500
+  private final static Logger LOG = LoggerFactory.getLogger(HiveServerSupport.class);
+
+  // "user" conflicts with USER db and the metastore_db can't be created.
+  private static final String METASTORE_DB_USER = "db_user";
+  private static final String METASTORE_DB_PASSWORD = "db_password";
+
+  private final HiveConf conf = new HiveConf();
+  private final int thriftPortMetastore;
+  private final int thriftPortServer;
+
+  private Path hiveTestDir;
+  private HiveServer2 hiveServer;
+  private ExecutorService metastoreExecutor;
+
+  public HiveServerSupport() throws IOException {
+    thriftPortServer = getFreePort();
+    thriftPortMetastore = getFreePort();
+    configure();
+  }
+
+  @Positive
+  public int getMetastoreThriftPort() {
+    return thriftPortMetastore;
+  }
+
+  @SuppressWarnings("deprecation")
+  public void configure() {
+    try {
+      hiveTestDir = Files.createTempDirectory("dumper-hive-test-");
+
+      createAndSetFolderProperty(HiveConf.ConfVars.SCRATCHDIR, "scratchdir");
+      createAndSetFolderProperty(HiveConf.ConfVars.LOCALSCRATCHDIR, "localscratchdir");
+      createAndSetFolderProperty(HiveConf.ConfVars.HIVEHISTORYFILELOC, "hivehistoryfileloc");
+
+      Path derbyHome = Files.createTempDirectory(hiveTestDir, "derby-home-");
+      System.setProperty("derby.system.home", derbyHome.toString());
+
+      String derbyLog = Files.createTempFile(hiveTestDir, "derby", ".log").toString();
+      System.setProperty("derby.stream.error.file", derbyLog);
+
+      Path warehouseDir = Files.createTempDirectory(hiveTestDir, "hive-warehouse-");
+      setHiveVar(HiveConf.ConfVars.METASTOREWAREHOUSE, warehouseDir.toString());
+
+      String driverClassName = EmbeddedDriver.class.getName();
+      conf.setBoolean("hcatalog.hive.client.cache.disabled", true);
+      String connectionURL = "jdbc:derby:memory:" + UUID.randomUUID() + ";create=true";
+
+      setMetastoreAndSystemProperty(ConfVars.CONNECT_URL_KEY, connectionURL);
+      setMetastoreAndSystemProperty(ConfVars.CONNECTION_DRIVER, driverClassName);
+      setMetastoreAndSystemProperty(ConfVars.CONNECTION_USER_NAME, METASTORE_DB_USER);
+      setMetastoreAndSystemProperty(ConfVars.PWD, METASTORE_DB_PASSWORD);
+
+      conf.setVar(HiveConf.ConfVars.METASTORE_CONNECTION_POOLING_TYPE, "NONE");
+      conf.setBoolVar(HiveConf.ConfVars.HMSHANDLERFORCERELOADCONF, true);
+
+      setMetastoreAndSystemProperty(ConfVars.AUTO_CREATE_ALL, "true");
+      setMetastoreAndSystemProperty(ConfVars.SCHEMA_VERIFICATION, "false");
+
+      conf.setIntVar(HiveConf.ConfVars.HIVE_SERVER2_WEBUI_PORT, 0); // disable
+      conf.setBoolVar(HiveConf.ConfVars.HIVESTATSAUTOGATHER, false);
+      conf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_LOGGING_OPERATION_ENABLED, false);
+      setMetastoreAndSystemProperty(ConfVars.EVENT_DB_NOTIFICATION_API_AUTH, "false");
+      conf.setTimeVar(HiveConf.ConfVars.HIVE_NOTFICATION_EVENT_POLL_INTERVAL, 0,
+          TimeUnit.MILLISECONDS);
+      conf.set(HiveConf.ConfVars.HIVE_SERVER2_MATERIALIZED_VIEWS_REGISTRY_IMPL.varname, "DUMMY");
+      System.setProperty(HiveConf.ConfVars.HIVE_SERVER2_MATERIALIZED_VIEWS_REGISTRY_IMPL.varname,
+          "DUMMY");
+
+      conf.setBoolVar(HiveConf.ConfVars.HIVESESSIONSILENT, true); // Do not print "OK"
+      setHiveVar(HiveConf.ConfVars.METASTOREURIS, "thrift://localhost:" + thriftPortMetastore);
+      setHiveIntVar(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_PORT, thriftPortServer);
+
+    } catch (IOException e) {
+      throw new UncheckedIOException("Error during configuration.", e);
+    }
+  }
+
+  public void startMetastore() throws InterruptedException {
+    metastoreExecutor = Executors.newFixedThreadPool(CONCURRENCY);
+
+    final Lock startLock = new ReentrantLock();
+    final Condition startCondition = startLock.newCondition();
+    final AtomicBoolean startedServing = new AtomicBoolean();
+
+    final HiveConf hiveConf = new HiveConf(conf, HiveMetaStoreClient.class);
+    metastoreExecutor.execute(() -> {
+      try {
+        HadoopThriftAuthBridge bridge = HadoopThriftAuthBridge23.getBridge();
+        HiveMetaStore.startMetaStore(thriftPortMetastore, bridge, hiveConf, startLock,
+            startCondition, startedServing);
+      } catch (Throwable t) {
+        LOG.error("Unable to start Hive Metastore", t);
+      }
+    });
+
+    wait(startLock, startCondition);
+
+  }
+
+  public void startServer() throws InterruptedException {
+    hiveServer = new HiveServer2();
+    hiveServer.init(conf);
+    hiveServer.start();
+    waitForState(hiveServer, STATE.STARTED);
+
+  }
+
+  public HiveServerSupport start() throws InterruptedException {
+    LOG.info("Starting Hive Metastore on port {}, HiveServer2 on port {} ...",
+        thriftPortMetastore, thriftPortServer);
+    conf.setBoolVar(METASTORE_FASTPATH, true);
+    startMetastore();
+    startServer();
+    LOG.info("Started.");
+    return this;
+  }
+
+  public void execute(String... sqlScripts) throws SQLException {
+    try (Connection connection = getJdbcConnection(); Statement statement = connection.createStatement()) {
+      for (String script : sqlScripts) {
+        statement.execute(script);
+      }
+    }
+  }
+
+  public Connection getJdbcConnection() throws SQLException {
+    String jdbcConnectionUrl = "jdbc:hive2://localhost:" + thriftPortServer;
+    return DriverManager.getConnection(jdbcConnectionUrl);
+  }
+
+  private int getFreePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+
+  private void waitForState(HiveServer2 hiveServer, STATE targetState) throws InterruptedException {
+    int retries = 0;
+    int maxRetries = 5;
+    while (hiveServer.getServiceState() != targetState && retries < maxRetries) {
+      TimeUnit.SECONDS.sleep(1);
+      retries++;
+    }
+    if (retries >= maxRetries) {
+      throw new RuntimeException("HiveServer2 did not start in a reasonable time");
+    }
+  }
+
+  private void wait(Lock startLock, Condition startCondition) throws InterruptedException {
+    for (int j = 0; j < 3; j++) {
+      startLock.lock();
+      try {
+        if (startCondition.await(1, TimeUnit.MINUTES)) {
+          return;
+        }
+      } finally {
+        startLock.unlock();
+      }
+    }
+    throw new RuntimeException(
+        "Maximum number of tries reached whilst waiting for Thrift server to be ready");
+  }
+
+  private void setMetastoreAndSystemProperty(ConfVars key, String value) {
+    conf.set(key.getVarname(), value);
+    conf.set(key.getHiveName(), value);
+
+    System.setProperty(key.getVarname(), value);
+    System.setProperty(key.getHiveName(), value);
+  }
+
+  private void createAndSetFolderProperty(HiveConf.ConfVars var, String childFolderName)
+      throws IOException {
+    String folderPath = newFolder(hiveTestDir, childFolderName).toAbsolutePath().toString();
+    conf.setVar(var, folderPath);
+  }
+
+  private Path newFolder(Path basedir, String folder) throws IOException {
+    Path newFolder = Files.createTempDirectory(basedir, folder);
+    FileUtil.setPermission(newFolder.toFile(), FsPermission.getDirDefault());
+    return newFolder;
+  }
+
+  public void setHiveVar(HiveConf.ConfVars variable, String value) {
+    conf.setVar(variable, value);
+  }
+
+  public void setHiveIntVar(HiveConf.ConfVars variable, int value) {
+    conf.setIntVar(variable, value);
+  }
+
+  @Override
+  public void close() throws Exception {
+    hiveServer.stop();
+    waitForState(hiveServer, STATE.STOPPED);
+    MoreExecutors.shutdownAndAwaitTermination(metastoreExecutor, 30, TimeUnit.SECONDS);
+    FileUtils.deleteDirectory(hiveTestDir.toFile());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/support/HiveTestSchemaBuilder.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/support/HiveTestSchemaBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.hive.support;
+
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.StringUtils;
+
+public class HiveTestSchemaBuilder {
+
+  public static final String DATABASE_PREFIX = "test_db_";
+  public static final String TABLE_PREFIX = "test_tbl_";
+  public static final List<String> PARTITION_NAMES = Lists.newArrayList("test_partition");
+  public static final int PARTITION_SPLIT = 50;
+
+  public static List<List<String>> getStatements(int dbCount, int tblCount, int colCount, int pCount) {
+    List<List<String>> result = new ArrayList<>();
+    result.add(createDatabases(dbCount));
+    result.add(createTables(dbCount, tblCount, colCount));
+    result.add(createPartitions(dbCount, tblCount, pCount));
+    return result;
+  }
+
+  public static List<String> createPartitions(int dbCount, int tblCount, int pCount) {
+    List<String> result = new ArrayList<>();
+    for (int db = 0; db < dbCount; db++) {
+      for (int tbl = 0; tbl < tblCount; tbl++) {
+        result.addAll(createPartitions(db, tbl, pCount, PARTITION_SPLIT));
+      }
+    }
+    return result;
+  }
+
+  public static List<String> createTables(int dbCount, int tblCount, int colCount) {
+    List<String> result = new ArrayList<>();
+    for (int db = 0; db < dbCount; db++) {
+      for (int tbl = 0; tbl < tblCount; tbl++) {
+        result.add(createTable(db, tbl, colCount));
+      }
+    }
+    return result;
+  }
+
+  public static List<String> createDatabases(int dbCount) {
+    return IntStream.range(0, dbCount).mapToObj(HiveTestSchemaBuilder::createDatabase).collect(Collectors.toList());
+  }
+
+  public static List<String> createPartitions(int dbIndex, int tblIndex, int partitionCount, int partitionSplit) {
+    List<String> partitions = IntStream.range(0, partitionCount)
+        .mapToObj(HiveTestSchemaBuilder::getPartitionValue)
+        .collect(Collectors.toList());
+
+    return Lists.partition(partitions, partitionSplit).stream()
+        .map(l -> StringUtils.join(l, " "))
+        .map(p -> String.format("alter table %s%d.%s%d add %s", DATABASE_PREFIX, dbIndex, TABLE_PREFIX, tblIndex, p))
+        .collect(Collectors.toList());
+  }
+
+  public static String createTable(int dbIndex, int tblIndex, int colCount) {
+    return String.format("create table %s%d.%s%d (%s) partitioned by (%s)",
+        DATABASE_PREFIX, dbIndex, TABLE_PREFIX, tblIndex, getColumns(colCount), getPartitionsDefinition());
+  }
+
+  private static String getColumns(int colCount) {
+    return IntStream.range(0, colCount)
+        .mapToObj(c ->"col_" + c + " int")
+        .collect(Collectors.joining(", "));
+  }
+
+  public static String createDatabase(int dbIndex) {
+    return String.format("create database %s%d",DATABASE_PREFIX, dbIndex);
+  }
+
+  private static String getPartitionsDefinition() {
+    return PARTITION_NAMES.stream()
+        .map(p -> p + " int")
+        .collect(Collectors.joining(", "));
+  }
+
+  private static String getPartitionValue(int value) {
+    return PARTITION_NAMES.stream()
+        .map(p -> String.format("partition (%s = %s)", p, value ))
+        .collect(Collectors.joining(", "));
+  }
+
+}

--- a/dumper/app/src/test/resources/logback.xml
+++ b/dumper/app/src/test/resources/logback.xml
@@ -1,0 +1,21 @@
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread{24}] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="debug">
+    <appender-ref ref="STDOUT" />
+  </root>
+  <logger name="org.apache" level="error">
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="shadow.org.apache" level="error">
+    <appender-ref ref="STDOUT" />
+  </logger>
+  <logger name="hive.ql" level="error">
+    <appender-ref ref="STDOUT" />
+  </logger>
+</configuration>

--- a/dumper/lib-ext-hive-metastore/build.gradle
+++ b/dumper/lib-ext-hive-metastore/build.gradle
@@ -21,12 +21,60 @@ buildscript {
 }
 plugins {
     id 'dwh-migration-dumper.java-library-conventions'
+    id 'com.github.johnrengelman.shadow' version '6.1.0'
 }
 apply plugin: 'org.anarres.thrift'
+
+sourceSets {
+    hive312 // build a runtime to run Hive 3.1.2 metastore/server
+}
 
 dependencies {
     api "org.apache.thrift:libthrift:0.14.1"
     implementation "com.google.guava:guava"
+
+    def hiveVersion = '3.1.2'
+    hive312RuntimeOnly "org.apache.hive:hive-common:$hiveVersion"
+    hive312RuntimeOnly "org.apache.hive:hive-exec:$hiveVersion"
+    hive312RuntimeOnly "org.apache.hive:hive-service:$hiveVersion"
+    hive312RuntimeOnly "org.apache.hive:hive-metastore:$hiveVersion"
+    hive312RuntimeOnly "org.apache.hive:hive-jdbc:$hiveVersion"
+    // For HiveServer2
+    hive312RuntimeOnly "org.apache.tez:tez-common:0.9.1"
+    hive312RuntimeOnly "org.apache.tez:tez-dag:0.9.1"
+    // Starting from version 1.8 the binding mechanics changed
+    hive312RuntimeOnly("org.slf4j:slf4j-api") {
+        version {
+            strictly '1.7.13'
+        }
+    }
+    // Hive has many dependencies on core through LogDivertAppender, use latest version
+    hive312RuntimeOnly("org.apache.logging.log4j:log4j-core") {
+        version {
+            strictly '2.18.0'
+        }
+    }
+}
+
+shadowJar {
+    zip64 true
+    configurations = [project.configurations.hive312RuntimeClasspath]
+
+    exclude 'META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat' // or write a custom merger
+
+    dependencies {
+        exclude(dependency('org.slf4j:slf4j-log4j12'))
+        exclude(dependency('log4j:log4j'))
+        exclude(dependency('org.apache.logging.log4j:log4j-slf4j-impl'))
+        exclude(dependency('org.datanucleus:.*')) // can't be safely shadowed
+    }
+
+    relocate 'org.apache.thrift', 'shadow.org.apache.thrift' // this is the whole point of doing this
+    relocate 'com.google.common', 'shadow.com.google.common'
+    relocate 'org.junit', 'shadow.org.junit'
+    relocate 'com.facebook', 'shadow.com.facebook'
+    relocate 'org.apache.commons.lang3', 'shadow.org.apache.commons.lang3'
+
 }
 
 generateThriftSource {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8 -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.parallel=true
+org.gradle.caching=true


### PR DESCRIPTION
Command:
```
./gradlew :dumper:app:{cleanTest,test} --tests HiveMetadataConnectorTest -Dtest.verbose=true -Dorg.gradle.java.home=/usr/lib/jvm/java-1.8.0-openjdk-amd64
```