### PR TITLE
extend redshift dump for assessment

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -106,8 +106,11 @@ public class RedshiftMetadataConnector extends AbstractRedshiftConnector impleme
         parallelTask.addTask(new JdbcSelectTask(RedshiftMetadataDumpFormat.PgViews.ZIP_ENTRY_NAME, "select * from pg_views where schemaname not in " + PG_SCHEMAS));
         parallelTask.addTask(new JdbcSelectTask(RedshiftMetadataDumpFormat.PgUser.ZIP_ENTRY_NAME, "select * from pg_user"));
 
-        if (arguments.isMetadataStats()) {
+        if (arguments.isMetadataStats() || arguments.isAssessment()) {
             selStar(parallelTask, "SVV_DISKUSAGE");
+            selStar(parallelTask, "STV_MV_INFO");
+            selStar(parallelTask, "STV_WLM_SERVICE_CLASS_CONFIG");
+            selStar(parallelTask, "STV_WLM_SERVICE_CLASS_STATE");
         }
     }
 }


### PR DESCRIPTION
- add STV_MV_INFO, STV_WLM_SERVICE_CLASS_CONFIG, STV_WLM_SERVICE_CLASS_STATE
- allow usage of "assessment" flag to control metadata behavior (as well as query logs)