### PR TITLE
Remove os.PathLike subscript type arg to support Python < 3.9.

### DIFF
--- a/client/bqms_run/gcp/gcs.py
+++ b/client/bqms_run/gcp/gcs.py
@@ -53,7 +53,10 @@ class GSClient(cloudpathlib.GSClient):
         cloudpathlib.GSClient._default_client = self  # type: ignore[misc] # pylint: disable=protected-access
 
     def _download_file(
-        self, cloud_path: cloudpathlib.GSPath, local_path: Union[str, os.PathLike[Any]]
+        self,
+        cloud_path: cloudpathlib.GSPath,
+        # Subscript type arg not supported on ABCs in Python < 3.9.
+        local_path: Union[str, os.PathLike],  # type: ignore[type-arg]
     ) -> Path:
         """Override to use bucket.blob instead of bucket.get_blob.
 
@@ -84,7 +87,11 @@ class GSPath(cloudpathlib.GSPath):
 
     client: GSClient
 
-    def download_to(self, destination: Union[str, os.PathLike[Any]]) -> Path:
+    def download_to(
+        self,
+        # Subscript type arg not supported on ABCs in Python < 3.9.
+        destination: Union[str, os.PathLike],  # type: ignore[type-arg]
+    ) -> Path:
         """Download GSPath to local cache."""
         destination = Path(destination)
         if destination.is_dir():


### PR DESCRIPTION
`os.PathLike` is an abstract base class and subscript type arguments are not supported on ABCs until Python 3.9.

This was not caught by our `nox` tests due to a misconfiguration that was causing tests to run outside of the `nox` virtualenv. This has also been fixed.