### PR TITLE
Logging: add minimal configuration.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -211,7 +211,7 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
         // Debugging:
         //   DSILogLevel=0..6;LogPath=C:\temp
         //   LogLevel 0/1
-        LOG.debug("URI is " + url);
+        LOG.trace("URI is " + url);
         DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
 
         return JdbcHandle.newPooledJdbcHandle(dataSource, arguments.getThreadPoolSize());

--- a/dumper/app/src/main/resources/logback.xml
+++ b/dumper/app/src/main/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+		<encoder>
+			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+		</encoder>
+	</appender>
+
+	<logger name="org.springframework.jdbc.core.JdbcTemplate" level="info"/>
+	<logger name="org.springframework.jdbc.datasource" level="info" />
+	<logger name="org.springframework" level="info"/>
+	<logger name="com.zaxxer.hikari" level="info"/>
+
+	<root level="${LOG_LEVEL:-debug}">
+		<appender-ref ref="CONSOLE" />
+	</root>
+
+</configuration>


### PR DESCRIPTION
Add some minimal logging configuration setting root logger to `DEBUG` as a default, and allowing override with `LOG_LEVEL` environment variable. Some common packages are set at `INFO` level.
Logging of JDBC URI is now set at `TRACE` level.