### PR TITLE
Implement the cloud dumper main class

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/Main.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.clouddumper;
+
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.gson.Gson;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Main {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(com.google.edwmigration.dumper.application.dumper.Main.class);
+
+  private static final Gson GSON = new Gson();
+
+  private final MetadataDumper metadataDumper;
+  private final MetadataRetriever metadataRetriever;
+
+  Main(MetadataDumper metadataDumper, MetadataRetriever metadataRetriever) {
+    this.metadataDumper = metadataDumper;
+    this.metadataRetriever = metadataRetriever;
+  }
+
+  void run() throws Exception {
+    String connectorName =
+        metadataRetriever
+            .getAttribute("dwh_connector")
+            .orElseThrow(() -> new IllegalStateException("Attribute connector is not defined."));
+    DumperConfiguration dumperConfig =
+        metadataRetriever
+            .getAttribute("dwh_extractor_configuration")
+            .map(s -> GSON.fromJson(s, DumperConfiguration.class))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        ("Attribute dwh_extractor_configuration is not defined.")));
+    ArrayList<String> args = new ArrayList<>();
+    args.add("--connector");
+    args.add(connectorName);
+    args.addAll(dumperConfig.args);
+    ConnectorArguments arguments = new ConnectorArguments(args.toArray(new String[args.size()]));
+    metadataDumper.run(arguments);
+  }
+
+  public static void main(String... args) throws Exception {
+    try {
+      new Main(new MetadataDumper(), new HttpClientMetadataRetriever(HttpClients.createDefault()))
+          .run();
+    } catch (MetadataDumperUsageException e) {
+      LOG.error(e.getMessage(), e);
+    }
+  }
+
+  static class DumperConfiguration {
+    private List<String> args;
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/MainTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/MainTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.clouddumper;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
+import java.util.Optional;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class MainTest {
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private MetadataDumper metadataDumper;
+  @Mock private MetadataRetriever metadataRetriever;
+
+  private Main underTest;
+
+  @Before
+  public void setUp() {
+    underTest = new Main(metadataDumper, metadataRetriever);
+  }
+
+  @Test
+  public void run_success() throws Exception {
+    when(metadataRetriever.getAttribute("dwh_connector")).thenReturn(Optional.of("test-db"));
+    when(metadataRetriever.getAttribute("dwh_extractor_configuration"))
+        .thenReturn(Optional.of("{\"args\": [\"--port\", \"2222\"]}"));
+
+    // Act
+    underTest.run();
+
+    // Verify
+    ArgumentCaptor<ConnectorArguments> connectorArgumentsCaptor =
+        ArgumentCaptor.forClass(ConnectorArguments.class);
+    verify(metadataDumper).run(connectorArgumentsCaptor.capture());
+    ConnectorArguments connectorArguments = connectorArgumentsCaptor.getValue();
+    assertEquals(Integer.valueOf(2222), connectorArguments.getPort());
+    assertEquals("test-db", connectorArguments.getConnectorName());
+  }
+}


### PR DESCRIPTION
The cloud dumper main class will be used to invoke the dumper from a GCE instance. It is intended to be invoked without arguments and get its configuratio from the instance metadata.

BUG=290102538