### PR TITLE
Pick QueryID from DBQLogTbl/QryLogV instead DBQLSQLTbl

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -95,7 +95,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector implements 
     // MUST match TeradataLogsDumpFormat.Header
     @VisibleForTesting
     static final String[] EXPRESSIONS = new String[]{
-        "ST.QueryID",
+        "L.QueryID",
         "ST.SQLRowNo",
         "ST.SQLTextInfo",
         "L.UserName",
@@ -270,7 +270,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector implements 
     protected static class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
         /* pp */ static final String ASSESSMENT_DEF_LOG_TABLE = "dbc.QryLogV";
         static final String[] EXPRESSIONS_FOR_ASSESSMENT = new String[]{
-                "ST.QueryID",
+                "L.QueryID",
                 "ST.SQLRowNo",
                 "ST.SQLTextInfo",
                 "L.AbortFlag",


### PR DESCRIPTION
Left outer join is based on L alias, but QueryID is taken from ST, making logs, missed in "dbc.DBQLSQLTbl", indistinguishable from each other.