### PR TITLE
Fix --database global flag help message.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -159,11 +159,10 @@ public class ConnectorArguments extends DefaultArguments {
           .ofType(String.class);
   private final OptionSpec<String> optionDatabase =
       parser
-          .accepts(OPT_DATABASE, "Database(s) to export")
+          .accepts(OPT_DATABASE, "Usage varies depending on connector.")
           .withRequiredArg()
           .ofType(String.class)
-          .withValuesSeparatedBy(',')
-          .describedAs("db0,db1,...");
+          .withValuesSeparatedBy(',');
   private final OptionSpec<String> optionSchema =
       parser
           .accepts(OPT_SCHEMA, "Schemata to export")


### PR DESCRIPTION
The `--database` command-line flag depends on the connector used. It can be a single database name or a comma-separated list of databases. Sometimes it is used for connecting to the database (e.g. Redshift connectors), sometimes it is used for extracting only specified databases (e.g. the `teradata` connector). Sometimes this flag is optional, sometimes it is required.