### PR TITLE
Don't use name mangling.

### DIFF
--- a/client/dwh_migration_client/config_parser.py
+++ b/client/dwh_migration_client/config_parser.py
@@ -55,14 +55,14 @@ class ConfigParser:  # pylint: disable=too-few-public-methods
         self._config_file_path = abspath(config_file_path)
 
     # Config field name
-    __TRANSLATION_TYPE = "translation_type"
-    __TRANSLATION_CONFIG = "translation_config"
-    __DEFAULT_DATABASE = "default_database"
-    __SCHEMA_SEARCH_PATH = "schema_search_path"
-    __CLEAN_UP = "clean_up_tmp_files"
+    _TRANSLATION_TYPE = "translation_type"
+    _TRANSLATION_CONFIG = "translation_config"
+    _DEFAULT_DATABASE = "default_database"
+    _SCHEMA_SEARCH_PATH = "schema_search_path"
+    _CLEAN_UP = "clean_up_tmp_files"
 
     # The supported task types
-    __SUPPORTED_TYPES = {
+    _SUPPORTED_TYPES = {
         AZURESYNAPSE2BQ,
         BTEQ2BQ,
         HIVEQL2BQ,
@@ -87,24 +87,24 @@ class ConfigParser:  # pylint: disable=too-few-public-methods
         )
         with open(self._config_file_path, encoding="utf-8") as file:
             data = yaml.load(file, Loader=SafeLoader)
-        self.__validate_config_yaml(data)
+        self._validate_config_yaml(data)
 
         gcp_settings_input = data["gcp_settings"]
         project_number = gcp_settings_input["project_number"]
         gcs_bucket = gcp_settings_input["gcs_bucket"]
 
-        translation_config_input = data[self.__TRANSLATION_CONFIG]
+        translation_config_input = data[self._TRANSLATION_CONFIG]
         location = translation_config_input["location"]
-        translation_type = translation_config_input[self.__TRANSLATION_TYPE]
+        translation_type = translation_config_input[self._TRANSLATION_TYPE]
 
         clean_up_tmp_files = (
             True
-            if self.__CLEAN_UP not in translation_config_input
-            else translation_config_input[self.__CLEAN_UP]
+            if self._CLEAN_UP not in translation_config_input
+            else translation_config_input[self._CLEAN_UP]
         )
 
-        default_database = translation_config_input.get(self.__DEFAULT_DATABASE)
-        schema_search_path = translation_config_input.get(self.__SCHEMA_SEARCH_PATH)
+        default_database = translation_config_input.get(self._DEFAULT_DATABASE)
+        schema_search_path = translation_config_input.get(self._SCHEMA_SEARCH_PATH)
 
         config = TranslationConfig(
             project_number=project_number,
@@ -120,15 +120,15 @@ class ConfigParser:  # pylint: disable=too-few-public-methods
         logging.info("The config is:\n%s", pformat(asdict(config)))
         return config
 
-    def __validate_config_yaml(self, yaml_data: Dict[str, Dict[str, str]]) -> None:
+    def _validate_config_yaml(self, yaml_data: Dict[str, Dict[str, str]]) -> None:
         """Validate the data in the config yaml file."""
         assert (
-            self.__TRANSLATION_CONFIG in yaml_data
+            self._TRANSLATION_CONFIG in yaml_data
         ), "Missing translation_config field in config.yaml."
         assert (
-            self.__TRANSLATION_TYPE in yaml_data[self.__TRANSLATION_CONFIG]
+            self._TRANSLATION_TYPE in yaml_data[self._TRANSLATION_CONFIG]
         ), "Missing translation_type field in config.yaml."
-        translation_type = yaml_data[self.__TRANSLATION_CONFIG][self.__TRANSLATION_TYPE]
+        translation_type = yaml_data[self._TRANSLATION_CONFIG][self._TRANSLATION_TYPE]
         assert (
-            translation_type in self.__SUPPORTED_TYPES
+            translation_type in self._SUPPORTED_TYPES
         ), f'The type "{translation_type}" is not supported.'

--- a/client/dwh_migration_client/gcloud_auth_helper.py
+++ b/client/dwh_migration_client/gcloud_auth_helper.py
@@ -42,12 +42,12 @@ class GcloudAuthHelper:
         self.project_id = None
         self.user_email = None
 
-    __GCLOUD_CRED_FILE = "~/.config/gcloud/application_default_credentials.json"
-    __APPLICATION_DEFAULT_LOGIN_COMMAND = "gcloud auth application-default login"
-    __AUTH_LIST = "gcloud auth list"
-    __AUTH_LOGIN = "gcloud auth login"
-    __CONFIG_LIST = "gcloud config list"
-    __SET_PROJECT = "gcloud config set project"
+    _GCLOUD_CRED_FILE = "~/.config/gcloud/application_default_credentials.json"
+    _APPLICATION_DEFAULT_LOGIN_COMMAND = "gcloud auth application-default login"
+    _AUTH_LIST = "gcloud auth list"
+    _AUTH_LOGIN = "gcloud auth login"
+    _CONFIG_LIST = "gcloud config list"
+    _SET_PROJECT = "gcloud config set project"
 
     def validate_login_status(self) -> None:
         """Validates the gcloud login status for the user through gcloud CLI command.
@@ -55,18 +55,18 @@ class GcloudAuthHelper:
         command.
         """
         logging.info("Validate user login status in gcloud...")
-        result = subprocess.getoutput(self.__AUTH_LIST)
+        result = subprocess.getoutput(self._AUTH_LIST)
         if "No credentialed accounts" in result:
             logging.info(
                 "User hasn't logged in to gcloud yet.  Running command to login "
                 '"%s"...',
-                self.__AUTH_LOGIN,
+                self._AUTH_LOGIN,
             )
             logging.info(
                 "Please open the following link in a browser and grant permission to "
                 "login..."
             )
-            os.system(self.__AUTH_LOGIN)
+            os.system(self._AUTH_LOGIN)
 
     def validate_auth_status(self) -> None:
         """Validates the user credential status.
@@ -74,26 +74,26 @@ class GcloudAuthHelper:
         credential file.
         """
         logging.info("Validate user credential status in gcloud...")
-        if not os.path.exists(os.path.expanduser(self.__GCLOUD_CRED_FILE)):
+        if not os.path.exists(os.path.expanduser(self._GCLOUD_CRED_FILE)):
             logging.info(
                 "Can't find application_default_credential file. Generating "
                 'credential through the command "%s"',
-                self.__APPLICATION_DEFAULT_LOGIN_COMMAND,
+                self._APPLICATION_DEFAULT_LOGIN_COMMAND,
             )
             logging.info(
                 "Please open the following link in a browser and grant permission to "
                 "download credential file..."
             )
-            os.system(self.__APPLICATION_DEFAULT_LOGIN_COMMAND)
+            os.system(self._APPLICATION_DEFAULT_LOGIN_COMMAND)
 
     def validate_project_config(self) -> None:
         logging.info("Validate project config status in gcloud...")
-        os.system(f"{self.__SET_PROJECT} {self.project_number}")
-        result = subprocess.getoutput(self.__CONFIG_LIST)
+        os.system(f"{self._SET_PROJECT} {self.project_number}")
+        result = subprocess.getoutput(self._CONFIG_LIST)
         logging.info("Your cloud config used for this translation job is:\n%s", result)
         assert "account =" in result, (
             "Can't find account info in gcloud config. "
-            f'Please log in through "{self.__AUTH_LOGIN}"'
+            f'Please log in through "{self._AUTH_LOGIN}"'
         )
         assert (
             f"project = {self.project_number in result}"

--- a/client/dwh_migration_client/macro_processor.py
+++ b/client/dwh_migration_client/macro_processor.py
@@ -48,7 +48,7 @@ class MacroProcessor:
             input_dir: path to the input directory.
             tmp_dir: path to a tmp directory that stores the files after preprocessing.
         """
-        self.__process(abspath(input_dir), abspath(tmp_dir), revert_expansion=False)
+        self._process(abspath(input_dir), abspath(tmp_dir), revert_expansion=False)
 
     def postprocess(self, tmp_dir: str, output_dir: str) -> None:
         """The post-download entry point of a MacroProcessor
@@ -62,7 +62,7 @@ class MacroProcessor:
             output_dir: path to the directory that stores the final outputs after
                 preprocessing.
         """
-        self.__process(abspath(tmp_dir), abspath(output_dir), revert_expansion=True)
+        self._process(abspath(tmp_dir), abspath(output_dir), revert_expansion=True)
 
     def is_ignored(self, path: str, name: str) -> bool:
         """Returns true if a file is ignored.
@@ -88,7 +88,7 @@ class MacroProcessor:
             return False
         return True
 
-    def __process(
+    def _process(
         self, input_dir: str, output_dir: str, revert_expansion: bool = False
     ) -> None:
         """Replaces or restores macros for every file in the input folder and save
@@ -192,12 +192,12 @@ class MacroProcessor:
 class MapBasedExpander:
     """An util class to handle map based yaml file."""
 
-    __YAML_KEY = "macros"
+    _YAML_KEY = "macros"
 
     def __init__(self, yaml_file_path: str) -> None:
         self.yaml_file_path = yaml_file_path
-        self.macro_expansion_maps = self.__parse_macros_config_file()
-        self.reversed_maps = self.__get_reversed_maps()
+        self.macro_expansion_maps = self._parse_macros_config_file()
+        self.reversed_maps = self._get_reversed_maps()
 
     def expand(self, text: str, path: str) -> str:
         """Expands the macros in the text with the corresponding values defined in the
@@ -205,7 +205,7 @@ class MapBasedExpander:
 
         Returns the text after macro substitution.
         """
-        reg_pattern_map, patterns = self.__get_all_regex_pattern_mapping(path)
+        reg_pattern_map, patterns = self._get_all_regex_pattern_mapping(path)
         return patterns.sub(lambda m: reg_pattern_map[re.escape(m.group(0))], text)
 
     def unexpand(self, text: str, path: str) -> str:
@@ -214,17 +214,17 @@ class MapBasedExpander:
 
         Returns the text after replacing the values with macros.
         """
-        reg_pattern_map, patterns = self.__get_all_regex_pattern_mapping(path, True)
+        reg_pattern_map, patterns = self._get_all_regex_pattern_mapping(path, True)
         return patterns.sub(lambda m: reg_pattern_map[re.escape(m.group(0))], text)
 
-    def __get_reversed_maps(self) -> Dict[str, Dict[str, str]]:
+    def _get_reversed_maps(self) -> Dict[str, Dict[str, str]]:
         """Swaps key and value in the macro maps and return the new map."""
         reversed_maps = {}
         for file_key, macro_map in self.macro_expansion_maps.items():
             reversed_maps[file_key] = dict((v, k) for k, v in macro_map.items())
         return reversed_maps
 
-    def __parse_macros_config_file(self) -> Dict[str, Dict[str, str]]:
+    def _parse_macros_config_file(self) -> Dict[str, Dict[str, str]]:
         """Parses the macros mapping yaml file.
 
         Return:
@@ -238,20 +238,20 @@ class MapBasedExpander:
                 file, Loader=SafeLoader
             )
         self.__validate_macro_file(data)
-        return data[self.__YAML_KEY]
+        return data[self._YAML_KEY]
 
     def __validate_macro_file(
         self, yaml_data: Dict[str, Dict[str, Dict[str, str]]]
     ) -> None:
         """Validates the macro replacement map yaml data."""
         assert (
-            self.__YAML_KEY in yaml_data
-        ), f"Missing {self.__YAML_KEY} field in {self.yaml_file_path}."
+            self._YAML_KEY in yaml_data
+        ), f"Missing {self._YAML_KEY} field in {self.yaml_file_path}."
         assert yaml_data[
-            self.__YAML_KEY
-        ], f"The {self.__YAML_KEY} is empty in {self.yaml_file_path}."
+            self._YAML_KEY
+        ], f"The {self._YAML_KEY} is empty in {self.yaml_file_path}."
 
-    def __get_all_regex_pattern_mapping(
+    def _get_all_regex_pattern_mapping(
         self, file_path: str, use_reversed_map: bool = False
     ) -> Tuple[Dict[str, str], Pattern[str]]:
         """Compiles all the macros matched with the file path into a single regex

--- a/client/dwh_migration_client/object_mapping_parser.py
+++ b/client/dwh_migration_client/object_mapping_parser.py
@@ -30,18 +30,18 @@ class ObjectMappingParser:  # pylint: disable=too-few-public-methods
     """A parser for the object name mapping json file."""
 
     def __init__(self, json_file_path: str) -> None:
-        self.__json_file_path = json_file_path
+        self._json_file_path = json_file_path
 
-    __NAME_MAP_FIELD = "name_map"
-    __SOURCE_FIELD = "source"
-    __TARGET_FIELD = "target"
-    __TYPE_FIELD = "type"
-    __DB_FIELD = "database"
-    __SCHEMA_FIELD = "schema"
-    __RELATION_FIELD = "relation"
-    __ATTRIBUTE_FIELD = "attribute"
+    _NAME_MAP_FIELD = "name_map"
+    _SOURCE_FIELD = "source"
+    _TARGET_FIELD = "target"
+    _TYPE_FIELD = "type"
+    _DB_FIELD = "database"
+    _SCHEMA_FIELD = "schema"
+    _RELATION_FIELD = "relation"
+    _ATTRIBUTE_FIELD = "attribute"
 
-    __SUPPORTED_TYPES = {
+    _SUPPORTED_TYPES = {
         "DATABASE",
         "SCHEMA",
         "RELATION",
@@ -54,61 +54,61 @@ class ObjectMappingParser:  # pylint: disable=too-few-public-methods
     def get_name_mapping_list(self) -> ObjectNameMappingList:
         """Parses the object name mapping json file into ObjectNameMappingList."""
         logging.info(
-            'Start parsing object name mapping from "%s"...', self.__json_file_path
+            'Start parsing object name mapping from "%s"...', self._json_file_path
         )
-        self.__validate_onm_file()
+        self._validate_onm_file()
         onm_list = ObjectNameMappingList()
-        with open(self.__json_file_path, encoding="utf-8") as file:
+        with open(self._json_file_path, encoding="utf-8") as file:
             data = json.load(file)
-        for name_map in data[self.__NAME_MAP_FIELD]:
-            assert self.__SOURCE_FIELD in name_map, (
-                f'Invalid object name mapping: can\'t find a "{self.__SOURCE_FIELD}" '
-                f'field in "{self.__json_file_path}". '
+        for name_map in data[self._NAME_MAP_FIELD]:
+            assert self._SOURCE_FIELD in name_map, (
+                f'Invalid object name mapping: can\'t find a "{self._SOURCE_FIELD}" '
+                f'field in "{self._json_file_path}". '
                 f'Instead we got "{name_map}".'
             )
-            assert self.__TARGET_FIELD in name_map, (
-                f'Invalid object name mapping: can\'t find a "{self.__TARGET_FIELD}" '
-                f'field in "{self.__json_file_path}". '
+            assert self._TARGET_FIELD in name_map, (
+                f'Invalid object name mapping: can\'t find a "{self._TARGET_FIELD}" '
+                f'field in "{self._json_file_path}". '
                 f'Instead we got "{name_map}".'
             )
             onm = ObjectNameMapping()
-            onm.source = self.__parse_source(name_map[self.__SOURCE_FIELD])
-            onm.target = self.__parse_target(name_map[self.__TARGET_FIELD])
+            onm.source = self._parse_source(name_map[self._SOURCE_FIELD])
+            onm.target = self._parse_target(name_map[self._TARGET_FIELD])
             onm_list.name_map.append(onm)
         return onm_list
 
-    def __parse_source(self, source_data: Dict[str, str]) -> NameMappingKey:
+    def _parse_source(self, source_data: Dict[str, str]) -> NameMappingKey:
         name_mapping_key = NameMappingKey()
-        if self.__TYPE_FIELD in source_data:
-            assert source_data[self.__TYPE_FIELD] in self.__SUPPORTED_TYPES, (
-                f'The source type of name mapping "{source_data[self.__TYPE_FIELD]}" '
-                f'in file "{self.__json_file_path}" is not one of'
-                f'the supported types: "{self.__SUPPORTED_TYPES}"'
+        if self._TYPE_FIELD in source_data:
+            assert source_data[self._TYPE_FIELD] in self._SUPPORTED_TYPES, (
+                f'The source type of name mapping "{source_data[self._TYPE_FIELD]}" '
+                f'in file "{self._json_file_path}" is not one of'
+                f'the supported types: "{self._SUPPORTED_TYPES}"'
             )
-            name_mapping_key.type_ = source_data[self.__TYPE_FIELD]
-        if self.__DB_FIELD in source_data:
-            name_mapping_key.database = source_data[self.__DB_FIELD]
-        if self.__SCHEMA_FIELD in source_data:
-            name_mapping_key.schema = source_data[self.__SCHEMA_FIELD]
-        if self.__RELATION_FIELD in source_data:
-            name_mapping_key.relation = source_data[self.__RELATION_FIELD]
-        if self.__ATTRIBUTE_FIELD in source_data:
-            name_mapping_key.attribute = source_data[self.__ATTRIBUTE_FIELD]
+            name_mapping_key.type_ = source_data[self._TYPE_FIELD]
+        if self._DB_FIELD in source_data:
+            name_mapping_key.database = source_data[self._DB_FIELD]
+        if self._SCHEMA_FIELD in source_data:
+            name_mapping_key.schema = source_data[self._SCHEMA_FIELD]
+        if self._RELATION_FIELD in source_data:
+            name_mapping_key.relation = source_data[self._RELATION_FIELD]
+        if self._ATTRIBUTE_FIELD in source_data:
+            name_mapping_key.attribute = source_data[self._ATTRIBUTE_FIELD]
         return name_mapping_key
 
-    def __parse_target(self, target_data: Dict[str, str]) -> NameMappingValue:
+    def _parse_target(self, target_data: Dict[str, str]) -> NameMappingValue:
         name_mapping_value = NameMappingValue()
-        if self.__DB_FIELD in target_data:
-            name_mapping_value.database = target_data[self.__DB_FIELD]
-        if self.__SCHEMA_FIELD in target_data:
-            name_mapping_value.schema = target_data[self.__SCHEMA_FIELD]
-        if self.__RELATION_FIELD in target_data:
-            name_mapping_value.relation = target_data[self.__RELATION_FIELD]
-        if self.__ATTRIBUTE_FIELD in target_data:
-            name_mapping_value.attribute = target_data[self.__ATTRIBUTE_FIELD]
+        if self._DB_FIELD in target_data:
+            name_mapping_value.database = target_data[self._DB_FIELD]
+        if self._SCHEMA_FIELD in target_data:
+            name_mapping_value.schema = target_data[self._SCHEMA_FIELD]
+        if self._RELATION_FIELD in target_data:
+            name_mapping_value.relation = target_data[self._RELATION_FIELD]
+        if self._ATTRIBUTE_FIELD in target_data:
+            name_mapping_value.attribute = target_data[self._ATTRIBUTE_FIELD]
         return name_mapping_value
 
-    def __validate_onm_file(self) -> None:
+    def _validate_onm_file(self) -> None:
         assert os.path.isfile(
-            self.__json_file_path
-        ), f'Can\'t find a file at "{self.__json_file_path}".'
+            self._json_file_path
+        ), f'Can\'t find a file at "{self._json_file_path}".'


### PR DESCRIPTION
Using a double underscore for "private" methods and attributes in Python is very rare. What the double underscore actually does is mangle the name of the method or attribute during bytecode compilation to include the class name as a prefix. This makes debugging and reflection more difficult.

Instead, the convention in Python is to use a single underscore for "private" methods and attributes. Both the single and double underscore don't actually make anything private. There is no way to truly make something private in Python. In this regard, you will hear some Python people say ["We are all consenting adults."](https://python-guide-chinese.readthedocs.io/zh_CN/latest/writing/style.html#we-are-all-consenting-adults). I guess this has been revised to [responsible users](https://github.com/realpython/python-guide/issues/525) in recent years.

[This SO post](https://stackoverflow.com/questions/7456807/python-name-mangling) has more details, most of which I agree with.