### PR TITLE
Add defaults to query-log-alternates option help.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -286,7 +286,9 @@ public class ConnectorArguments extends DefaultArguments {
       parser
           .accepts(
               "query-log-alternates",
-              "pair of alternate query log tables to export (teradata-logs only)")
+              "pair of alternate query log tables to export (teradata-logs only), by default "
+                  + "logTable=dbc.DBQLogTbl and queryTable=dbc.DBQLSQLTbl, if --assessment flag"
+                  + " is enabled, then logTable=dbc.QryLogV and queryTable=dbc.DBQLSQLTbl.")
           .withRequiredArg()
           .ofType(String.class)
           .withValuesSeparatedBy(',')


### PR DESCRIPTION
The command line option `query-log-alternates` did not explain in the help output, what logTable and queryTable were. I've added the default values to make the description easier to understand.