### PR TITLE
move STL_WLM_QUERY to raw logs connector (Redshift assessment dump)

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -111,7 +111,6 @@ public class RedshiftMetadataConnector extends AbstractRedshiftConnector impleme
             selStar(parallelTask, "STV_MV_INFO");
             selStar(parallelTask, "STV_WLM_SERVICE_CLASS_CONFIG");
             selStar(parallelTask, "STV_WLM_SERVICE_CLASS_STATE");
-            selStar(parallelTask, "STL_WLM_QUERY");
         }
     }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -17,10 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 
 import com.google.auto.service.AutoService;
-import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.List;
-import org.apache.commons.lang3.StringUtils;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
@@ -35,122 +31,143 @@ import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
-import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.ParallelTaskGroup;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftMetadataDumpFormat;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftRawLogsDumpFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Generates these csv.
- * 1. userid => username mapping ( duplicated from schema )
- * 2. SVL_DDLTEXT for DDLs
- * 3 SVL_QUERY_TEXT for non-DDLS
- * 4. SQL_QUERY_METRICS for metrics
+ * Generates these csv. 1. userid => username mapping ( duplicated from schema ) 2. SVL_DDLTEXT for
+ * DDLs 3 SVL_QUERY_TEXT for non-DDLS 4. SQL_QUERY_METRICS for metrics
  */
 @AutoService({Connector.class, LogsConnector.class})
 @Description("Dumps logs from Amazon Redshift.")
 @RespectsInput(order = ConnectorArguments.OPT_PORT_ORDER,
-        arg = ConnectorArguments.OPT_PORT,
-        description = "The port of the server.",
-        required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
-        defaultValue = "" + RedshiftMetadataConnector.OPT_PORT_DEFAULT)
+    arg = ConnectorArguments.OPT_PORT,
+    description = "The port of the server.",
+    required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
+    defaultValue = "" + RedshiftMetadataConnector.OPT_PORT_DEFAULT)
 @RespectsArgumentAssessment
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart
 @RespectsArgumentQueryLogEnd
