### PR TITLE
Add connector-specific max-rows options.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -95,9 +95,6 @@ public class ConnectorArguments extends DefaultArguments {
   public static final String OPT_DATABASE = "database";
   public static final String OPT_SCHEMA = "schema";
   public static final String OPT_ASSESSMENT = "assessment";
-  public static final String OPT_TERADATA_MAX_TABLESIZEV_ROWS = "max-tablesizev-rows";
-  public static final String OPT_TERADATA_MAX_DATABASESV_USER_ROWS = "max-databasesv-user-rows";
-  public static final String OPT_TERADATA_MAX_DATABASESV_DB_ROWS = "max-databasesv-db-rows";
   public static final String OPT_ORACLE_SID = "oracle-sid";
   public static final String OPT_ORACLE_SERVICE = "oracle-service";
 
@@ -176,33 +173,6 @@ public class ConnectorArguments extends DefaultArguments {
       parser.accepts(
           OPT_ASSESSMENT,
           "Whether to create a dump for assessment (i.e., dump additional information).");
-
-  public static final String TERADATA_MAX_TABLE_SIZE_V_ROWS_DESCRIPTION =
-      "Max number of rows to extract from DBC.TableSizeV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxTableSizeVRows =
-      parser
-          .accepts(OPT_TERADATA_MAX_TABLESIZEV_ROWS, TERADATA_MAX_TABLE_SIZE_V_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
-  public static final String TERADATA_MAX_DATABASES_V_USER_ROWS_DESCRIPTION =
-      "Max number of user rows (DBKind='U') to extract from DBC.DatabasesV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxDatabasesVUserRows =
-      parser
-          .accepts(
-              OPT_TERADATA_MAX_DATABASESV_USER_ROWS, TERADATA_MAX_DATABASES_V_USER_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
-  public static final String TERADATA_MAX_DATABASES_V_DB_ROWS_DESCRIPTION =
-      "Max number of database rows (DBKind='D') to extract from DBC.DatabasesV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxDatabasesVDbRows =
-      parser
-          .accepts(
-              OPT_TERADATA_MAX_DATABASESV_DB_ROWS, TERADATA_MAX_DATABASES_V_DB_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
 
   private final OptionSpec<String> optionUser =
       parser.accepts(OPT_USER, "Database username").withRequiredArg().describedAs("admin");
@@ -613,18 +583,6 @@ public class ConnectorArguments extends DefaultArguments {
 
   public boolean isAssessment() {
     return getOptions().has(optionAssessment);
-  }
-
-  public Optional<Long> getTeradataMaxTableSizeVRows() {
-    return optionAsOptional(optionTeradataMaxTableSizeVRows);
-  }
-
-  public Optional<Long> getTeradataMaxDatabasesVUserRows() {
-    return optionAsOptional(optionTeradataMaxDatabasesVUserRows);
-  }
-
-  public Optional<Long> getTeradataMaxDatabasesVDbRows() {
-    return optionAsOptional(optionTeradataMaxDatabasesVDbRows);
   }
 
   private <T> Optional<T> optionAsOptional(OptionSpec<T> spec) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -16,10 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper;
 
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_TERADATA_MAX_DATABASESV_DB_ROWS;
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_TERADATA_MAX_DATABASESV_USER_ROWS;
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_TERADATA_MAX_TABLESIZEV_ROWS;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
@@ -53,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -96,35 +91,6 @@ public class MetadataDumper {
     return new String(out);
   }
 
-  private static class ArgumentValidationException extends RuntimeException {
-    ArgumentValidationException(String message) {
-      super(message);
-    }
-  }
-
-  private static void validateArgumentGreaterThan(
-      Optional<Long> valueMaybe, long minValue, String argumentName) {
-    valueMaybe.ifPresent(
-        value -> {
-          if (value <= minValue) {
-            throw new ArgumentValidationException(
-                String.format(
-                    "Argument for '%s' option must be greater than 0. Actual: '%s'.",
-                    argumentName, value));
-          }
-        });
-  }
-
-  private static void validateArguments(ConnectorArguments arguments)
-      throws ArgumentValidationException {
-    validateArgumentGreaterThan(
-        arguments.getTeradataMaxTableSizeVRows(), 0, OPT_TERADATA_MAX_TABLESIZEV_ROWS);
-    validateArgumentGreaterThan(
-        arguments.getTeradataMaxDatabasesVUserRows(), 0, OPT_TERADATA_MAX_DATABASESV_USER_ROWS);
-    validateArgumentGreaterThan(
-        arguments.getTeradataMaxDatabasesVDbRows(), 0, OPT_TERADATA_MAX_DATABASESV_DB_ROWS);
-  }
-
   public void run(@Nonnull String... args) throws Exception {
     ConnectorArguments arguments = new ConnectorArguments(args);
 
@@ -142,13 +108,6 @@ public class MetadataDumper {
               + " not supported; available are "
               + CONNECTORS.keySet()
               + ".");
-      return;
-    }
-
-    try {
-      validateArguments(arguments);
-    } catch (ArgumentValidationException ex) {
-      LOG.error("ERROR: Validation failed. {}", ex.getMessage());
       return;
     }
 


### PR DESCRIPTION
Add a possibility to limit the number of rows extracted from DBC.DiskSpaceV table during teradata metadata extraction.

New connector-specific options:
- for TableSizeV: `-Dteradata.metadata.tablesizev.max-rows`
- for DiskSpaceV: `-Dteradata.metadata.diskspacev.max-rows`
- for users in DatabasesV: `-Dteradata.metadata.databasesv.users.max-rows`
- for databases in DatabasesV: `-Dteradata.metadata.databasesv.dbs.max-rows`