### PR TITLE
Fix gradlew path in bin/dwh-migration-dumper

### DIFF
--- a/bin/dwh-migration-dumper
+++ b/bin/dwh-migration-dumper
@@ -1,10 +1,10 @@
 #!/bin/sh -ex
 
-BASE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>&1 > /dev/null && pwd)
-BIN="${BASE_DIR}/../dumper/app/build/install/app/bin/dwh-migration-dumper"
+BASE_DIR=$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>&1 > /dev/null && cd .. && pwd)
+BIN="${BASE_DIR}/dumper/app/build/install/app/bin/dwh-migration-dumper"
 
 if [ ! -x "$BIN" ] ; then
-	./gradlew --parallel :dumper:app:installDist
+  (cd "${BASE_DIR}" && ./gradlew --parallel :dumper:app:installDist)
 fi
 
 exec "$BIN" "$@"


### PR DESCRIPTION
Gradle must be executed from the main directory of the project. Thus, the script bin/dwh-migration-dumper only works if executed from this path. To allow it being run from anywhere, use a subshell to cd to the directory and execute gradlew.