### PR TITLE
Fix processing empty string in command line arguments.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFile.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFile.java
@@ -55,16 +55,13 @@ public class JsonResponseFile {
   @Nonnull
   public static String[] addResponseFiles(@Nonnull @NonNull String @NonNull [] args)
       throws IOException {
-    boolean hasResponseFile = true;
-    for (int j = 0; hasResponseFile && j < args.length; j++)
-      if (args[j].charAt(0) == '@') hasResponseFile = true;
-    if (!hasResponseFile) return args;
-
-    // Now convert...
     List<String> ret = new ArrayList<>();
-    for (int j = 0; j < args.length; j++) {
-      if (args[j].charAt(0) != '@') ret.add(args[j]);
-      else ret.addAll(to_arguments(new File(args[j].substring(1))));
+    for (String argument : args) {
+      if (argument.startsWith("@")) {
+        ret.addAll(to_arguments(new File(argument.substring(1))));
+      } else {
+        ret.add(argument);
+      }
     }
     return ret.toArray(ArrayUtils.EMPTY_STRING_ARRAY);
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFileTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFileTest.java
@@ -16,6 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper;
 
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -103,5 +106,25 @@ public class JsonResponseFileTest {
         JsonResponseFile.to_arguments(
                 new ObjectMapper().writeValueAsString(JsonResponseFile.from_arguments(args)))
             .toArray(new String[] {}));
+  }
+
+  @Test
+  public void addResponseFiles_emptyArray() throws IOException {
+    // Act
+    String[] result = JsonResponseFile.addResponseFiles(new String[0]);
+
+    // Assert
+    assertEquals(0, result.length);
+  }
+
+  @Test
+  public void addResponseFiles_emptyElement() throws IOException {
+    String[] args = new String[] {""};
+
+    // Act
+    String[] result = JsonResponseFile.addResponseFiles(args);
+
+    // Assert
+    assertArrayEquals(args, result);
   }
 }


### PR DESCRIPTION
Empty string in command line arguments failed with the confusing message:
```
Exception in thread "main" java.lang.StringIndexOutOfBoundsException:
String index out of range: 0
```

After this change the processing is not interrupted in JsonResponseFile class, so the new error message depends on which command line option is affected by the empty string.