-public class RedshiftRawLogsConnector extends AbstractRedshiftConnector implements LogsConnector, RedshiftRawLogsDumpFormat {
+public class RedshiftRawLogsConnector extends AbstractRedshiftConnector implements LogsConnector,
+    RedshiftRawLogsDumpFormat {
 
-    private static final Logger LOG = LoggerFactory.getLogger(RedshiftRawLogsConnector.class);
+  private static final Logger LOG = LoggerFactory.getLogger(RedshiftRawLogsConnector.class);
 
-    public RedshiftRawLogsConnector() {
-        super("redshift-raw-logs");
+  public RedshiftRawLogsConnector() {
+    super("redshift-raw-logs");
+  }
+
+  @Override
+  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments)
+      throws MetadataDumperUsageException {
+
+    ParallelTaskGroup parallelTask = new ParallelTaskGroup(this.getName());
+    out.add(parallelTask);
+
+    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(new FormatTask(FORMAT_NAME));
+
+    //  is also be there in the metadata , no harm is making zip self-sufficient
+    parallelTask.addTask(new JdbcSelectTask(RedshiftMetadataDumpFormat.PgUser.ZIP_ENTRY_NAME,
+        "select * from pg_user"));
+
+    ZonedIntervalIterable intervals = ZonedIntervalIterable.forConnectorArguments(arguments);
+
+    // DDL TEXT is simple ...
+    // min() as there is no ANY() or SOME()
+    String queryTemplateDDL = "SELECT userid, xid, pid, trim(label) as label, starttime, endtime, sequence, text FROM STL_DDLTEXT WHERE ##";
+
+    if (arguments.isAssessment()) {
+      queryTemplateDDL += " ORDER BY starttime, xid, pid, sequence";
     }
 
-    @Override
-    public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) throws MetadataDumperUsageException {
+    makeTasks(arguments, intervals, RedshiftRawLogsDumpFormat.DdlHistory.ZIP_ENTRY_PREFIX,
+        queryTemplateDDL, "starttime", parallelTask);
 
-        ParallelTaskGroup parallelTask = new ParallelTaskGroup(this.getName());
-        out.add(parallelTask);
+    // Query Text has bit of playing around
+    // 1. STL_QUERY has starttime, queryid, but text is 4000 char wich is useless
+    // 2. STL_QUERY_TEXT has xid+squence+text which reconstructs query, but no starttime.
+    // STL_QUERY is 1 row per query ; SQL_QUERY_TEXT is multi rows per query, using sequence and xid
+    String queryTemplateQuery
+        = "SELECT userid, xid, pid, query, trim(label) as label, starttime, endtime, sequence, text"
+        + " FROM STL_QUERY join STL_QUERYTEXT using (userid, xid, pid, query) WHERE ##";
 
-        out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
-        out.add(new FormatTask(FORMAT_NAME));
-
-        //  is also be there in the metadata , no harm is making zip self-sufficient
-        parallelTask.addTask(new JdbcSelectTask(RedshiftMetadataDumpFormat.PgUser.ZIP_ENTRY_NAME, "select * from pg_user"));
-
-        ZonedIntervalIterable intervals = ZonedIntervalIterable.forConnectorArguments(arguments);
-
-        // DDL TEXT is simple ...
-        // min() as there is no ANY() or SOME()
-        String queryTemplateDDL = "SELECT userid, xid, pid, trim(label) as label, starttime, endtime, sequence, text FROM STL_DDLTEXT WHERE ##";
-
-        if (arguments.isAssessment()) {
-            queryTemplateDDL += " ORDER BY starttime, xid, pid, sequence";
-        }
-
-        makeTasks(arguments, intervals, RedshiftRawLogsDumpFormat.DdlHistory.ZIP_ENTRY_PREFIX, queryTemplateDDL, "starttime", parallelTask);
-
-        // Query Text has bit of playing around
-        // 1. STL_QUERY has starttime, queryid, but text is 4000 char wich is useless
-        // 2. STL_QUERY_TEXT has xid+squence+text which reconstructs query, but no starttime.
-        // STL_QUERY is 1 row per query ; SQL_QUERY_TEXT is multi rows per query, using sequence and xid
-        String queryTemplateQuery
-                = "SELECT userid, xid, pid, query, trim(label) as label, starttime, endtime, sequence, text"
-                + " FROM STL_QUERY join STL_QUERYTEXT using (userid, xid, pid, query) WHERE ##";
-
-        if (arguments.isAssessment()) {
-            queryTemplateQuery += " ORDER BY starttime, query, sequence";
-        }
-
-        makeTasks(arguments, intervals, RedshiftRawLogsDumpFormat.QueryHistory.ZIP_ENTRY_PREFIX, queryTemplateQuery, "starttime", parallelTask);
-
-        if (arguments.isAssessment()) {
-            String queryMetricsTemplateQuery
-                = "SELECT userid, service_class, query, segment, step_type, starttime, slices, "
-                + "  max_rows, rows, max_cpu_time, cpu_time, max_blocks_read, blocks_read, "
-                + "  max_run_time, run_time, max_blocks_to_disk, blocks_to_disk, step, "
-                + "  max_query_scan_size, query_scan_size, query_priority, query_queue_time, "
-                + "  service_class_name "
-                + "FROM STL_QUERY_METRICS WHERE ##";
-            makeTasks(arguments, intervals,
-                RedshiftRawLogsDumpFormat.QueryMetricsHistory.ZIP_ENTRY_PREFIX,
-                queryMetricsTemplateQuery, "starttime", parallelTask);
-
-            String queryQueueInfoTemplateQuery
-                = "SELECT database, query, xid, userid, queue_start_time, "
-                + " exec_start_time, service_class, slots, queue_elapsed, exec_elapsed, "
-                + " wlm_total_elapsed, commit_queue_elapsed, commit_exec_time "
-                + "FROM SVL_QUERY_QUEUE_INFO WHERE ##";
-            makeTasks(arguments, intervals,
-                RedshiftRawLogsDumpFormat.QueryQueueInfo.ZIP_ENTRY_PREFIX,
-                queryQueueInfoTemplateQuery, "queue_start_time", parallelTask);
-        }
+    if (arguments.isAssessment()) {
+      queryTemplateQuery += " ORDER BY starttime, query, sequence";
     }
 
-    // ##  in the template to be replaced by the complete WHERE clause.
-    private void makeTasks(ConnectorArguments arguments,
-            ZonedIntervalIterable intervals,
-            String filePrefix,
-            String queryTemplate,
-            String startField,
-            ParallelTaskGroup out) throws MetadataDumperUsageException {
+    makeTasks(arguments, intervals, RedshiftRawLogsDumpFormat.QueryHistory.ZIP_ENTRY_PREFIX,
+        queryTemplateQuery, "starttime", parallelTask);
 
-        List<String> whereClauses = new ArrayList<>();
+    if (arguments.isAssessment()) {
+      String queryMetricsTemplateQuery
+          = "SELECT userid, service_class, query, segment, step_type, starttime, slices, "
+          + "  max_rows, rows, max_cpu_time, cpu_time, max_blocks_read, blocks_read, "
+          + "  max_run_time, run_time, max_blocks_to_disk, blocks_to_disk, step, "
+          + "  max_query_scan_size, query_scan_size, query_priority, query_queue_time, "
+          + "  service_class_name "
+          + "FROM STL_QUERY_METRICS WHERE ##";
+      makeTasks(arguments, intervals,
+          RedshiftRawLogsDumpFormat.QueryMetricsHistory.ZIP_ENTRY_PREFIX,
+          queryMetricsTemplateQuery, "starttime", parallelTask);
 
-        if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp()))
-            whereClauses.add(String.format("%s >= CAST( '%s' as TIMESTAMP)", startField, arguments.getQueryLogEarliestTimestamp()));
+      String queryQueueInfoTemplateQuery
+          = "SELECT database, query, xid, userid, queue_start_time, "
+          + " exec_start_time, service_class, slots, queue_elapsed, exec_elapsed, "
+          + " wlm_total_elapsed, commit_queue_elapsed, commit_exec_time "
+          + "FROM SVL_QUERY_QUEUE_INFO WHERE ##";
+      makeTasks(arguments, intervals,
+          RedshiftRawLogsDumpFormat.QueryQueueInfo.ZIP_ENTRY_PREFIX,
+          queryQueueInfoTemplateQuery, "queue_start_time", parallelTask);
 
-        // LOG.info("Exporting query log for " + intervals);
-        for (ZonedInterval interval : intervals) {
-            String query = queryTemplate.replace("##",
-                    newWhereClause(whereClauses,
-                            String.format("%s >= TIMESTAMP '%s'", startField, SQL_FORMAT.format(interval.getStart())),
-                            String.format("%s < TIMESTAMP '%s'", startField, SQL_FORMAT.format(interval.getEndExclusive()))));
-            String file = filePrefix + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(interval.getStartUTC()) + RedshiftRawLogsDumpFormat.ZIP_ENTRY_SUFFIX;
-            out.addTask(new JdbcSelectTask(file, query));
-        }
+      String wlmQueryTemplateQuery
+          = "SELECT userid, xid, task, query, service_class, slot_count, service_class_start_time,"
+          + " queue_start_time, queue_end_time, total_queue_time, exec_start_time, exec_end_time,"
+          + " total_exec_time, service_class_end_time, final_state, query_priority"
+          + " FROM STL_WLM_QUERY WHERE ##";
+      makeTasks(arguments, intervals,
+          RedshiftRawLogsDumpFormat.WlmQuery.ZIP_ENTRY_PREFIX,
+          wlmQueryTemplateQuery, "service_class_start_time", parallelTask);
     }
+  }
+
+  // ##  in the template to be replaced by the complete WHERE clause.
+  private void makeTasks(ConnectorArguments arguments,
+      ZonedIntervalIterable intervals,
+      String filePrefix,
+      String queryTemplate,
+      String startField,
+      ParallelTaskGroup out) throws MetadataDumperUsageException {
+
+    List<String> whereClauses = new ArrayList<>();
+
+    if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp())) {
+      whereClauses.add(String.format("%s >= CAST( '%s' as TIMESTAMP)", startField,
+          arguments.getQueryLogEarliestTimestamp()));
+    }
+
+    // LOG.info("Exporting query log for " + intervals);
+    for (ZonedInterval interval : intervals) {
+      String query = queryTemplate.replace("##",
+          newWhereClause(whereClauses,
+              String.format("%s >= TIMESTAMP '%s'", startField,
+                  SQL_FORMAT.format(interval.getStart())),
+              String.format("%s < TIMESTAMP '%s'", startField,
+                  SQL_FORMAT.format(interval.getEndExclusive()))));
+      String file =
+          filePrefix + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(interval.getStartUTC())
+              + RedshiftRawLogsDumpFormat.ZIP_ENTRY_SUFFIX;
+      out.addTask(new JdbcSelectTask(file, query));
+    }
+  }
 }

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftRawLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftRawLogsDumpFormat.java
@@ -19,65 +19,77 @@ package com.google.edwmigration.dumper.plugin.lib.dumper.spi;
 import javax.annotation.Nonnull;
 
 /**
- * All names in here are lowercase because they are the aliases from the redshift projection,
- * and the dumper did not quote them, so they were lowercased by the server because redshift is a
+ * All names in here are lowercase because they are the aliases from the redshift projection, and
+ * the dumper did not quote them, so they were lowercased by the server because redshift is a
  * CASE_SMASH_LOWER dialect.
  */
 public interface RedshiftRawLogsDumpFormat {
 
-    public static final String FORMAT_NAME = "redshift-raw.logs.zip";
-    public static final String ZIP_ENTRY_SUFFIX = ".csv";
+  public static final String FORMAT_NAME = "redshift-raw.logs.zip";
+  public static final String ZIP_ENTRY_SUFFIX = ".csv";
 
-    public static interface DdlHistory {
+  public static interface DdlHistory {
 
-        public static final String ZIP_ENTRY_PREFIX = "ddltext_";
+    public static final String ZIP_ENTRY_PREFIX = "ddltext_";
 
-        public static enum Header {
-            userid, xid, pid, label, starttime, endtime, sequence, text;
-        }
-
-        public static boolean isZipEntryName(@Nonnull String name) {
-            return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
-        }
+    public static enum Header {
+      userid, xid, pid, label, starttime, endtime, sequence, text;
     }
 
-    public static interface QueryHistory {
+    public static boolean isZipEntryName(@Nonnull String name) {
+      return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
+    }
+  }
 
-        public static final String ZIP_ENTRY_PREFIX = "querytext_";
+  public static interface QueryHistory {
 
-        public static enum Header {
-            userid, xid, pid, query, label, starttime, endtime, sequence, text;
-        }
+    public static final String ZIP_ENTRY_PREFIX = "querytext_";
 
-        public static boolean isZipEntryName(@Nonnull String name) {
-            return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
-        }
+    public static enum Header {
+      userid, xid, pid, query, label, starttime, endtime, sequence, text;
     }
 
-    public static interface QueryMetricsHistory {
+    public static boolean isZipEntryName(@Nonnull String name) {
+      return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
+    }
+  }
 
-        public static final String ZIP_ENTRY_PREFIX = "querymetrics_";
+  public static interface QueryMetricsHistory {
 
-        public static enum Header {
-            userid, service_class, query, segment, step_type, starttime, slices, max_rows, rows,
-            max_cpu_time, cpu_time, max_blocks_read, blocks_read, max_run_time, run_time,
-            max_blocks_to_disk, blocks_to_disk, step, max_query_scan_size, query_scan_size,
-            query_priority, query_queue_time, service_class_name;
+    public static final String ZIP_ENTRY_PREFIX = "querymetrics_";
 
-        }
+    public static enum Header {
+      userid, service_class, query, segment, step_type, starttime, slices, max_rows, rows,
+      max_cpu_time, cpu_time, max_blocks_read, blocks_read, max_run_time, run_time,
+      max_blocks_to_disk, blocks_to_disk, step, max_query_scan_size, query_scan_size,
+      query_priority, query_queue_time, service_class_name;
 
-        public static boolean isZipEntryName(@Nonnull String name) {
-            return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
-        }
     }
 
-    interface QueryQueueInfo {
-        String ZIP_ENTRY_PREFIX = "query_queue_info_";
-
-        enum Header {
-            database, query, xid, userid, queue_start_time, exec_start_time,
-            service_class, slots, queue_elapsed, exec_elapsed, wlm_total_elapsed,
-            commit_queue_elapsed, commit_exec_time;
-        }
+    public static boolean isZipEntryName(@Nonnull String name) {
+      return name.startsWith(ZIP_ENTRY_PREFIX) && name.endsWith(ZIP_ENTRY_SUFFIX);
     }
+  }
+
+  interface QueryQueueInfo {
+
+    String ZIP_ENTRY_PREFIX = "query_queue_info_";
+
+    enum Header {
+      database, query, xid, userid, queue_start_time, exec_start_time,
+      service_class, slots, queue_elapsed, exec_elapsed, wlm_total_elapsed,
+      commit_queue_elapsed, commit_exec_time;
+    }
+  }
+
+  interface WlmQuery {
+
+    String ZIP_ENTRY_PREFIX = "wlm_query_";
+
+    enum Header {
+      userid, xid, task, query, service_class, slot_count, service_class_start_time,
+      queue_start_time, queue_end_time, total_queue_time, exec_start_time, exec_end_time,
+      total_exec_time, service_class_end_time, final_state, query_priority;
+    }
+  }
 }


### PR DESCRIPTION
STL_WLM_QUERY can be big and has a timestamp, so raw logs connector is the correct place to dump it.