### PR TITLE
Remove the bin/dwh-migration-client script, as the executable it referred to no longer exists

### DIFF
--- a/bin/dwh-migration-client
+++ b/bin/dwh-migration-client
@@ -1,3 +1,0 @@
-#!/bin/sh -ex
-
-exec dwh-migration-client "$@"

--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,6 @@ distributions {
                 exclude "**/__pycache__"
                 into "client"
             }
-            from("bin/dwh-migration-client") {
-                into "bin"
-            }
             project(":dumper:app").afterEvaluate {
                 from it.tasks.installPublishedDist
             }


### PR DESCRIPTION
[The docs on the GCP site](https://cloud.google.com/bigquery/docs/batch-sql-translator#submit_a_translation_job) and the `bin` scripts included in the release zip refer to an executable named `dwh-migration-client`, but that command doesn't exist anymore, there's only `run.sh` and `bqms-run`.

There will need to be a separate Google-internal change to update the GCP docs.

The current behavior of the client on a clean `pip install` can be confirmed using [this Dockerfile](https://gist.github.com/arotenberg-google/9286f6856d43b95465281e73da64a70a):

```shell
> whereis dwh-migration-client
dwh-migration-client:
> whereis bqms-run            
bqms-run: /usr/local/bin/bqms-run
```