### PR TITLE
Change Snowflake extended query log format adding "-au" suffix...

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -341,12 +341,9 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
               QueryHistoryExtendedFormat.ZIP_ENTRY_PREFIX,
               createExtendedQueryFromAccountUsage(arguments),
               QueryHistoryExtendedFormat.Header.class));
+      tasks.addAll(createTaskDescriptions(arguments));
     } else {
       tasks.add(new TaskDescription(ZIP_ENTRY_PREFIX, newQueryFormat(arguments), Header.class));
-    }
-
-    if (arguments.isAssessment()) {
-      tasks.addAll(createTaskDescriptions(arguments));
     }
 
     // (24 * 7) -> 7 trailing days == 168 hours

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeLogsDumpFormat.java
@@ -43,7 +43,7 @@ public interface SnowflakeLogsDumpFormat {
   }
 
   interface QueryHistoryExtendedFormat {
-    String ZIP_ENTRY_PREFIX = "query_history_";
+    String ZIP_ENTRY_PREFIX = "query_history-au_";
 
     enum Header {
       QueryId,


### PR DESCRIPTION
...so that it complies with the convention of other assessment-only time-series tables.

Also tidy the logic flow a little.