### PR TITLE
remove SVV_DISKUSAGE dumping for Redshift

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -146,7 +146,6 @@ public class RedshiftMetadataConnector extends AbstractRedshiftConnector
             RedshiftMetadataDumpFormat.PgUser.ZIP_ENTRY_NAME, "select * from pg_user"));
 
     if (arguments.isAssessment()) {
-      selStar(parallelTask, "SVV_DISKUSAGE");
       selStar(parallelTask, "STV_MV_INFO");
       selStar(parallelTask, "STV_WLM_SERVICE_CLASS_CONFIG");
       selStar(parallelTask, "STV_WLM_SERVICE_CLASS_STATE");


### PR DESCRIPTION
- this table can be big (60GB)
- currently it is not processed
- we can restore it when we know how to aggregate