### PR TITLE
New syntax for max number of rows parameters.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -95,10 +95,6 @@ public class ConnectorArguments extends DefaultArguments {
   public static final String OPT_DATABASE = "database";
   public static final String OPT_SCHEMA = "schema";
   public static final String OPT_ASSESSMENT = "assessment";
-  public static final String OPT_TERADATA_MAX_TABLESIZEV_ROWS = "max-tablesizev-rows";
-  public static final String OPT_TERADATA_MAX_DATABASESV_USER_ROWS = "max-databasesv-user-rows";
-  public static final String OPT_TERADATA_MAX_DATABASESV_DB_ROWS = "max-databasesv-db-rows";
-  public static final String OPT_TERADATA_MAX_DISKSPACEV_ROWS = "max-diskspacev-rows";
   public static final String OPT_ORACLE_SID = "oracle-sid";
   public static final String OPT_ORACLE_SERVICE = "oracle-service";
 
@@ -177,41 +173,6 @@ public class ConnectorArguments extends DefaultArguments {
       parser.accepts(
           OPT_ASSESSMENT,
           "Whether to create a dump for assessment (i.e., dump additional information).");
-
-  public static final String TERADATA_MAX_TABLE_SIZE_V_ROWS_DESCRIPTION =
-      "Max number of rows to extract from DBC.TableSizeV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxTableSizeVRows =
-      parser
-          .accepts(OPT_TERADATA_MAX_TABLESIZEV_ROWS, TERADATA_MAX_TABLE_SIZE_V_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
-  public static final String TERADATA_MAX_DATABASES_V_USER_ROWS_DESCRIPTION =
-      "Max number of user rows (DBKind='U') to extract from DBC.DatabasesV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxDatabasesVUserRows =
-      parser
-          .accepts(
-              OPT_TERADATA_MAX_DATABASESV_USER_ROWS, TERADATA_MAX_DATABASES_V_USER_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
-  public static final String TERADATA_MAX_DATABASES_V_DB_ROWS_DESCRIPTION =
-      "Max number of database rows (DBKind='D') to extract from DBC.DatabasesV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxDatabasesVDbRows =
-      parser
-          .accepts(
-              OPT_TERADATA_MAX_DATABASESV_DB_ROWS, TERADATA_MAX_DATABASES_V_DB_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
-  public static final String TERADATA_MAX_DISK_SPACE_V_ROWS_DESCRIPTION =
-      "Max number of rows to extract from DBC.DiskSpaceV table (available for 'teradata' connector only)";
-  private final OptionSpec<Long> optionTeradataMaxDiskSpaceVRows =
-      parser
-          .accepts(OPT_TERADATA_MAX_DISKSPACEV_ROWS, TERADATA_MAX_DISK_SPACE_V_ROWS_DESCRIPTION)
-          .withRequiredArg()
-          .ofType(Long.class)
-          .describedAs("100000");
 
   private final OptionSpec<String> optionUser =
       parser.accepts(OPT_USER, "Database username").withRequiredArg().describedAs("admin");
@@ -622,22 +583,6 @@ public class ConnectorArguments extends DefaultArguments {
 
   public boolean isAssessment() {
     return getOptions().has(optionAssessment);
-  }
-
-  public Optional<Long> getTeradataMaxTableSizeVRows() {
-    return optionAsOptional(optionTeradataMaxTableSizeVRows);
-  }
-
-  public Optional<Long> getTeradataMaxDatabasesVUserRows() {
-    return optionAsOptional(optionTeradataMaxDatabasesVUserRows);
-  }
-
-  public Optional<Long> getTeradataMaxDatabasesVDbRows() {
-    return optionAsOptional(optionTeradataMaxDatabasesVDbRows);
-  }
-
-  public Optional<Long> getTeradataMaxDiskSpaceVRows() {
-    return optionAsOptional(optionTeradataMaxDiskSpaceVRows);
   }
 
   private <T> Optional<T> optionAsOptional(OptionSpec<T> spec) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -16,10 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper;
 
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_TERADATA_MAX_DATABASESV_DB_ROWS;
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_TERADATA_MAX_DATABASESV_USER_ROWS;
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_TERADATA_MAX_TABLESIZEV_ROWS;
-
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
@@ -53,7 +49,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -96,35 +91,6 @@ public class MetadataDumper {
     return new String(out);
   }
 
-  private static class ArgumentValidationException extends RuntimeException {
-    ArgumentValidationException(String message) {
-      super(message);
-    }
-  }
-
-  private static void validateArgumentGreaterThan(
-      Optional<Long> valueMaybe, long minValue, String argumentName) {
-    valueMaybe.ifPresent(
-        value -> {
-          if (value <= minValue) {
-            throw new ArgumentValidationException(
-                String.format(
-                    "Argument for '%s' option must be greater than 0. Actual: '%s'.",
-                    argumentName, value));
-          }
-        });
-  }
-
-  private static void validateArguments(ConnectorArguments arguments)
-      throws ArgumentValidationException {
-    validateArgumentGreaterThan(
-        arguments.getTeradataMaxTableSizeVRows(), 0, OPT_TERADATA_MAX_TABLESIZEV_ROWS);
-    validateArgumentGreaterThan(
-        arguments.getTeradataMaxDatabasesVUserRows(), 0, OPT_TERADATA_MAX_DATABASESV_USER_ROWS);
-    validateArgumentGreaterThan(
-        arguments.getTeradataMaxDatabasesVDbRows(), 0, OPT_TERADATA_MAX_DATABASESV_DB_ROWS);
-  }
-
   public void run(@Nonnull String... args) throws Exception {
     ConnectorArguments arguments = new ConnectorArguments(args);
 
@@ -142,13 +108,6 @@ public class MetadataDumper {
               + " not supported; available are "
               + CONNECTORS.keySet()
               + ".");
-      return;
-    }
-
-    try {
-      validateArguments(arguments);
-    } catch (ArgumentValidationException ex) {
-      LOG.error("ERROR: Validation failed. {}", ex.getMessage());
       return;
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
@@ -20,10 +20,11 @@ import static com.google.edwmigration.dumper.application.dumper.connector.terada
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabasePredicate;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
@@ -33,36 +34,54 @@ import com.google.edwmigration.dumper.application.dumper.utils.SqlBuilder;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.TeradataMetadataDumpFormat;
 import java.util.List;
-import java.util.Optional;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.OptionalLong;
+import javax.annotation.Nonnull;
+import org.apache.commons.lang3.StringUtils;
 
 /** @author miguel */
 @AutoService({Connector.class, MetadataConnector.class})
 @Description("Dumps metadata from Teradata.")
 @RespectsArgumentDatabasePredicate
 @RespectsArgumentAssessment
-@RespectsInput(
-    order = 450,
-    arg = ConnectorArguments.OPT_TERADATA_MAX_TABLESIZEV_ROWS,
-    description = ConnectorArguments.TERADATA_MAX_TABLE_SIZE_V_ROWS_DESCRIPTION)
-@RespectsInput(
-    order = 450,
-    arg = ConnectorArguments.OPT_TERADATA_MAX_DATABASESV_USER_ROWS,
-    description = ConnectorArguments.TERADATA_MAX_DATABASES_V_USER_ROWS_DESCRIPTION)
-@RespectsInput(
-    order = 450,
-    arg = ConnectorArguments.OPT_TERADATA_MAX_DATABASESV_DB_ROWS,
-    description = ConnectorArguments.TERADATA_MAX_DATABASES_V_DB_ROWS_DESCRIPTION)
-@RespectsInput(
-    order = 450,
-    arg = ConnectorArguments.OPT_TERADATA_MAX_DISKSPACEV_ROWS,
-    description = ConnectorArguments.TERADATA_MAX_DISK_SPACE_V_ROWS_DESCRIPTION)
 public class TeradataMetadataConnector extends AbstractTeradataConnector
     implements MetadataConnector, TeradataMetadataDumpFormat {
 
-  @SuppressWarnings("UnusedVariable")
-  private static final Logger LOG = LoggerFactory.getLogger(TeradataMetadataConnector.class);
+  public enum TeradataMetadataConnectorProperties implements ConnectorProperty {
+    TABLE_SIZE_V_MAX_ROWS(
+        "tablesizev.max-rows", "Max number of rows to extract from dbc.TableSizeV table."),
+    DISK_SPACE_V_MAX_ROWS(
+        "diskspacev.max-rows", "Max number of rows to extract from dbc.DiskSpaceV table."),
+    DATABASES_V_USERS_MAX_ROWS(
+        "databasesv.users.max-rows",
+        "Max number of user rows (rows with DBKind='U') to extract from dbc.DatabasesV table."),
+    DATABASES_V_DBS_MAX_ROWS(
+        "databasesv.dbs.max-rows",
+        "Max number of database rows (rows with DBKind='D') to extract from dbc.DatabasesV table.");
+
+    private final String name;
+    private final String description;
+
+    TeradataMetadataConnectorProperties(String name, String description) {
+      this.name = "teradata.metadata." + name;
+      this.description = description;
+    }
+
+    @Nonnull
+    public String getName() {
+      return name;
+    }
+
+    @Nonnull
+    public String getDescription() {
+      return description;
+    }
+  }
+
+  @Nonnull
+  @Override
+  public Class<? extends Enum<? extends ConnectorProperty>> getConnectorProperties() {
+    return TeradataMetadataConnectorProperties.class;
+  }
 
   public TeradataMetadataConnector() {
     super("teradata");
@@ -72,8 +91,8 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
    * QuotedIdentifiers are needed to make the queries work in PG.
    * It looks like quoted teradata identifiers are also case insensitive, so this should be ok. */
   @Override
-  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
-
+  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments)
+      throws MetadataDumperUsageException {
     String whereDatabaseNameClause =
         new SqlBuilder()
             .withWhereInVals("\"DatabaseName\"", arguments.getDatabases())
@@ -193,10 +212,13 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
   }
 
   private TeradataJdbcSelectTask createTaskForDatabasesV(
-      String whereDatabaseNameClause, ConnectorArguments arguments) {
+      String whereDatabaseNameClause, ConnectorArguments arguments)
+      throws MetadataDumperUsageException {
     StringBuilder query = new StringBuilder();
-    Optional<Long> userRows = arguments.getTeradataMaxDatabasesVUserRows();
-    Optional<Long> dbRows = arguments.getTeradataMaxDatabasesVDbRows();
+    OptionalLong userRows =
+        parseMaxRows(arguments, TeradataMetadataConnectorProperties.DATABASES_V_USERS_MAX_ROWS);
+    OptionalLong dbRows =
+        parseMaxRows(arguments, TeradataMetadataConnectorProperties.DATABASES_V_DBS_MAX_ROWS);
     query.append("SELECT %s FROM ");
     if (!userRows.isPresent() && !dbRows.isPresent()) {
       query.append(" DBC.DatabasesV ").append(whereDatabaseNameClause);
@@ -221,7 +243,8 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
   }
 
   private TeradataJdbcSelectTask createTaskForTableSizeV(
-      String whereDataBaseNameClause, ConnectorArguments arguments) {
+      String whereDataBaseNameClause, ConnectorArguments arguments)
+      throws MetadataDumperUsageException {
     StringBuilder query = new StringBuilder();
     // TableSizeV contains a row per each VProc/AMP, so it can grow significantly for large dbs.
     // Hence, we aggregate before dumping.
@@ -229,7 +252,7 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
     // https://docs.teradata.com/r/Teradata-VantageTM-Data-Dictionary/March-2019/Views-Reference/TableSizeV-X/Examples-Using-TableSizeV
     appendSelect(
         query,
-        arguments.getTeradataMaxTableSizeVRows(),
+        parseMaxRows(arguments, TeradataMetadataConnectorProperties.TABLE_SIZE_V_MAX_ROWS),
         " DataBaseName, AccountName, TableName, SUM(CurrentPerm) CurrentPerm, SUM(PeakPerm) PeakPerm FROM DBC.TableSizeV "
             + whereDataBaseNameClause
             + " GROUP BY 1,2,3 ",
@@ -240,17 +263,43 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
   }
 
   private TeradataJdbcSelectTask createTaskForDiskSpaceV(
-      String whereDataBaseNameClause, ConnectorArguments arguments) {
+      String whereDataBaseNameClause, ConnectorArguments arguments)
+      throws MetadataDumperUsageException {
     StringBuilder query = new StringBuilder();
     query.append("SELECT %s FROM (");
     appendSelect(
         query,
-        arguments.getTeradataMaxDiskSpaceVRows(),
+        parseMaxRows(arguments, TeradataMetadataConnectorProperties.DISK_SPACE_V_MAX_ROWS),
         " * FROM DBC.DiskSpaceV " + whereDataBaseNameClause,
         " ORDER BY CurrentPerm DESC ");
     query.append(") AS t;");
     return new TeradataJdbcSelectTask(
         DiskSpaceVFormat.ZIP_ENTRY_NAME, TaskCategory.OPTIONAL, formatQuery(query.toString()));
+  }
+
+  private static OptionalLong parseMaxRows(
+      ConnectorArguments arguments, TeradataMetadataConnectorProperties property)
+      throws MetadataDumperUsageException {
+    String stringValue = arguments.getDefinition(property);
+    if (StringUtils.isEmpty(stringValue)) {
+      return OptionalLong.empty();
+    }
+    long value;
+    try {
+      value = Long.parseLong(stringValue);
+    } catch (NumberFormatException ex) {
+      throw new MetadataDumperUsageException(
+          String.format(
+              "ERROR: Option '%s' accepts only positive integers. Actual: '%s'.",
+              property.name, stringValue));
+    }
+    if (value <= 0) {
+      throw new MetadataDumperUsageException(
+          String.format(
+              "ERROR: Option '%s' accepts only positive integers. Actual: '%s'.",
+              property.name, stringValue));
+    }
+    return OptionalLong.of(value);
   }
 
   private static String concatWhere(String whereClause, String condition) {
@@ -265,7 +314,7 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
   }
 
   private static void appendSelect(
-      StringBuilder query, Optional<Long> maxRowCountMaybe, String selectBody, String orderBy) {
+      StringBuilder query, OptionalLong maxRowCountMaybe, String selectBody, String orderBy) {
     query.append(" SELECT ");
     maxRowCountMaybe.ifPresent(
         maxRowCount -> query.append(" TOP ").append(maxRowCount).append(' '));


### PR DESCRIPTION
- add support for limitting max number of rows of DiskSpaceV table
- replace the old global options (`--max-tablesizev-rows` etc.) with the connector-specific options (`-Dteradata.metadata.TableSizeV.max-rows`)

New connector-specific options:
- for TableSizeV: `-Dteradata.metadata.TableSizeV.max-rows`
- for DiskSpaceV: `-Dteradata.metadata.DiskSpaceV.max-rows`
- for users in DatabasesV: `-Dteradata.metadata.DatabasesV.users.max-rows`
- for databases in DatabasesV: `-Dteradata.metadata.DatabasesV.dbs.max-rows`