### PR TITLE
Replace CollectTimeStamp with StartTime for Teradata query tables

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
@@ -132,8 +132,8 @@ public class Teradata14LogsConnector extends TeradataLogsConnector {
 
             buf.append(" FROM ").append(logTable).append(" L ");
 
-            buf.append(String.format("WHERE L.CollectTimeStamp >= CAST('%s' AS TIMESTAMP)\n"
-                    + "AND L.CollectTimeStamp < CAST('%s' AS TIMESTAMP)\n",
+            buf.append(String.format("WHERE L.StartTime >= CAST('%s' AS TIMESTAMP)\n"
+                    + "AND L.StartTime < CAST('%s' AS TIMESTAMP)\n",
                     SQL_FORMAT.format(interval.getStart()), SQL_FORMAT.format(interval.getEndExclusive())));
 
             for (String condition : conditions) {
@@ -168,7 +168,7 @@ public class Teradata14LogsConnector extends TeradataLogsConnector {
         List<String> logConditions = new ArrayList<>();
         if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp())) {
             lSqlConditions.add("ST.CollectTimeStamp >= " + arguments.getQueryLogEarliestTimestamp());
-            logConditions.add("L.CollectTimeStamp >= " + arguments.getQueryLogEarliestTimestamp());
+            logConditions.add("L.StartTime >= " + arguments.getQueryLogEarliestTimestamp());
         }
 
         final int daysToExport = arguments.getQueryLogDays(7);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -116,7 +116,8 @@ public class TeradataLogsConnector extends AbstractTeradataConnector implements 
         "L.SessionWDID",
         "L.Statements",
         "L.TotalIOCount",
-        "L.WarningOnly"
+        "L.WarningOnly",
+        "L.StartTime"
     };
 
     public static boolean isQueryTable(@Nonnull String expression) {
@@ -230,8 +231,8 @@ public class TeradataLogsConnector extends AbstractTeradataConnector implements 
             }
 
             buf.append(String.format(" WHERE L.ErrorCode=0\n"
-                    + "AND L.CollectTimeStamp >= CAST('%s' AS TIMESTAMP)\n"
-                    + "AND L.CollectTimeStamp < CAST('%s' AS TIMESTAMP)\n",
+                    + "AND L.StartTime >= CAST('%s' AS TIMESTAMP)\n"
+                    + "AND L.StartTime < CAST('%s' AS TIMESTAMP)\n",
                     SQL_FORMAT.format(interval.getStart()), SQL_FORMAT.format(interval.getEndExclusive())));
 
             for (String condition : conditions) {
@@ -425,7 +426,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector implements 
         // preventing that in the future. To do that, we should require getQueryLogEarliestTimestamp()
         // to parse and return an ISO instant, not a database-server-specific format.
         if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp()))
-            conditions.add("L.CollectTimeStamp >= " + arguments.getQueryLogEarliestTimestamp());
+            conditions.add("L.StartTime >= " + arguments.getQueryLogEarliestTimestamp());
 
         // Beware of Teradata SQLSTATE HY000. See issue #4126.
         // Most likely caused by some operation (equality?) being performed on a datum which is too long for a varchar.

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
@@ -116,7 +116,7 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
             OutputHandleFactory sinkFactory = new FileSystemOutputHandleFactory(fileSystem, "/");
             handle.getJdbcTemplate().execute("attach ':memory:' as dbc");
             // handle.getJdbcTemplate().execute("create table dbc.dbcinfo (InfoKey varchar,  InfoData varchar)");
-            handle.getJdbcTemplate().execute("create table " + TeradataLogsConnector.DEF_LOG_TABLE + " (UserName varchar, errorcode int, collecttimestamp int)");
+            handle.getJdbcTemplate().execute("create table " + TeradataLogsConnector.DEF_LOG_TABLE + " (UserName varchar, errorcode int, StartTime int)");
 
             TaskRunContext runContext = new DummyTaskRunContext(sinkFactory, handle);
             List<Task<?>> tasks = new ArrayList<>();

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/TeradataLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/TeradataLogsDumpFormat.java
@@ -50,7 +50,8 @@ public interface TeradataLogsDumpFormat {
         SessionWDID,
         Statements,
         TotalIOCount,
-        WarningOnly
+        WarningOnly,
+        StartTime
 
     }
 
@@ -205,7 +206,8 @@ public interface TeradataLogsDumpFormat {
         SessionWDID,
         Statements,
         TotalIOCount,
-        WarningOnly
+        WarningOnly,
+        StartTime
 
     }
 }


### PR DESCRIPTION
`CollectTimeStamp` doesn't relate to query – from the documentation it is "A date and time unique to each buffer cache, which changes for each new buffer", also see [community answer](https://support.teradata.com/community?id=community_question&sys_id=647632d01b9010d046fcb99e0a4bcb6b).

On the Assessment side we saw 2 year difference between `CollectTimeStamp` and `StartTime` columns. This PR changes SQL WHERE clauses for query tables to use `StartTime` instead.

It doesn't touch SQL log table on purpose – `CollectTimeStamp` there represents a time when row is written to DB ([link](https://docs.teradata.com/r/Teradata-Database-Administration/April-2018/Tracking-Query-Behavior-with-Database-Query-Logging-Operational-DBAs/SQL-Log-Table-DBQLSQLTbl).