### PR TITLE
Change default snowflake data retrieval methods.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
@@ -22,7 +22,6 @@ import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageExce
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
-import org.apache.commons.lang3.StringUtils;
 
 /** @author shevek */
 @AutoService({Connector.class, LogsConnector.class})
@@ -36,41 +35,6 @@ public class SnowflakeAccountUsageLogsConnector extends SnowflakeLogsConnector {
   @Override
   protected String newQueryFormat(ConnectorArguments arguments)
       throws MetadataDumperUsageException {
-    String overrideQuery = getOvverrideQuery(arguments);
-    if (overrideQuery != null) return overrideQuery;
-
-    String overrideWhere = getOverrideWhere(arguments);
-
-    @SuppressWarnings("OrphanedFormatString")
-    StringBuilder queryBuilder =
-        new StringBuilder(
-            "SELECT database_name, \n"
-                + "schema_name, \n"
-                + "user_name, \n"
-                + "warehouse_name, \n"
-                + "execution_status, \n"
-                + "error_code, \n"
-                + "start_time, \n"
-                + "end_time, \n"
-                + "total_elapsed_time, \n"
-                + "bytes_scanned, \n"
-                + "rows_produced, \n"
-                + "credits_used_cloud_services, \n"
-                + "query_text \n"
-                + "FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY\n"
-                + "WHERE end_time >= to_timestamp_ltz('%s')\n"
-                + "AND end_time <= to_timestamp_ltz('%s')\n");
-    // if the user specifies an earliest start time there will be extraneous empty dump files
-    // because we always iterate over the full 7 trailing days; maybe it's worth
-    // preventing that in the future. To do that, we should require getQueryLogEarliestTimestamp()
-    // to parse and return an ISO instant, not a database-server-specific format.
-    // TODO: Use ZonedIntervalIterable.forConnectorArguments()
-    if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp()))
-      queryBuilder
-          .append("AND start_time >= ")
-          .append(arguments.getQueryLogEarliestTimestamp())
-          .append("\n");
-    if (overrideWhere != null) queryBuilder.append(" AND ").append(overrideWhere);
-    return queryBuilder.toString().replace('\n', ' ');
+    return createQueryFromAccountUsage(arguments);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -17,9 +17,9 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import com.google.auto.service.AutoService;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
-import com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeMetadataConnector.TaskVariant;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
@@ -40,7 +40,8 @@ public class SnowflakeAccountUsageMetadataConnector extends SnowflakeMetadataCon
       Class<? extends Enum<?>> header,
       String format,
       TaskVariant is_task,
-      TaskVariant au_task) {
+      TaskVariant au_task,
+      ConnectorArguments arguments) {
     Task<?> t0 =
         new JdbcSelectTask(
                 au_task.zipEntryName,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
@@ -17,9 +17,12 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import com.google.auto.service.AutoService;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
+import javax.annotation.Nonnull;
 
 /** @author shevek */
 @AutoService({Connector.class, LogsConnector.class})
@@ -28,5 +31,11 @@ public class SnowflakeInformationSchemaLogsConnector extends SnowflakeLogsConnec
 
   public SnowflakeInformationSchemaLogsConnector() {
     super("snowflake-information-schema-logs");
+  }
+
+  @Override
+  protected String newQueryFormat(@Nonnull ConnectorArguments arguments)
+      throws MetadataDumperUsageException {
+    return createQueryFromInformationSchema(arguments);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import com.google.auto.service.AutoService;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
@@ -39,7 +40,8 @@ public class SnowflakeInformationSchemaMetadataConnector extends SnowflakeMetada
       Class<? extends Enum<?>> header,
       String format,
       TaskVariant is_task,
-      TaskVariant au_task) {
+      TaskVariant au_task,
+      ConnectorArguments arguments) {
     Task<?> t0 =
         new JdbcSelectTask(
                 is_task.zipEntryName,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -138,11 +138,12 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
                 String.format(format, au_task.schemaName, au_task.whereClause))
             .withHeaderClass(header);
 
-    Task<?> t0 = arguments.isAssessment() ? au_jdbcTask : is_jdbcTask;
-    Task<?> t1 = (arguments.isAssessment() ? is_jdbcTask : au_jdbcTask).onlyIfFailed(t0);
-
-    out.add(t0);
-    out.add(t1);
+    if (arguments.isAssessment()) {
+      out.add(au_jdbcTask);
+    } else {
+      out.add(is_jdbcTask);
+      out.add(au_jdbcTask.onlyIfFailed(is_jdbcTask));
+    }
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -21,9 +21,11 @@ import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
+import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat;
@@ -122,18 +124,23 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,
       @Nonnull TaskVariant is_task,
-      @Nonnull TaskVariant au_task) {
-    Task<?> t0 =
+      @Nonnull TaskVariant au_task,
+      ConnectorArguments arguments) {
+    AbstractJdbcTask<Summary> is_jdbcTask =
         new JdbcSelectTask(
                 is_task.zipEntryName,
                 String.format(format, is_task.schemaName, is_task.whereClause))
             .withHeaderClass(header);
-    Task<?> t1 =
+
+    AbstractJdbcTask<Summary> au_jdbcTask =
         new JdbcSelectTask(
                 au_task.zipEntryName,
                 String.format(format, au_task.schemaName, au_task.whereClause))
-            .withHeaderClass(header)
-            .onlyIfFailed(t0);
+            .withHeaderClass(header);
+
+    Task<?> t0 = arguments.isAssessment() ? au_jdbcTask : is_jdbcTask;
+    Task<?> t1 = (arguments.isAssessment() ? is_jdbcTask : au_jdbcTask).onlyIfFailed(t0);
+
     out.add(t0);
     out.add(t1);
   }
@@ -165,7 +172,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             SnowflakeMetadataConnectorProperties.DATABASES_OVERRIDE_WHERE),
         new TaskVariant(SnowflakeMetadataDumpFormat.DatabasesFormat.IS_ZIP_ENTRY_NAME, IS),
         new TaskVariant(
-            SnowflakeMetadataDumpFormat.DatabasesFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE));
+            SnowflakeMetadataDumpFormat.DatabasesFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
+        arguments);
 
     addSqlTasks(
         out,
@@ -176,36 +184,34 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             SnowflakeMetadataConnectorProperties.SCHEMATA_OVERRIDE_QUERY,
             SnowflakeMetadataConnectorProperties.SCHEMATA_OVERRIDE_WHERE),
         new TaskVariant(SnowflakeMetadataDumpFormat.SchemataFormat.IS_ZIP_ENTRY_NAME, IS),
