### PR TITLE
Support GCS as an output option

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
     implementation "com.google.cloud:google-cloud-bigquery"
+    implementation "com.google.cloud:google-cloud-nio:0.126.15"
 
     runtimeOnly "ch.qos.logback:logback-classic"
     runtimeOnly "org.slf4j:jcl-over-slf4j"

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -207,13 +207,17 @@ public class ConnectorArguments extends DefaultArguments {
   // private final OptionSpec<String> optionDatabase = parser.accepts("database", "database (can be
   // repeated; all if not
   // specified)").withRequiredArg().describedAs("my_dbname").withValuesSeparatedBy(',');
-  private final OptionSpec<File> optionOutput =
+  private final OptionSpec<String> optionOutput =
       parser
           .accepts(
               "output",
-              "Output file or directory name. If the file name, along with the `.zip` extension, is not provided dumper will attempt to create the zip file with the default file name in the directory.")
+              "Output file, directory name, or GCS path. If the file name, along with "
+                  + "the `.zip` extension, is not provided dumper will attempt to create the zip "
+                  + "file with the default file name in the directory. To use GCS, use the format "
+                  + "gs://<BUCKET>/<PATH>. This requires Google Cloud credentials. See "
+                  + "https://cloud.google.com/docs/authentication/client-libraries for details.")
           .withRequiredArg()
-          .ofType(File.class)
+          .ofType(String.class)
           .describedAs("cw-dump.zip");
   private final OptionSpec<Void> optionOutputContinue =
       parser.accepts("continue", "Continues writing a previous output file.");
@@ -641,8 +645,8 @@ public class ConnectorArguments extends DefaultArguments {
     return getOptions().valuesOf(optionConfiguration);
   }
 
