### PR TITLE
Change `--assessment` and `--metadata-stats` flags spec to Void

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -132,7 +132,7 @@ public class ConnectorArguments extends DefaultArguments {
     private final OptionSpec<String> optionWarehouse = parser.accepts(OPT_WAREHOUSE, "Virtual warehouse to use once connected (for providers such as Snowflake)").withRequiredArg().ofType(String.class);
     private final OptionSpec<String> optionDatabase = parser.accepts(OPT_DATABASE, "Database(s) to export").withRequiredArg().ofType(String.class).withValuesSeparatedBy(',').describedAs("db0,db1,...");
     private final OptionSpec<String> optionSchema = parser.accepts(OPT_SCHEMA, "Schemata to export").withRequiredArg().ofType(String.class).withValuesSeparatedBy(',').describedAs("sch0,sch1,...");
-    private final OptionSpec<Boolean> optionAssessment = parser.accepts(OPT_ASSESSMENT, "Whether to create a dump for assessment (i.e., dump additional information).").withOptionalArg().withValuesConvertedBy(BooleanValueConverter.INSTANCE).defaultsTo(Boolean.FALSE);
+    private final OptionSpec<Void> optionAssessment = parser.accepts(OPT_ASSESSMENT, "Whether to create a dump for assessment (i.e., dump additional information).");
     private final OptionSpec<String> optionUser = parser.accepts(OPT_USER, "Database username").withRequiredArg().describedAs("admin");
     private final OptionSpec<String> optionPass = parser.accepts(OPT_PASSWORD, "Database password, prompted if not provided").withOptionalArg().describedAs("sekr1t");
     private final OptionSpec<String> optionRole = parser.accepts(OPT_ROLE, "Database role").withRequiredArg().describedAs("dumper");
@@ -142,7 +142,7 @@ public class ConnectorArguments extends DefaultArguments {
     // private final OptionSpec<String> optionDatabase = parser.accepts("database", "database (can be repeated; all if not specified)").withRequiredArg().describedAs("my_dbname").withValuesSeparatedBy(',');
     private final OptionSpec<File> optionOutput = parser.accepts("output", "Output file").withRequiredArg().ofType(File.class).describedAs("cw-dump.zip");
     private final OptionSpec<Void> optionOutputContinue = parser.accepts("continue", "Continues writing a previous output file.");
-    private final OptionSpec<Boolean> optionMetadataStats = parser.accepts(OPT_METADATA_STATS, "Dump metadata stats.").withOptionalArg().withValuesConvertedBy(BooleanValueConverter.INSTANCE).defaultsTo(Boolean.FALSE);
+    private final OptionSpec<Void> optionMetadataStats = parser.accepts(OPT_METADATA_STATS, "Dump metadata stats.");
     // TODO: Make this be an ISO instant.
     @Deprecated
     private final OptionSpec<String> optionQueryLogEarliestTimestamp = parser.accepts("query-log-earliest-timestamp",
@@ -416,7 +416,7 @@ public class ConnectorArguments extends DefaultArguments {
     }
 
     public boolean isAssessment() {
-        return BooleanUtils.isTrue(getOptions().valueOf(optionAssessment));
+        return getOptions().has(optionAssessment);
     }
 
     @Nonnull
@@ -478,7 +478,7 @@ public class ConnectorArguments extends DefaultArguments {
     }
 
     public boolean isMetadataStats() {
-        return BooleanUtils.isTrue(getOptions().valueOf(optionMetadataStats));
+        return getOptions().has(optionMetadataStats);
     }
 
     @CheckForNull


### PR DESCRIPTION
Currently following examples give results which go against the documentation:
* `--assessment` is parsed as false
* `--assessment any_possible_value` is parsed as false instead of failing

As per discussion, set it to OptionSet<Void>, making any arguments after the flag noop because of joptsimple bug.