-        new TaskVariant(
-            SnowflakeMetadataDumpFormat.SchemataFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE));
+        new TaskVariant(SnowflakeMetadataDumpFormat.SchemataFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
+        arguments);
 
     addSqlTasks(
         out,
         SnowflakeMetadataDumpFormat.TablesFormat.Header.class,
         getOverrideableQuery(
             arguments,
-            "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM %1$s.TABLES%2$s",
+            "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes,"
+                + " clustering_key FROM %1$s.TABLES%2$s",
             SnowflakeMetadataConnectorProperties.TABLES_OVERRIDE_QUERY,
             SnowflakeMetadataConnectorProperties.TABLES_OVERRIDE_WHERE),
         new TaskVariant(SnowflakeMetadataDumpFormat.TablesFormat.IS_ZIP_ENTRY_NAME, IS),
-        new TaskVariant(
-            SnowflakeMetadataDumpFormat.TablesFormat.AU_ZIP_ENTRY_NAME,
-            AU,
-            AU_WHERE)); // Painfully slow.
+        new TaskVariant(SnowflakeMetadataDumpFormat.TablesFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
+        arguments); // Painfully slow.
 
     addSqlTasks(
         out,
         SnowflakeMetadataDumpFormat.ColumnsFormat.Header.class,
         getOverrideableQuery(
             arguments,
-            "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type FROM %1$s.COLUMNS%2$s",
+            "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name,"
+                + " data_type FROM %1$s.COLUMNS%2$s",
             SnowflakeMetadataConnectorProperties.COLUMNS_OVERRIDE_QUERY,
             SnowflakeMetadataConnectorProperties.COLUMNS_OVERRIDE_WHERE),
         new TaskVariant(SnowflakeMetadataDumpFormat.ColumnsFormat.IS_ZIP_ENTRY_NAME, IS),
-        new TaskVariant(
-            SnowflakeMetadataDumpFormat.ColumnsFormat.AU_ZIP_ENTRY_NAME,
-            AU,
-            AU_WHERE)); // Very fast.
+        new TaskVariant(SnowflakeMetadataDumpFormat.ColumnsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
+        arguments); // Very fast.
 
     addSqlTasks(
         out,
@@ -216,19 +222,22 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             SnowflakeMetadataConnectorProperties.VIEWS_OVERRIDE_QUERY,
             SnowflakeMetadataConnectorProperties.VIEWS_OVERRIDE_WHERE),
         new TaskVariant(SnowflakeMetadataDumpFormat.ViewsFormat.IS_ZIP_ENTRY_NAME, IS),
-        new TaskVariant(SnowflakeMetadataDumpFormat.ViewsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE));
+        new TaskVariant(SnowflakeMetadataDumpFormat.ViewsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
+        arguments);
 
     addSqlTasks(
         out,
         SnowflakeMetadataDumpFormat.FunctionsFormat.Header.class,
         getOverrideableQuery(
             arguments,
-            "SELECT function_schema, function_name, data_type, argument_signature FROM %1$s.FUNCTIONS%2$s",
+            "SELECT function_schema, function_name, data_type, argument_signature FROM"
+                + " %1$s.FUNCTIONS%2$s",
             SnowflakeMetadataConnectorProperties.FUNCTIONS_OVERRIDE_QUERY,
             SnowflakeMetadataConnectorProperties.FUNCTIONS_OVERRIDE_WHERE),
         new TaskVariant(SnowflakeMetadataDumpFormat.FunctionsFormat.IS_ZIP_ENTRY_NAME, IS),
         new TaskVariant(
-            SnowflakeMetadataDumpFormat.FunctionsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE));
+            SnowflakeMetadataDumpFormat.FunctionsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
+        arguments);
   }
 
   private String getOverrideableQuery(


### PR DESCRIPTION
Depending on the `assessment` flag, the default metadata and query-logs retrieval method should change.