### PR TITLE
Fix for readlink on mac

### DIFF
--- a/bin/dwh-migration-dumper
+++ b/bin/dwh-migration-dumper
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
-BIN=$(dirname $(readlink -f $0))/../dumper/app/build/install/app/bin/dwh-migration-dumper
+BIN=$(dirname $(readlink -f $0 2> /dev/null || perl -MCwd=abs_path -le 'print abs_path readlink(shift);' $0))/../dumper/app/build/install/app/bin/dwh-migration-dumper
 
 if [ ! -x "$BIN" ] ; then
 	./gradlew --parallel :dumper:app:installDist


### PR DESCRIPTION
On Mac OS X, readlink -f $0 returns 'illegal option -- f'. See this post: https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac for details. Added a workaround of using perl, which is preinstalled with all mac os since at least 2002 (http://preserve.mactech.com/articles/mactech/Vol.18/18.09/PerlforMacOSX/index.html).