### PR TITLE
Various improvements to first-time user documentation in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 This project contains a collection of tools related to the [BigQuery Migration
 Service](https://cloud.google.com/bigquery/docs/migration-intro).
 
-**Download the latest cross-platform release zip `dwh-migration-tools-vX.X.X.zip`
-from [the Releases page](https://github.com/google/dwh-migration-tools/releases).**
+**[Download the latest cross-platform release zip `dwh-migration-tools-vX.X.X.zip`.](https://github.com/google/dwh-migration-tools/releases/latest)**
 
 The currently available tools are:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,34 @@
 # Data Warehouse Migration Tools
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
-This project contains a collection of tools related to [BigQuery Migration Service](https://cloud.google.com/bigquery/docs/migration-intro).
+This project contains a collection of tools related to the [BigQuery Migration
+Service](https://cloud.google.com/bigquery/docs/migration-intro).
 
-The current available tools are:
-- Metadata and Log Dumper: can generate an archive containing metadata or logs for the currently supported DBMSs, for more information [read the tool documentation](https://cloud.google.com/bigquery/docs/generate-metadata).
-- Batch SQL Translation Client: command line utility to run a Batch SQL Translation job with support for macro expansion/unexpansion, for more information [read how to submit a translation job using the client](https://cloud.google.com/bigquery/docs/batch-sql-translator#submit_a_translation_job).
+**Download the latest cross-platform release zip `dwh-migration-tools-vX.X.X.zip`
+from [the Releases page](https://github.com/google/dwh-migration-tools/releases).**
+
+The currently available tools are:
+
+- **Metadata and Log Dumper:** Utility for connecting to an existing database
+and generating an archive of DDL metadata or logs for consumption by Assessment
+or the Translation Service. For more information, [read the tool
+documentation](https://cloud.google.com/bigquery/docs/generate-metadata).
+
+- **Batch SQL Translation Client:** Command line utility to run a Batch SQL
+Translation job with support for macro expansion/unexpansion. For more
+information, [read how to submit a translation job using the
+client](https://cloud.google.com/bigquery/docs/batch-sql-translator#submit_a_translation_job)
+and view the [installation instructions](client/README.md).
 
 ## Contributing
 
 Contributing instructions are available, per tool, at the following locations:
+- [Metadata and Log Dumper contribution guide](dumper/CONTRIBUTING.md)
 - [Batch SQL Translation Client contribution guide](client/CONTRIBUTING.md)
-- [Metadata and Log Dumper](dumper/CONTRIBUTING.md)
 
 ## License
 
-Copyright 2021 Google LLC
+Copyright 2023 Google LLC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/client/README.md
+++ b/client/README.md
@@ -12,10 +12,10 @@ this client][how to submit].
 
 - [Installation](#installation)
 - [Quickstart](#quickstart)
+- [config.yaml](#configyaml)
 - [Running Using `run.sh`](#running-using-runsh)
 - [Running Using `bqms-run` Directly](#running-using-bqms-run-directly)
   - [Environment Variables](#environment-variables)
-- [config.yaml](#configyaml)
 - [Metadata Lookup](#metadata-lookup)
   - [DDL and Metadata Dump](#ddl-and-metadata-dump)
   - [Unqualified References](#unqualified-references)
@@ -32,12 +32,11 @@ this client][how to submit].
 Preferred OS: Linux or macOS. Windows usage may be possible through PowerShell,
 but it is not officially supported.
 
-**Download and extract the latest release zip `dwh-migration-tools-vX.X.X.zip`
-from [the Releases page](https://github.com/google/dwh-migration-tools/releases).**
+**Download and extract [the latest release zip `dwh-migration-tools-vX.X.X.zip`](https://github.com/google/dwh-migration-tools/releases/latest).**
 
 Python &ge; 3.7.2 is required, as well as the additional local dependencies
 `pkg-config` and `libicu-dev`. Typical commands for installing these
-dependencies on Linux would be:
+dependencies on a Debian-based Linux distribution such as Ubuntu would be:
 
 ```shell
 sudo apt update
@@ -88,6 +87,37 @@ export BQMS_GCS_BUCKET="<YOUR_GCS_BUCKET>"
 
 # Run the translation.
 ./run.sh
+```
+
+## config.yaml
+
+The `config.yaml` file specifies the translation type (i.e. source and target
+dialects), translation location and default values for
+[unqualified references](#unqualified-references).
+
+The `run.sh` wrapper script looks for `config.yaml` in the `config` directory
+in which it is running. If you are using `bqms-run` directly instead, it
+requires a file path be passed as the `BQMS_CONFIG_PATH` environment variable.
+
+Example `config.yaml` file:
+
+```yaml
+# The type of translation to perform e.g. Teradata to BigQuery. Doc:
+# https://cloud.google.com/bigquery/docs/reference/migration/rest/v2/projects.locations.workflows#migrationtask
+translation_type: Translation_Teradata2BQ
+
+# The region where the translation job will run.
+location: 'us'
+
+# Default database and schemas to use when looking up unqualified references:
+
+# https://cloud.google.com/bigquery/docs/output-name-mapping#default_database
+default_database: default_db
+
+# https://cloud.google.com/bigquery/docs/output-name-mapping#default_schema
+schema_search_path:
+  - library
+  - foo
 ```
 
 ## Running Using `run.sh`
@@ -223,37 +253,6 @@ See also the instructions for [deploying to Cloud Run](#deploying-to-cloud-run).
    not set this as it is only required if GCS files are being manipulated by an
    out-of-band process which is highly discouraged.
 - `BQMS_VERBOSE`: Set to `True` to enable debug logging.
-
-## config.yaml
-
-The `config.yaml` file specifies the translation type (i.e. source and target
-dialects), translation location and default values for
-[unqualified references](#unqualified-references).
-
-The `run.sh` wrapper script looks for `config.yaml` in the `config` directory
-in which it is running. If you are using `bqms-run` directly instead, it
-requires a file path be passed as the `BQMS_CONFIG_PATH` environment variable.
-
-Example `config.yaml` file:
-
-```yaml
-# The type of translation to perform e.g. Teradata to BigQuery. Doc:
-# https://cloud.google.com/bigquery/docs/reference/migration/rest/v2/projects.locations.workflows#migrationtask
-translation_type: Translation_Teradata2BQ
-
-# The region where the translation job will run.
-location: 'us'
-
-# Default database and schemas to use when looking up unqualified references:
-
-# https://cloud.google.com/bigquery/docs/output-name-mapping#default_database
-default_database: default_db
-
-# https://cloud.google.com/bigquery/docs/output-name-mapping#default_schema
-schema_search_path:
-  - library
-  - foo
-```
 
 ## Metadata Lookup
 

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -1,0 +1,16 @@
+# BigQuery Migration Service Metadata and Log Dumper
+
+This directory contains the Metadata and Log Dumper, a command line tool for
+connecting to an existing database and generating an archive of DDL metadata or
+logs. This tool generates archives in a format suitable for consumption by the
+[BigQuery Migration Service's][BQMS] Assessment or Translation Service.
+
+The Dumper is a Java tool. **Download the latest cross-platform release zip
+`dwh-migration-tools-vX.X.X.zip` from
+[the Releases page](https://github.com/google/dwh-migration-tools/releases).**
+
+To get started using the Dumper, read
+[the documentation](https://cloud.google.com/bigquery/docs/generate-metadata).
+
+
+[BQMS]: https://cloud.google.com/bigquery/docs/migration-intro

--- a/dumper/README.md
+++ b/dumper/README.md
@@ -5,9 +5,7 @@ connecting to an existing database and generating an archive of DDL metadata or
 logs. This tool generates archives in a format suitable for consumption by the
 [BigQuery Migration Service's][BQMS] Assessment or Translation Service.
 
-The Dumper is a Java tool. **Download the latest cross-platform release zip
-`dwh-migration-tools-vX.X.X.zip` from
-[the Releases page](https://github.com/google/dwh-migration-tools/releases).**
+The Dumper is a Java tool. **[Download the latest cross-platform release zip `dwh-migration-tools-vX.X.X.zip`.](https://github.com/google/dwh-migration-tools/releases/latest)**
 
 To get started using the Dumper, read
 [the documentation](https://cloud.google.com/bigquery/docs/generate-metadata).


### PR DESCRIPTION
This PR is intended to help address several problems we've seen with first-time user experience using these tools.

- Users were sometimes confused about the relationship between the tools in this repo. This PR adds a `README.md` for the dumper, which previously did not have one, and changes some wording to help clarify that these are separate tools in one repository.
- A common issue with users trying to use the dumper is that they were trying to build it themselves from source when there is no reason to and they could just be using the binary release. This PR adds a line at the top of all three `README.md` files directing the user to download the zip from the project's Releases page.
- The documentation in `client/README.md` previously did not clearly indicate the full set of prerequisites necessary before executing the commands in the "Quickstart" section. (This PR is intended to supersede #193, which also addressed part of this.)
- The documentation in `client/README.md` previously placed the "Recommended usage" below the instructions for the not-recommended direct usage. This PR reorders the sections so they consistently go from simpler use cases to more complicated ones, and more clearly distinguishes the `run.sh` usage from the `bqms-run` usage.