### PR TITLE
move STL_WLM_QUERY to raw logs connector (Redshift assessment dump)

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -111,7 +111,6 @@ public class RedshiftMetadataConnector extends AbstractRedshiftConnector impleme
             selStar(parallelTask, "STV_MV_INFO");
             selStar(parallelTask, "STV_WLM_SERVICE_CLASS_CONFIG");
             selStar(parallelTask, "STV_WLM_SERVICE_CLASS_STATE");
-            selStar(parallelTask, "STL_WLM_QUERY");
         }
     }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -127,6 +127,15 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector implemen
             makeTasks(arguments, intervals,
                 RedshiftRawLogsDumpFormat.QueryQueueInfo.ZIP_ENTRY_PREFIX,
                 queryQueueInfoTemplateQuery, "queue_start_time", parallelTask);
+
+            String wlmQueryTemplateQuery
+                = "SELECT userid, xid, task, query, service_class, slot_count, service_class_start_time,"
+                + " queue_start_time, queue_end_time, total_queue_time, exec_start_time, exec_end_time,"
+                + " total_exec_time, service_class_end_time, final_state, query_priority"
+                + " FROM STL_WLM_QUERY WHERE ##";
+            makeTasks(arguments, intervals,
+                RedshiftRawLogsDumpFormat.WlmQuery.ZIP_ENTRY_PREFIX,
+                wlmQueryTemplateQuery, "service_class_start_time", parallelTask);
         }
     }
 

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftRawLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftRawLogsDumpFormat.java
@@ -80,4 +80,14 @@ public interface RedshiftRawLogsDumpFormat {
             commit_queue_elapsed, commit_exec_time;
         }
     }
+
+    interface WlmQuery {
+        String ZIP_ENTRY_PREFIX = "wlm_query_";
+
+        enum Header {
+            userid, xid, task, query, service_class, slot_count, service_class_start_time,
+            queue_start_time, queue_end_time, total_queue_time, exec_start_time, exec_end_time,
+            total_exec_time, service_class_end_time, final_state, query_priority;
+        }
+    }
 }


### PR DESCRIPTION
STL_WLM_QUERY can be big and has a timestamp, so raw logs connector is a correct place to dump it.