### PR TITLE
Add a run override to the dumper to pass in arguments

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
@@ -32,20 +32,12 @@ public class Main {
   }
 
   public void run(@Nonnull String... args) throws Exception {
-    ConnectorArguments arguments = new ConnectorArguments(args);
-    try {
-      metadataDumper.run(arguments);
-    } finally {
-      if (arguments.saveResponseFile()) {
-        JsonResponseFile.save(arguments);
-      }
-    }
+    metadataDumper.run(args);
   }
 
   public static void main(String... args) throws Exception {
     try {
       Main main = new Main(new MetadataDumper());
-      args = JsonResponseFile.addResponseFiles(args);
       // LOG.debug("Arguments are: [" + String.join("] [", args) + "]");
       // Without this, the dumper prints "Missing required arguments:[connector]"
       if (args.length == 0) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -94,6 +94,17 @@ public class MetadataDumper {
     return this;
   }
 
+  public void run(String... args) throws Exception {
+    ConnectorArguments arguments = new ConnectorArguments(JsonResponseFile.addResponseFiles(args));
+    try {
+      run(arguments);
+    } finally {
+      if (arguments.saveResponseFile()) {
+        JsonResponseFile.save(arguments);
+      }
+    }
+  }
+
   public void run(@Nonnull ConnectorArguments arguments) throws Exception {
     String connectorName = arguments.getConnectorName();
     if (connectorName == null) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/Main.java
@@ -19,7 +19,6 @@ package com.google.edwmigration.dumper.application.dumper.clouddumper;
 import com.google.cloud.kms.v1.CryptoKeyName;
 import com.google.cloud.kms.v1.DecryptResponse;
 import com.google.cloud.kms.v1.KeyManagementServiceClient;
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.gson.Gson;
@@ -88,8 +87,7 @@ public class Main {
                 args.add(driverPath.toString());
               });
       args.addAll(connectorConfiguration.args);
-      ConnectorArguments arguments = new ConnectorArguments(args.toArray(new String[args.size()]));
-      metadataDumperSupplier.get().run(arguments);
+      metadataDumperSupplier.get().run(args.toArray(new String[args.size()]));
     }
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/MainTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/MainTest.java
@@ -22,7 +22,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumper;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import java.util.Optional;
@@ -57,12 +56,11 @@ public class MainTest {
     underTest.run();
 
     // Verify
-    ArgumentCaptor<ConnectorArguments> connectorArgumentsCaptor =
-        ArgumentCaptor.forClass(ConnectorArguments.class);
+    ArgumentCaptor<String[]> connectorArgumentsCaptor = ArgumentCaptor.forClass(String[].class);
     verify(metadataDumper).run(connectorArgumentsCaptor.capture());
-    ConnectorArguments connectorArguments = connectorArgumentsCaptor.getValue();
-    assertEquals(Integer.valueOf(2222), connectorArguments.getPort());
-    assertEquals("test-db", connectorArguments.getConnectorName());
+    assertEquals(
+        new String[] {"--connector", "test-db", "--port", "2222"},
+        connectorArgumentsCaptor.getValue());
   }
 
   @Test
@@ -84,20 +82,18 @@ public class MainTest {
 
     // Verify
     {
-      ArgumentCaptor<ConnectorArguments> connectorArgumentsCaptor =
-          ArgumentCaptor.forClass(ConnectorArguments.class);
+      ArgumentCaptor<String[]> connectorArgumentsCaptor = ArgumentCaptor.forClass(String[].class);
       verify(metadataDumper1).run(connectorArgumentsCaptor.capture());
-      ConnectorArguments connectorArguments = connectorArgumentsCaptor.getValue();
-      assertEquals(Integer.valueOf(2222), connectorArguments.getPort());
-      assertEquals("test-db", connectorArguments.getConnectorName());
+      assertEquals(
+          new String[] {"--connector", "test-db", "--port", "2222"},
+          connectorArgumentsCaptor.getValue());
     }
     {
-      ArgumentCaptor<ConnectorArguments> connectorArgumentsCaptor =
-          ArgumentCaptor.forClass(ConnectorArguments.class);
+      ArgumentCaptor<String[]> connectorArgumentsCaptor = ArgumentCaptor.forClass(String[].class);
       verify(metadataDumper2).run(connectorArgumentsCaptor.capture());
-      ConnectorArguments connectorArguments = connectorArgumentsCaptor.getValue();
-      assertEquals(Integer.valueOf(2223), connectorArguments.getPort());
-      assertEquals("test-db-logs", connectorArguments.getConnectorName());
+      assertEquals(
+          new String[] {"--connector", "test-db-logs", "--port", "2223"},
+          connectorArgumentsCaptor.getValue());
     }
   }
 


### PR DESCRIPTION
Add a `run(String... args)` override to allow passing in arguments directly. Also add handling of JSON response files to it.

This means that the overloaded `run` method has additional behavior beyond converting argument types which is not optimal and a result of abstraction leakage in `ConnectorArguments`. However, if we want to allow passing in arguments directly, short of a larger refactor, this is a reasonable compromise.