### PR TITLE
Enable dumping of warehouse_events_history for Snowflake

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -154,10 +154,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,
       @Nonnull TaskVariant task) {
-    out.add(new JdbcSelectTask(
-        task.zipEntryName,
-        String.format(format, task.schemaName, task.whereClause))
-        .withHeaderClass(header));
+    out.add(
+        new JdbcSelectTask(
+                task.zipEntryName, String.format(format, task.schemaName, task.whereClause))
+            .withHeaderClass(header));
   }
 
   @Override
@@ -255,7 +255,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         arguments);
 
     if (arguments.isAssessment()) {
-      addSingleSqlTask(out, SnowflakeMetadataDumpFormat.WarehouseEventsHistoryFormat.Header.class,
+      addSingleSqlTask(
+          out,
+          SnowflakeMetadataDumpFormat.WarehouseEventsHistoryFormat.Header.class,
           getOverrideableQuery(
               arguments,
               "SELECT * FROM %1$s.WAREHOUSE_EVENTS_HISTORY%2$s",

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnectorTest.java
@@ -56,7 +56,9 @@ public class SnowflakeAccountUsageMetadataConnectorTest
     validator.withEntryValidator(
         SnowflakeMetadataDumpFormat.FunctionsFormat.AU_ZIP_ENTRY_NAME,
         SnowflakeMetadataDumpFormat.FunctionsFormat.Header.class);
-
+    validator.withEntryValidator(
+        SnowflakeMetadataDumpFormat.WarehouseEventsHistoryFormat.AU_ZIP_ENTRY_NAME,
+        SnowflakeMetadataDumpFormat.WarehouseEventsHistoryFormat.Header.class);
     validator.run(outputFile);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -98,7 +98,9 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
               SnowflakeMetadataDumpFormat.FunctionsFormat.IS_ZIP_ENTRY_NAME,
               SnowflakeMetadataDumpFormat.FunctionsFormat.AU_ZIP_ENTRY_NAME),
           SnowflakeMetadataDumpFormat.FunctionsFormat.Header.class);
-
+      validator.withEntryValidator(
+          SnowflakeMetadataDumpFormat.WarehouseEventsHistoryFormat.AU_ZIP_ENTRY_NAME,
+          SnowflakeMetadataDumpFormat.WarehouseEventsHistoryFormat.Header.class);
       validator.run(outputFile);
     }
   }

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeMetadataDumpFormat.java
@@ -99,4 +99,22 @@ public interface SnowflakeMetadataDumpFormat {
       ArgumentSignature
     }
   }
+
+  interface WarehouseEventsHistoryFormat {
+
+    String AU_ZIP_ENTRY_NAME = "warehouse_events-au.csv";
+
+    enum Header {
+      Timestamp,
+      WarehouseId,
+      WarehouseName,
+      ClusterNumber,
+      EventName,
+      EventReason,
+      EventState,
+      UserName,
+      RoleName,
+      QueryId
+    }
+  }
 }


### PR DESCRIPTION
Tested manually ; sample output:
```
Timestamp,WarehouseId,WarehouseName,ClusterNumber,EventName,EventReason,EventState,UserName,RoleName,QueryId
2023-06-13 16:28:02.334,3,COMPUTE_WH,0,SUSPEND_WAREHOUSE,WAREHOUSE_AUTOSUSPEND,STARTED,,,
2023-06-13 15:57:27.169,3,COMPUTE_WH,0,RESUME_WAREHOUSE,WAREHOUSE_AUTORESUME,STARTED,,,
```