### PR TITLE
Remove partitions limit from Hive Thrift metadata connector

### DIFF
--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -194,7 +194,7 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
             @Override
             public List<? extends Partition> getPartitions() throws Exception {
                 List<Partition> out = new ArrayList<>();
-                for (String partitionName : client.get_partition_names(databaseName, tableName, Short.MAX_VALUE)) {
+                for (String partitionName : client.get_partition_names(databaseName, tableName, (short) -1)) {
                     com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.Partition partition = client.get_partition_by_name(databaseName, tableName, partitionName);
                     out.add(new Partition() {
                         @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -194,7 +194,7 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
             @Override
             public List<? extends Partition> getPartitions() throws Exception {
                 List<Partition> out = new ArrayList<>();
-                for (String partitionName : client.get_partition_names(databaseName, tableName, Short.MAX_VALUE)) {
+                for (String partitionName : client.get_partition_names(databaseName, tableName, (short) -1)) {
                     com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.Partition partition = client.get_partition_by_name(databaseName, tableName, partitionName);
                     out.add(new Partition() {
                         @Nonnull


### PR DESCRIPTION
Source code [indicates](http://go/gh/apache/hive/blob/master/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift#L2655) that it's possible to return all the partitions for the table. 

With this I was able to get all 41K partitions for one of my tables. Tested with other smaller ones too. 