### PR TITLE
Reformat the code according to Google Java Style.

### DIFF
--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -170,6 +170,8 @@ spotless {
 	// ratchetFrom 'origin/main' // Enables lazy copyright year updates.
 
 	java {
+                googleJavaFormat()
+                ratchetFrom("v1.0.20")
 		licenseHeaderFile rootProject.file("gradle/codequality/HEADER.java");
 		trimTrailingWhitespace();
         FileCollection files = files();


### PR DESCRIPTION
The reformatting uses spotless Gradle plugin. Only files changed after `v1.0.20` tag will be affected.