### PR TITLE
Add query metrics to Redshift raw log connector

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -96,6 +96,7 @@ public class ConnectorArguments extends DefaultArguments {
     public static final String OPT_WAREHOUSE = "warehouse";
     public static final String OPT_DATABASE = "database";
     public static final String OPT_SCHEMA = "schema";
+    public static final String OPT_ASSESSMENT = "assessment";
     public static final String OPT_ORACLE_SID = "oracle-sid";
     public static final String OPT_ORACLE_SERVICE = "oracle-service";
 
@@ -131,6 +132,7 @@ public class ConnectorArguments extends DefaultArguments {
     private final OptionSpec<String> optionWarehouse = parser.accepts(OPT_WAREHOUSE, "Virtual warehouse to use once connected (for providers such as Snowflake)").withRequiredArg().ofType(String.class);
     private final OptionSpec<String> optionDatabase = parser.accepts(OPT_DATABASE, "Database(s) to export").withRequiredArg().ofType(String.class).withValuesSeparatedBy(',').describedAs("db0,db1,...");
     private final OptionSpec<String> optionSchema = parser.accepts(OPT_SCHEMA, "Schemata to export").withRequiredArg().ofType(String.class).withValuesSeparatedBy(',').describedAs("sch0,sch1,...");
+    private final OptionSpec<Void> optionAssessment = parser.accepts(OPT_ASSESSMENT, "Whether to create a dump for assessment (i.e., dump additional information).");
     private final OptionSpec<String> optionUser = parser.accepts(OPT_USER, "Database username").withRequiredArg().describedAs("admin");
     private final OptionSpec<String> optionPass = parser.accepts(OPT_PASSWORD, "Database password, prompted if not provided").withOptionalArg().describedAs("sekr1t");
     private final OptionSpec<String> optionRole = parser.accepts(OPT_ROLE, "Database role").withRequiredArg().describedAs("dumper");
@@ -412,6 +414,8 @@ public class ConnectorArguments extends DefaultArguments {
     public List<String> getSchemata() {
         return getOptions().valuesOf(optionSchema);
     }
+
+    public boolean isAssessment() { return getOptions().has(optionAssessment); }
 
     @Nonnull
     public Predicate<String> getSchemaPredicate() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -94,6 +94,19 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector implemen
                 = "SELECT userid, xid, pid, query, trim(label) as label, starttime, endtime, sequence, text"
                 + " FROM STL_QUERY join STL_QUERYTEXT using (userid, xid, pid, query) WHERE ##";
         makeTasks(arguments, intervals, RedshiftRawLogsDumpFormat.QueryHistory.ZIP_ENTRY_PREFIX, queryTemplateQuery, "starttime", parallelTask);
+
+        if (arguments.isAssessment()) {
+            String queryMetricsTemplateQuery
+                = "SELECT userid, service_class, query, segment, step_type, starttime, slices, "
+                + "  max_rows, rows, max_cpu_time, cpu_time, max_blocks_read, blocks_read, "
+                + "  max_run_time, run_time, max_blocks_to_disk, blocks_to_disk, step, "
+                + "  max_query_scan_size, query_scan_size, query_priority, query_queue_time, "
+                + "  service_class_name "
+                + "FROM STL_QUERY_METRICS WHERE ##";
+            makeTasks(arguments, intervals,
+                RedshiftRawLogsDumpFormat.QueryMetricsHistory.ZIP_ENTRY_PREFIX,
+                queryMetricsTemplateQuery, "starttime", parallelTask);
+        }
     }
 
     // ##  in the template to be replaced by the complete WHERE clause.

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftRawLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftRawLogsDumpFormat.java
@@ -53,4 +53,21 @@ public interface RedshiftRawLogsDumpFormat {
             return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
         }
     }
+
+    public static interface QueryMetricsHistory {
+
+        public static final String ZIP_ENTRY_PREFIX = "querymetrics_";
+
+        public static enum Header {
+            userid, service_class, query, segment, step_type, starttime, slices, max_rows, rows,
+            max_cpu_time, cpu_time, max_blocks_read, blocks_read, max_run_time, run_time,
+            max_blocks_to_disk, blocks_to_disk, step, max_query_scan_size, query_scan_size,
+            query_priority, query_queue_time, service_class_name;
+
+        }
+
+        public static boolean isZipEntryName(@Nonnull String name) {
+            return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
+        }
+    }
 }


### PR DESCRIPTION
Dump the view `STL_QUERY_METRICS` to `querymetrics_...` in the Redshift raw logs connector when the `--assessment` flag is set.

b/241398395