### PR TITLE
Dump Redshift's CURRENT_DATABASE and VERSION

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftEnvironmentYamlTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftEnvironmentYamlTask.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2022 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.redshift;
+
+import com.google.common.io.ByteSink;
+import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import com.google.edwmigration.dumper.plugin.ext.jdk.progress.RecordProgressMonitor;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftMetadataDumpFormat.RedshiftEnvironmentFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftMetadataDumpFormat.RedshiftEnvironmentFormat.Root;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.springframework.jdbc.core.ResultSetExtractor;
+
+public class RedshiftEnvironmentYamlTask extends AbstractJdbcTask<Void> {
+
+  private static final String ENV_QUERY =
+      "SELECT current_database() AS db_name, version() as db_version;";
+
+  public RedshiftEnvironmentYamlTask() {
+    super(RedshiftEnvironmentFormat.ZIP_ENTRY_NAME);
+  }
+
+  @CheckForNull
+  @Override
+  protected Void doInConnection(@Nonnull TaskRunContext context,
+      @Nonnull JdbcHandle jdbcHandle,
+      @Nonnull ByteSink sink, @Nonnull Connection connection) throws SQLException {
+    ResultSetExtractor<Void> rse = getRedshiftEnvironmentExtractor(sink);
+    return doSelect(connection, rse, ENV_QUERY);
+  }
+
+  private ResultSetExtractor<Void> getRedshiftEnvironmentExtractor(@Nonnull ByteSink sink) {
+    return rs -> {
+      try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName());
+          Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
+        if (rs.next()) {
+          monitor.count();
+          Root root = new Root();
+          root.currentDatabase = rs.getString("db_name");
+          root.redshiftVersion = rs.getString("db_version");
+          CoreMetadataDumpFormat.MAPPER.writeValue(writer, root);
+        }
+        return null;
+      } catch (IOException e) {
+        throw new SQLException(e);
+      }
+    };
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -60,6 +60,7 @@ public class RedshiftMetadataConnector extends AbstractRedshiftConnector impleme
 
         out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
         out.add(new FormatTask(FORMAT_NAME));
+        out.add(new RedshiftEnvironmentYamlTask());
 
         parallelTask.addTask(new JdbcSelectTask(SvvColumnsFormat.ZIP_ENTRY_NAME, "SELECT * FROM SVV_COLUMNS"));
         selStar(parallelTask, "SVV_TABLES");

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RedshiftMetadataDumpFormat.java
@@ -16,6 +16,9 @@
  */
 package com.google.edwmigration.dumper.plugin.lib.dumper.spi;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 /**
  *
  * @author shevek
@@ -199,6 +202,17 @@ public interface RedshiftMetadataDumpFormat extends PostgresqlMetadataDumpFormat
             /* Trailing fields are optional; as long as we match on the important ones. */
             // column_set_using,   // Used not to be present, but is in Elon's dump.
             // is_identity;
+        }
+    }
+
+    public static interface RedshiftEnvironmentFormat {
+        public static final String ZIP_ENTRY_NAME = "redshift-environment.yaml";
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        @JsonInclude(JsonInclude.Include.NON_ABSENT)
+        public static class Root {
+            public String currentDatabase;
+            public String redshiftVersion;
         }
     }
 }


### PR DESCRIPTION
This PR makes Redshift metadata dumper gather environment information and save them in metadata ZIP.

1. A new `redshift-environment.yaml` file will be present in the ZIP
2. `CURRENT_DATABASE()` and `VERSION()` of the Redshift instance the dumper is executed against will be stored in respectively `currentDatabase` and `redshiftVersion` attributes of the YAML.