### PR TITLE
Swap the order of dumping from AU vs dumping from IS.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -35,7 +35,7 @@ public class SnowflakeAccountUsageMetadataConnector extends SnowflakeMetadataCon
   }
 
   @Override
-  protected void addSqlTasks(
+  protected void addSqlTasksWithInfoSchemaFallback(
       List<? super Task<?>> out,
       Class<? extends Enum<?>> header,
       String format,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -35,7 +35,7 @@ public class SnowflakeInformationSchemaMetadataConnector extends SnowflakeMetada
   }
 
   @Override
-  protected void addSqlTasks(
+  protected void addSqlTasksWithInfoSchemaFallback(
       List<? super Task<?>> out,
       Class<? extends Enum<?>> header,
       String format,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -119,9 +119,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
   }
 
-  /** Adds the INFORMATION_SCHEMA task, with a fallback to the ACCOUNT_USAGE task. */
+  /** Adds the ACCOUNT_USAGE task, with a fallback to the INFORMATION_SCHEMA task. */
   @ForOverride
-  protected void addSqlTasks(
+  protected void addSqlTasksWithInfoSchemaFallback(
       @Nonnull List<? super Task<?>> out,
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,
@@ -143,8 +143,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     if (arguments.isAssessment()) {
       out.add(au_jdbcTask);
     } else {
-      out.add(is_jdbcTask);
-      out.add(au_jdbcTask.onlyIfFailed(is_jdbcTask));
+      out.add(au_jdbcTask);
+      out.add(is_jdbcTask.onlyIfFailed(au_jdbcTask));
     }
   }
 
@@ -177,7 +177,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     // https://docs.snowflake.net/manuals/sql-reference/account-usage.html
     // https://docs.snowflake.net/manuals/user-guide/data-share-consumers.html
     // You must: GRANT IMPORTED PRIVILEGES ON DATABASE snowflake TO ROLE <SOMETHING>;
-    addSqlTasks(
+    addSqlTasksWithInfoSchemaFallback(
         out,
         SnowflakeMetadataDumpFormat.DatabasesFormat.Header.class,
         getOverrideableQuery(
@@ -190,7 +190,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             SnowflakeMetadataDumpFormat.DatabasesFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
         arguments);
 
-    addSqlTasks(
+    addSqlTasksWithInfoSchemaFallback(
         out,
         SnowflakeMetadataDumpFormat.SchemataFormat.Header.class,
         getOverrideableQuery(
@@ -202,7 +202,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         new TaskVariant(SnowflakeMetadataDumpFormat.SchemataFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
         arguments);
 
-    addSqlTasks(
+    addSqlTasksWithInfoSchemaFallback(
         out,
         SnowflakeMetadataDumpFormat.TablesFormat.Header.class,
         getOverrideableQuery(
@@ -215,7 +215,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         new TaskVariant(SnowflakeMetadataDumpFormat.TablesFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
         arguments); // Painfully slow.
 
-    addSqlTasks(
+    addSqlTasksWithInfoSchemaFallback(
         out,
         SnowflakeMetadataDumpFormat.ColumnsFormat.Header.class,
         getOverrideableQuery(
@@ -228,7 +228,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         new TaskVariant(SnowflakeMetadataDumpFormat.ColumnsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
         arguments); // Very fast.
 
-    addSqlTasks(
+    addSqlTasksWithInfoSchemaFallback(
         out,
         SnowflakeMetadataDumpFormat.ViewsFormat.Header.class,
         getOverrideableQuery(
@@ -240,7 +240,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         new TaskVariant(SnowflakeMetadataDumpFormat.ViewsFormat.AU_ZIP_ENTRY_NAME, AU, AU_WHERE),
         arguments);
 
-    addSqlTasks(
+    addSqlTasksWithInfoSchemaFallback(
         out,
         SnowflakeMetadataDumpFormat.FunctionsFormat.Header.class,
         getOverrideableQuery(


### PR DESCRIPTION
According to this comment https://github.com/google/dwh-migration-tools/blob/7a432471b3c1e1ef22409f375fc94d3a9824182d/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java#L175 it only makes sense that IS is the fallback of AU, not the other way around.