### PR TITLE
Split out a dump runner out of MetadataDumper

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
 
 application {
     // Define the main class for the application.
-    mainClass = 'com.google.edwmigration.dumper.application.dumper.MetadataDumper'
+    mainClass = 'com.google.edwmigration.dumper.application.dumper.Main'
     applicationName = 'dwh-migration-dumper'
 }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -371,7 +371,7 @@ public class ConnectorArguments extends DefaultArguments {
   // and if not given, asked at the console.
   private String askedPassword;
 
-  public ConnectorArguments(@Nonnull String[] args) throws IOException {
+  public ConnectorArguments(@Nonnull String... args) throws IOException {
     super(args);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper;
+
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** @author miguel */
+public class Main {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Main.class);
+
+  private final MetadataDumper metadataDumper;
+
+  public Main(MetadataDumper metadataDumper) {
+    this.metadataDumper = metadataDumper;
+  }
+
+  public void run(@Nonnull String... args) throws Exception {
+    ConnectorArguments arguments = new ConnectorArguments(args);
+    try {
+      metadataDumper.run(arguments);
+    } finally {
+      if (arguments.saveResponseFile()) {
+        JsonResponseFile.save(arguments);
+      }
+    }
+  }
+
+  public static void main(String... args) throws Exception {
+    try {
+      Main main = new Main(new MetadataDumper());
+      args = JsonResponseFile.addResponseFiles(args);
+      // LOG.debug("Arguments are: [" + String.join("] [", args) + "]");
+      // Without this, the dumper prints "Missing required arguments:[connector]"
+      if (args.length == 0) {
+        args = new String[] {"--help"};
+      }
+      main.run(args);
+    } catch (MetadataDumperUsageException e) {
+      LOG.error(e.getMessage());
+      for (String msg : e.getMessages()) LOG.error(msg);
+    }
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperTest.java
@@ -34,7 +34,7 @@ public class MetadataDumperTest {
 
   // TODO(ishmum): `testOverridesZipWithGivenName` with content check
   private File file;
-  private MetadataDumper dumper = new MetadataDumper().withExitOnError(false);
+  private Main dumper = new Main(new MetadataDumper().withExitOnError(false));
   private final Connector connector = new HiveMetadataConnector();
   private final String defaultFileName = "dwh-migration-hiveql-metadata.zip";
 
@@ -47,7 +47,7 @@ public class MetadataDumperTest {
 
   @Test
   public void testInstantiate() throws Exception {
-    dumper = new MetadataDumper();
+    dumper = new Main(new MetadataDumper());
     dumper.run("--connector", new BigQueryLogsConnector().getName(), "--dry-run");
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractConnectorExecutionTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractConnectorExecutionTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Predicates;
 import com.google.common.io.ByteSource;
+import com.google.edwmigration.dumper.application.dumper.Main;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractTask;
 import com.google.edwmigration.dumper.common.io.ZipArchiveEntryByteSource;
@@ -112,7 +113,7 @@ public abstract class AbstractConnectorExecutionTest extends AbstractConnectorTe
   }
 
   public void runDumper(@Nonnull String... args) throws Exception {
-    MetadataDumper dumper = new MetadataDumper();
+    Main dumper = new Main(new MetadataDumper());
     dumper.run(args);
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -17,7 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.hive;
 
 import com.google.common.collect.Lists;
-import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
+import com.google.edwmigration.dumper.application.dumper.Main;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnectorTest;
 import com.google.edwmigration.dumper.application.dumper.connector.hive.support.HiveServerSupport;
 import com.google.edwmigration.dumper.application.dumper.connector.hive.support.HiveTestSchemaBuilder;
@@ -108,7 +108,7 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
         File tmpFile = tmpPath.toFile();
 
         try {
-          MetadataDumper.main(
+          Main.main(
               "--connector",
               "hiveql",
               "--port",

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
@@ -213,7 +213,7 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
     TeradataLogsJdbcTask.EXPRESSION_VALIDITY_QUERY = "SELECT %s FROM %s FETCH FIRST 1 ROW ONLY";
 
     MetadataDumper dumper = new MetadataDumper();
-    dumper.run(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY));
+    dumper.run(new ConnectorArguments(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY)));
 
     // TODO: Use ZipValidator to assert that all N_QUERY_LOGS entries are present.
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnectorTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.Resources;
 import com.google.common.primitives.Ints;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
 import com.google.edwmigration.dumper.application.dumper.ResourceLocation;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnectorExecutionTest;
@@ -275,13 +276,13 @@ public class TeradataMetadataConnectorTest extends AbstractConnectorExecutionTes
 
     MetadataDumper dumper = new MetadataDumper().withExitOnError(false);
 
-    dumper.run(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY));
+    dumper.run(new ConnectorArguments(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY)));
 
     CONTINUE:
     {
       // Prove that --continue is doing its thing.
       Stopwatch stopwatch = Stopwatch.createStarted();
-      dumper.run(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY));
+      dumper.run(new ConnectorArguments(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY)));
       assertTrue(
           "Second run of dumper was too slow.",
           stopwatch.elapsed(TimeUnit.SECONDS)


### PR DESCRIPTION
To prepare creating an alternative main class for the Cloud Extractor, split out the re-usable part into `DumpRunner` and call it from `MetadataDumper`.