-  public Optional<File> getOutputFile() {
-    return optionAsOptional(optionOutput).filter(file -> !file.getName().isEmpty());
+  public Optional<String> getOutputFile() {
+    return optionAsOptional(optionOutput).filter(file -> !Strings.isNullOrEmpty(file));
   }
 
   public boolean isOutputContinue() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper;
 
+import com.google.cloud.storage.contrib.nio.CloudStorageFileSystem;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
@@ -40,10 +41,13 @@ import com.google.edwmigration.dumper.application.dumper.task.TaskSetState.Impl;
 import com.google.edwmigration.dumper.application.dumper.task.TaskState;
 import com.google.edwmigration.dumper.application.dumper.task.VersionTask;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,6 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnegative;
@@ -76,6 +82,9 @@ public class MetadataDumper {
 
   private static final String STARS =
       "*******************************************************************";
+
+  private static final Pattern GCS_PATH_PATTERN =
+      Pattern.compile("gs://(?<bucket>[^/]+)/(?<path>.*)");
 
   private boolean exitOnError = true;
 
@@ -183,6 +192,33 @@ public class MetadataDumper {
     }
   }
 
+  private Path prepareOutputPath(
+      @Nonnull String fileName, @Nonnull Closer closer, @Nonnull ConnectorArguments arguments)
+      throws IOException {
+    Matcher matcher = GCS_PATH_PATTERN.matcher(fileName);
+    if (matcher.matches()) {
+      String bucket = matcher.group("bucket");
+      String path = matcher.group("path");
+      LOG.debug(
+          String.format(
+              "Setting up CloudStorageFileSystem with bucket '%s' and path '%s'.", bucket, path));
+      CloudStorageFileSystem cloudStorageFileSystem =
+          closer.register(CloudStorageFileSystem.forBucket(bucket));
+      return cloudStorageFileSystem.getPath(path);
+    } else {
+      Path path = Paths.get(fileName);
+      File file = path.toFile();
+      if (file.exists()) {
+        if (!arguments.isOutputContinue()) {
+          file.delete(); // It's a simple file, and we were asked to overwrite it.
+        }
+      } else {
+        Files.createParentDirs(file);
+      }
+      return path;
+    }
+  }
+
   protected void run(@Nonnull Connector connector, @Nonnull ConnectorArguments arguments)
       throws Exception {
     List<Task<?>> tasks = new ArrayList<>();
@@ -197,13 +233,13 @@ public class MetadataDumper {
     // The default output file is based on the connector.
     // We had a customer request to base it on the database, but that isn't well-defined,
     // as there may be 0 or N databases in a single file.
-    File outputFile = getOutputFile(connector, arguments);
+    String outputFileLocation = getOutputFileLocation(connector, arguments);
 
     if (arguments.isDryRun()) {
       String title = "Dry run: Printing task list for " + connector.getName();
       System.out.println(title);
       System.out.println(repeat('=', title.length()));
-      System.out.println("Writing to " + outputFile);
+      System.out.println("Writing to " + outputFileLocation);
       for (Task<?> task : tasks) {
         print(task, 1);
       }
@@ -213,15 +249,9 @@ public class MetadataDumper {
 
       LOG.info("Using " + connector);
       try (Closer closer = Closer.create()) {
+        Path outputPath = prepareOutputPath(outputFileLocation, closer, arguments);
 
-        if (outputFile.exists()) {
-          if (!arguments.isOutputContinue())
-            outputFile.delete(); // It's a simple file, and we were asked to overwrite it.
-        } else {
-          Files.createParentDirs(outputFile);
-        }
-
-        URI outputUri = URI.create("jar:" + outputFile.toURI());
+        URI outputUri = URI.create("jar:" + outputPath.toUri());
         // LOG.debug("Is a zip file: " + outputUri);
         Map<String, Object> fileSystemProperties =
             ImmutableMap.<String, Object>builder()
@@ -255,19 +285,22 @@ public class MetadataDumper {
 
       } finally {
         // We must do this in finally after the ZipFileSystem has been closed.
-        if (outputFile.isFile()) LOG.debug("Dumper wrote " + outputFile.length() + " bytes.");
+        File outputFile = new File(outputFileLocation);
+        if (outputFile.isFile()) {
+          LOG.debug("Dumper wrote " + outputFile.length() + " bytes.");
+        }
         LOG.debug("Dumper took " + stopwatch + ".");
       }
 
       printTaskResults(state);
-      printDumperSummary(connector, outputFile);
-      checkRequiredTaskSuccess(state, outputFile);
+      printDumperSummary(connector, outputFileLocation);
+      checkRequiredTaskSuccess(state, outputFileLocation);
       logStatusSummary(state);
       System.out.println(STARS);
     }
   }
 
-  private File getOutputFile(Connector connector, ConnectorArguments arguments) {
+  private String getOutputFileLocation(Connector connector, ConnectorArguments arguments) {
     // The default output file is based on the connector.
     // We had a customer request to base it on the database, but that isn't well-defined,
     // as there may be 0 or N databases in a single file.
@@ -275,30 +308,42 @@ public class MetadataDumper {
     return arguments
         .getOutputFile()
         .map(file -> getVerifiedFile(defaultFileName, file))
-        .orElseGet(() -> new File(defaultFileName));
+        .orElseGet(() -> defaultFileName);
   }
 
-  private File getVerifiedFile(String defaultFileName, File file) {
-    String fileName = file.getPath();
-    boolean isZipFile = StringUtils.endsWithIgnoreCase(fileName, ".zip");
+  private String getVerifiedFile(String defaultFileName, String fileName) {
+    Matcher gcsPathMatcher = GCS_PATH_PATTERN.matcher(fileName);
 
-    if (file.isFile() && !isZipFile) {
-      throw new IllegalStateException(
-          String.format(
-              "A file already exists at %1$s. If you want to create a directory, please"
-                  + " provide the path to the directory. If you want to create %1$s.zip,"
-                  + " please add the `.zip` extension manually.",
-              fileName));
+    if (gcsPathMatcher.matches()) {
+      LOG.debug("Got GCS target with bucket '{}'.", gcsPathMatcher.group("bucket"));
+      if (StringUtils.endsWithIgnoreCase(fileName, ".zip")) {
+        return fileName;
+      }
+      if (fileName.endsWith("/")) {
+        return fileName + defaultFileName;
+      }
+      return fileName + "/" + defaultFileName;
+    } else {
+      Path path = Paths.get(fileName);
+      boolean isZipFile =
+          StringUtils.endsWithIgnoreCase(fileName, ".zip") && !path.toFile().isDirectory();
+      if (path.toFile().isFile() && !isZipFile) {
+        throw new IllegalStateException(
+            String.format(
+                "A file already exists at %1$s. If you want to create a directory, please"
+                    + " provide the path to the directory. If you want to create %1$s.zip,"
+                    + " please add the `.zip` extension manually.",
+                fileName));
+      }
+      return isZipFile ? fileName : path.resolve(defaultFileName).toString();
     }
-
-    return file.isDirectory() || !isZipFile ? new File(file, defaultFileName) : file;
   }
 
-  private void printDumperSummary(Connector connector, File outputFile) {
+  private void printDumperSummary(Connector connector, String outputFileName) {
     if (connector instanceof MetadataConnector) {
-      log("Metadata has been saved to " + outputFile);
+      log("Metadata has been saved to " + outputFileName);
     } else if (connector instanceof LogsConnector) {
-      log("Logs have been saved to " + outputFile);
+      log("Logs have been saved to " + outputFileName);
     }
   }
 
@@ -321,7 +366,7 @@ public class MetadataDumper {
     log(lines);
   }
 
-  private void checkRequiredTaskSuccess(Impl state, File outputFile) {
+  private void checkRequiredTaskSuccess(Impl state, String outputFileName) {
     long requiredTasksNotSucceeded =
         state.getTaskResultMap().entrySet().stream()
             .filter(e -> TaskCategory.REQUIRED.equals(e.getKey().getCategory()))
@@ -330,7 +375,7 @@ public class MetadataDumper {
     if (requiredTasksNotSucceeded > 0) {
       log(
           "ERROR: " + requiredTasksNotSucceeded + " required task[s] failed.",
-          "Output, including debugging information, has been saved to " + outputFile);
+          "Output, including debugging information, has been saved to " + outputFileName);
       if (exitOnError) {
         System.out.println(STARS);
         System.exit(1);

--- a/gradle/license-allowed.json
+++ b/gradle/license-allowed.json
@@ -73,12 +73,10 @@
 			"moduleName": ".*"
 		},
 		{
-			"moduleLicense": "The Go license",
+			"moduleLicense": "Go License",
 			"notes": "This is another BSD license.",
 			"moduleName": ".*"
 		},
-
-
 		{
 			"moduleLicense": "Apache License",
 			"moduleName": "org.apache.httpcomponents:httpclient"


### PR DESCRIPTION
Support using a GCS bucket as an output target by providing an output of the form 'gs://<bucket>/<path>'.

This uses CloudStorageFileSystem to create a  instance that writs to GCS.

BUG=283484739