### PR TITLE
Expand Snowflake query history dumping fields for assessment

### DIFF
--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeLogsDumpFormat.java
@@ -28,6 +28,9 @@ public interface SnowflakeLogsDumpFormat {
     SchemaName,
     UserName,
     WarehouseName,
+    QueryId,
+    SessionId,
+    QueryType,
     ExecutionStatus,
     ErrorCode,
     StartTime,
@@ -37,6 +40,56 @@ public interface SnowflakeLogsDumpFormat {
     RowsProduced,
     CreditsUsedCloudServices,
     QueryText
+  }
+
+  interface QueryHistoryExtendedFormat {
+    String ZIP_ENTRY_PREFIX = "query_history_";
+
+    enum Header {
+      QueryId,
+      QueryText,
+      DatabaseName,
+      SchemaName,
+      QueryType,
+      SessionId,
+      UserName,
+      WarehouseName,
+      ClusterNumber,
+      QueryTag,
+      ExecutionStatus,
+      ErrorCode,
+      ErrorMessage,
+      StartTime,
+      EndTime,
+      BytesScanned,
+      PercentageScannedFromCache,
+      BytesWritten,
+      RowsProduced,
+      RowsInserted,
+      RowsUpdated,
+      RowsDeleted,
+      RowsUnloaded,
+      BytesDeleted,
+      PartitionsScanned,
+      PartitionsTotal,
+      BytesSpilledToLocalStorage,
+      BytesSpilledToRemoteStorage,
+      BytesSentOverTheNetwork,
+      TotalElapsedTime,
+      CompilationTime,
+      ExecutionTime,
+      QueuedProvisioningTime,
+      QueuedRepairTime,
+      QueuedOverloadTime,
+      TransactionBlockedTime,
+      ListExternalFilesTime,
+      CreditsUsedCloudServices,
+      QueryLoadPercent,
+      QueryAccelerationBytesScanned,
+      QueryAccelerationPartitionsScanned,
+      ChildQueriesWaitTime,
+      TransactionId,
+    }
   }
 
   interface WarehouseEventsHistoryFormat {


### PR DESCRIPTION
Add an extended query log dumping format including all useful information.

Also add several more light-weight fields for ordinary query log dumping format as these are essential information that is also available for other dialects

Also decouple assessment query log dumping from ordinary log dumping - assessment log dumping uses the extended query log format, while both AU- and IS- based ordinary dumpings use the original format.

Have built locally and tested against a live Snowflake database with and without --assessment flag.