### PR TITLE
Integrate driver retriever into cloud extractor

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -33,8 +33,13 @@ configurations {
 }
 
 def mockitoVersion = '4.11.0'
+def autoValueVersion = '1.10.2'
 
 dependencies {
+    compileOnly "com.google.auto.value:auto-value-annotations:${autoValueVersion}"
+
+    annotationProcessor "com.google.auto.value:auto-value:${autoValueVersion}"
+
     implementation project(':dumper:lib-common')
     implementation project(':dumper:lib-dumper-spi')
     implementation project(':dumper:lib-ext-bigquery')

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
     implementation "com.google.cloud:google-cloud-bigquery"
     implementation "com.google.cloud:google-cloud-nio:0.126.15"
+    implementation "com.google.cloud:google-cloud-kms:2.23.0"
     implementation "org.apache.httpcomponents.client5:httpclient5:5.2.1"
 
     runtimeOnly "ch.qos.logback:logback-classic"

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformation.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformation.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.clouddumper;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import java.net.URI;
+import java.util.Optional;
+
+@AutoValue
+public abstract class DriverInformation {
+
+  public static DriverInformation.Builder builder(String name, URI uri) {
+    return new AutoValue_DriverInformation.Builder().setName(name).setUri(uri).setAliases();
+  }
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    public abstract Builder setName(String name);
+
+    public abstract Builder setAliases(String... aliases);
+
+    public abstract Builder setUri(URI uri);
+
+    public abstract Builder setChecksum(byte[] checksum);
+
+    public abstract DriverInformation build();
+  }
+
+  public abstract String name();
+
+  public abstract ImmutableList<String> aliases();
+
+  public abstract URI uri();
+
+  public abstract Optional<byte[]> checksum();
+
+  public String getDriverFileName() {
+    String path = uri().getPath();
+    return path.substring(path.lastIndexOf('/') + 1);
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformation.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformation.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.clouddumper;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.util.Optional;
 
@@ -25,15 +24,13 @@ import java.util.Optional;
 public abstract class DriverInformation {
 
   public static DriverInformation.Builder builder(String name, URI uri) {
-    return new AutoValue_DriverInformation.Builder().setName(name).setUri(uri).setAliases();
+    return new AutoValue_DriverInformation.Builder().setName(name).setUri(uri);
   }
 
   @AutoValue.Builder
   public abstract static class Builder {
 
     public abstract Builder setName(String name);
-
-    public abstract Builder setAliases(String... aliases);
 
     public abstract Builder setUri(URI uri);
 
@@ -43,8 +40,6 @@ public abstract class DriverInformation {
   }
 
   public abstract String name();
-
-  public abstract ImmutableList<String> aliases();
 
   public abstract URI uri();
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetriever.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetriever.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.clouddumper;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.hash.HashCode;
+import com.google.common.hash.Hashing;
+import com.google.common.io.BaseEncoding;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.entity.FileEntity;
+import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Retriever for JDBC drivers. */
+public class DriverRetriever {
+
+  private static final Logger LOG = LoggerFactory.getLogger(DriverRetriever.class);
+
+  private static final BaseEncoding HEX_ENCODER = BaseEncoding.base16().lowerCase();
+
+  private final CloseableHttpClient httpClient;
+  private final Path driverPath;
+  private final ImmutableMap<String, DriverInformation> driverInformationMap;
+
+  @VisibleForTesting
+  DriverRetriever(
+      CloseableHttpClient httpClient,
+      Path driverPath,
+      ImmutableList<DriverInformation> driverInformationList) {
+    this.httpClient = httpClient;
+    this.driverPath = driverPath;
+    this.driverInformationMap =
+        driverInformationList.stream()
+            .flatMap(
+                driverInformation ->
+                    Stream.concat(
+                        Stream.of(Pair.of(driverInformation.name(), driverInformation)),
+                        driverInformation.aliases().stream()
+                            .map(alias -> Pair.of(alias, driverInformation))))
+            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+  }
+
+  public static DriverRetriever create(CloseableHttpClient httpClient, Path driverPath) {
+    ImmutableList<DriverInformation> driverInformationList;
+    try {
+      driverInformationList =
+          ImmutableList.of(
+              DriverInformation.builder(
+                      "redshift",
+                      new URI(
+                          "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.17/redshift-jdbc42-2.1.0.17.zip"))
+                  .setAliases("redshift-logs", "redshift-raw-logs")
+                  .setChecksum(
+                      HEX_ENCODER.decode(
+                          "258c2e193e1d70ef637e5a0db08256dcf68c53ace87d0627e3c81339d8d6a449"))
+                  .build(),
+              DriverInformation.builder(
+                      "bigquery",
+                      new URI(
+                          "https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip"))
+                  .setAliases("bigquery-logs")
+                  .setChecksum(
+                      HEX_ENCODER.decode(
+                          "51eb2186a167f76671546cf98f612a1e772a20c4db867d986b0b1fe7f8acfffb"))
+                  .build(),
+              DriverInformation.builder(
+                      "snowflake",
+                      new URI(
+                          "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.33/snowflake-jdbc-3.13.33.jar"))
+                  .setAliases(
+                      "snowflake-account-usage-logs",
+                      "snowflake-account-usage-metadata",
+                      "snowflake-information-schema-logs",
+                      "snowflake-information-schema-metadata",
+                      "snowflake-logs")
+                  .setChecksum(
+                      HEX_ENCODER.decode(
+                          "84f60f5c2d53f7cbc03ecb6ebf6f78b0e626f450cc7adeb49123959acc440811"))
+                  .build(),
+              DriverInformation.builder(
+                      "hive",
+                      new URI(
+                          "https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3.jar"))
+                  .setChecksum(
+                      HEX_ENCODER.decode(
+                          "f9fa451cf20598013df335e4328b9580fdec0c3fd72d7149dd2ceadb043be7c6"))
+                  .build());
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("Got unexpected exception.", e);
+    }
+    return new DriverRetriever(httpClient, driverPath, driverInformationList);
+  }
+
+  /**
+   * Gets the driver for the given database (e.g. "teradata") and returns the path to it if
+   * available.
+   */
+  public Optional<Path> getDriver(String name) throws IOException {
+    if (!driverInformationMap.containsKey(name)) {
+      LOG.info("Got no driver for connector '{}'.", name);
+      return Optional.empty();
+    }
+    DriverInformation driverInformation = driverInformationMap.get(name);
+    ClassicHttpRequest httpGet = ClassicRequestBuilder.get(driverInformation.uri()).build();
+    return httpClient.execute(
+        httpGet,
+        response -> {
+          Preconditions.checkState(
+              response.getCode() == HttpStatus.SC_OK,
+              "Failed to get driver for '%s': Got unexpected response code %s for URI '%s'.",
+              name,
+              response.getCode(),
+              driverInformation.uri());
+          Path outputPath = driverPath.resolve(driverInformation.getDriverFileName());
+          try (OutputStream output = Files.newOutputStream(outputPath)) {
+            FileEntity.writeTo(response.getEntity(), output);
+          }
+          checkChecksum(driverInformation, outputPath);
+          return Optional.of(outputPath);
+        });
+  }
+
+  private void checkChecksum(DriverInformation driverInformation, Path outputPath)
+      throws IOException {
+    if (driverInformation.checksum().isPresent()) {
+      byte[] checksum = driverInformation.checksum().get();
+      HashCode hashCode =
+          com.google.common.io.Files.asByteSource(outputPath.toFile()).hash(Hashing.sha256());
+      Preconditions.checkState(
+          Arrays.equals(checksum, hashCode.asBytes()),
+          "Retrieved driver for %s expected to have SHA256 sum '%s' but got '%s'.",
+          driverInformation.name(),
+          HEX_ENCODER.encode(checksum),
+          HEX_ENCODER.encode(hashCode.asBytes()));
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetriever.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetriever.java
@@ -18,7 +18,6 @@ package com.google.edwmigration.dumper.application.dumper.clouddumper;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
@@ -31,8 +30,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.stream.Stream;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpStatus;
@@ -56,69 +53,86 @@ public class DriverRetriever {
   DriverRetriever(
       CloseableHttpClient httpClient,
       Path driverPath,
-      ImmutableList<DriverInformation> driverInformationList) {
+      ImmutableMap<String, DriverInformation> driverInformationMap) {
     this.httpClient = httpClient;
     this.driverPath = driverPath;
-    this.driverInformationMap =
-        driverInformationList.stream()
-            .flatMap(
-                driverInformation ->
-                    Stream.concat(
-                        Stream.of(Pair.of(driverInformation.name(), driverInformation)),
-                        driverInformation.aliases().stream()
-                            .map(alias -> Pair.of(alias, driverInformation))))
-            .collect(ImmutableMap.toImmutableMap(Pair::getKey, Pair::getValue));
+    this.driverInformationMap = driverInformationMap;
+  }
+
+  static class DriverInformationMapBuilder {
+
+    private final ImmutableMap.Builder<String, DriverInformation> mapBuilder =
+        ImmutableMap.builder();
+
+    DriverInformationMapBuilder addDriver(String name, URI uri, String... aliases) {
+      addDriver(name, DriverInformation.builder(name, uri).build(), aliases);
+      return this;
+    }
+
+    DriverInformationMapBuilder addDriver(
+        String name, URI uri, byte[] checksum, String... aliases) {
+      addDriver(name, DriverInformation.builder(name, uri).setChecksum(checksum).build(), aliases);
+      return this;
+    }
+
+    DriverInformationMapBuilder addDriver(
+        String name, DriverInformation driverInformation, String... aliases) {
+      mapBuilder.put(name, driverInformation);
+      for (String alias : aliases) {
+        addDriver(alias, driverInformation);
+      }
+      return this;
+    }
+
+    ImmutableMap<String, DriverInformation> build() {
+      return mapBuilder.build();
+    }
   }
 
   public static DriverRetriever create(CloseableHttpClient httpClient, Path driverPath) {
-    ImmutableList<DriverInformation> driverInformationList;
+    ImmutableMap<String, DriverInformation> driverInformationMap;
     try {
-      driverInformationList =
-          ImmutableList.of(
-              DriverInformation.builder(
-                      "redshift",
-                      new URI(
-                          "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.17/redshift-jdbc42-2.1.0.17.zip"))
-                  .setAliases("redshift-logs", "redshift-raw-logs")
-                  .setChecksum(
-                      HEX_ENCODER.decode(
-                          "258c2e193e1d70ef637e5a0db08256dcf68c53ace87d0627e3c81339d8d6a449"))
-                  .build(),
-              DriverInformation.builder(
-                      "bigquery",
-                      new URI(
-                          "https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip"))
-                  .setAliases("bigquery-logs")
-                  .setChecksum(
-                      HEX_ENCODER.decode(
-                          "51eb2186a167f76671546cf98f612a1e772a20c4db867d986b0b1fe7f8acfffb"))
-                  .build(),
-              DriverInformation.builder(
-                      "snowflake",
-                      new URI(
-                          "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.33/snowflake-jdbc-3.13.33.jar"))
-                  .setAliases(
-                      "snowflake-account-usage-logs",
-                      "snowflake-account-usage-metadata",
-                      "snowflake-information-schema-logs",
-                      "snowflake-information-schema-metadata",
-                      "snowflake-logs")
-                  .setChecksum(
-                      HEX_ENCODER.decode(
-                          "84f60f5c2d53f7cbc03ecb6ebf6f78b0e626f450cc7adeb49123959acc440811"))
-                  .build(),
-              DriverInformation.builder(
-                      "hive",
-                      new URI(
-                          "https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3.jar"))
-                  .setChecksum(
-                      HEX_ENCODER.decode(
-                          "f9fa451cf20598013df335e4328b9580fdec0c3fd72d7149dd2ceadb043be7c6"))
-                  .build());
+      driverInformationMap =
+          new DriverInformationMapBuilder()
+              .addDriver(
+                  "redshift",
+                  new URI(
+                      "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.17/redshift-jdbc42-2.1.0.17.zip"),
+                  HEX_ENCODER.decode(
+                      "258c2e193e1d70ef637e5a0db08256dcf68c53ace87d0627e3c81339d8d6a449"),
+                  "redshift-logs",
+                  "redshift-raw-logs")
+              .addDriver(
+                  "bigquery",
+                  new URI(
+                      "https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip"),
+                  HEX_ENCODER.decode(
+                      "51eb2186a167f76671546cf98f612a1e772a20c4db867d986b0b1fe7f8acfffb"),
+                  "bigquery-logs")
+              .addDriver(
+                  "snowflake",
+                  new URI(
+                      "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.33/snowflake-jdbc-3.13.33.jar"),
+                  HEX_ENCODER.decode(
+                      "84f60f5c2d53f7cbc03ecb6ebf6f78b0e626f450cc7adeb49123959acc440811"),
+                  "snowflake-account-usage-logs",
+                  "snowflake-account-usage-metadata",
+                  "snowflake-information-schema-logs",
+                  "snowflake-information-schema-metadata",
+                  "snowflake-logs")
+              .addDriver(
+                  "hive",
+                  new URI(
+                      "https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3.jar"),
+                  HEX_ENCODER.decode(
+                      "f9fa451cf20598013df335e4328b9580fdec0c3fd72d7149dd2ceadb043be7c6"))
+              .build();
     } catch (URISyntaxException e) {
+      // This should not happen unless there is an error above which would cause a unit test to
+      // fail.
       throw new RuntimeException("Got unexpected exception.", e);
     }
-    return new DriverRetriever(httpClient, driverPath, driverInformationList);
+    return new DriverRetriever(httpClient, driverPath, driverInformationMap);
   }
 
   /**

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/Main.java
@@ -33,8 +33,10 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
-import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.util.TimeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,7 +94,12 @@ public class Main {
   }
 
   public static void main(String... args) throws Exception {
-    try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+    try (CloseableHttpClient httpClient =
+        HttpClientBuilder.create()
+            .setRetryStrategy(
+                new DefaultHttpRequestRetryStrategy(
+                    /* maxRetries= */ 3, /* defaultRetryInterval= */ TimeValue.ofSeconds(1L)))
+            .build()) {
       new Main(
               () -> new MetadataDumper(),
               new HttpClientMetadataRetriever(httpClient),

--- a/dumper/app/src/main/resources/logback.xml
+++ b/dumper/app/src/main/resources/logback.xml
@@ -11,6 +11,7 @@
 	<logger name="org.springframework.jdbc.datasource" level="info" />
 	<logger name="org.springframework" level="info"/>
 	<logger name="com.zaxxer.hikari" level="info"/>
+	<logger name="org.apache.hc.client5.http" level="info"/>
 
 	<root level="${LOG_LEVEL:-debug}">
 		<appender-ref ref="CONSOLE" />

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformationTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.clouddumper;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import org.junit.Test;
+
+public class DriverInformationTest {
+
+  @Test
+  public void getDriverFileName_rootPath_success() throws Exception {
+    assertEquals(
+        "foo.zip",
+        DriverInformation.builder("test", new URI("http://google.com/foo.zip"))
+            .build()
+            .getDriverFileName());
+  }
+
+  @Test
+  public void getDriverFileName_complexUri_success() throws Exception {
+    assertEquals(
+        "foo",
+        DriverInformation.builder("test", new URI("http://google.com/some/path/foo?q=1#bar"))
+            .build()
+            .getDriverFileName());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetrieverTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetrieverTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.clouddumper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.BaseEncoding;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.HttpStatus;
+import org.apache.hc.core5.http.io.HttpClientResponseHandler;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicClassicHttpResponse;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+@RunWith(JUnit4.class)
+public class DriverRetrieverTest {
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private CloseableHttpClient httpClient;
+
+  private Path driverOutputPath;
+  private DriverRetriever underTest;
+
+  @Before
+  public void setUp() throws Exception {
+    driverOutputPath = Files.createTempDirectory("driver-retriever-test");
+    underTest =
+        new DriverRetriever(
+            httpClient,
+            driverOutputPath,
+            ImmutableList.<DriverInformation>of(
+                DriverInformation.builder("test", new URI("http://test.google.com/my/driver.jar"))
+                    .setAliases("test_alias")
+                    .build(),
+                DriverInformation.builder(
+                        "test_with_checksum",
+                        new URI("http://test.google.com/my/checked_driver.jar"))
+                    .setChecksum(
+                        BaseEncoding.base16()
+                            .lowerCase()
+                            .decode(
+                                "202d40302f856f7f6ec75335254169c600549427e13d712de10f8029854ca99a"))
+                    .build()));
+  }
+
+  @Test
+  public void getDriver_success() throws Exception {
+    ClassicHttpResponse httpResponse = new BasicClassicHttpResponse(HttpStatus.SC_OK);
+    httpResponse.setEntity(new StringEntity("Test driver"));
+    when(httpClient.execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class)))
+        .thenAnswer(
+            invocation ->
+                ((HttpClientResponseHandler) invocation.getArguments()[1])
+                    .handleResponse(httpResponse));
+
+    // Act
+    Optional<Path> driverPath = underTest.getDriver("test");
+
+    // Verify
+    assertEquals(Optional.of(driverOutputPath.resolve("driver.jar")), driverPath);
+    assertEquals(
+        ImmutableList.of("Test driver"), Files.readAllLines(driverPath.get(), Charsets.UTF_8));
+    ArgumentCaptor<ClassicHttpRequest> requestCaptor =
+        ArgumentCaptor.forClass(ClassicHttpRequest.class);
+    verify(httpClient).execute(requestCaptor.capture(), any(HttpClientResponseHandler.class));
+    assertEquals(
+        new URI("http://test.google.com/my/driver.jar"), requestCaptor.getValue().getUri());
+  }
+
+  @Test
+  public void getDriver_aliasSuccess() throws Exception {
+    ClassicHttpResponse httpResponse = new BasicClassicHttpResponse(HttpStatus.SC_OK);
+    httpResponse.setEntity(new StringEntity("Test driver"));
+    when(httpClient.execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class)))
+        .thenAnswer(
+            invocation ->
+                ((HttpClientResponseHandler) invocation.getArguments()[1])
+                    .handleResponse(httpResponse));
+
+    // Act
+    Optional<Path> driverPath = underTest.getDriver("test_alias");
+
+    // Verify
+    assertEquals(Optional.of(driverOutputPath.resolve("driver.jar")), driverPath);
+  }
+
+  @Test
+  public void getDriver_emptyForUnknownConnector() throws Exception {
+    // Act
+    Optional<Path> driverPath = underTest.getDriver("nulldb");
+
+    // Verify
+    assertEquals(Optional.empty(), driverPath);
+  }
+
+  @Test
+  public void getDriver_successWithCorrecChecksum() throws Exception {
+    ClassicHttpResponse httpResponse = new BasicClassicHttpResponse(HttpStatus.SC_OK);
+    httpResponse.setEntity(new StringEntity("Checked test driver"));
+    when(httpClient.execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class)))
+        .thenAnswer(
+            invocation ->
+                ((HttpClientResponseHandler) invocation.getArguments()[1])
+                    .handleResponse(httpResponse));
+
+    // Act
+    Optional<Path> driverPath = underTest.getDriver("test_with_checksum");
+
+    // Verify
+    assertEquals(Optional.of(driverOutputPath.resolve("checked_driver.jar")), driverPath);
+    assertEquals(
+        ImmutableList.of("Checked test driver"),
+        Files.readAllLines(driverPath.get(), Charsets.UTF_8));
+  }
+
+  @Test
+  public void getDriver_throwsOnFailureToRetrieve() throws Exception {
+    ClassicHttpResponse httpResponse =
+        new BasicClassicHttpResponse(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+    when(httpClient.execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class)))
+        .thenAnswer(
+            invocation ->
+                ((HttpClientResponseHandler) invocation.getArguments()[1])
+                    .handleResponse(httpResponse));
+
+    // Act
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> underTest.getDriver("test"));
+
+    // Verify
+    assertTrue(
+        "Actual message: " + exception.getMessage(),
+        exception
+            .getMessage()
+            .contains("Failed to get driver for 'test': Got unexpected response code 500 for URI"));
+  }
+
+  @Test
+  public void getDriver_throwsOnChecksumMismatch() throws Exception {
+    ClassicHttpResponse httpResponse = new BasicClassicHttpResponse(HttpStatus.SC_OK);
+    httpResponse.setEntity(new StringEntity("Corrupt test driver"));
+    when(httpClient.execute(any(ClassicHttpRequest.class), any(HttpClientResponseHandler.class)))
+        .thenAnswer(
+            invocation ->
+                ((HttpClientResponseHandler) invocation.getArguments()[1])
+                    .handleResponse(httpResponse));
+
+    // Act
+    IllegalStateException exception =
+        assertThrows(IllegalStateException.class, () -> underTest.getDriver("test_with_checksum"));
+
+    // Verify
+    assertTrue(
+        "Actual message: " + exception.getMessage(),
+        exception
+            .getMessage()
+            .contains(
+                "Retrieved driver for test_with_checksum expected to have SHA256 sum "
+                    + "'202d40302f856f7f6ec75335254169c600549427e13d712de10f8029854ca99a' but got"));
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetrieverTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetrieverTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.when;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
+import com.google.edwmigration.dumper.application.dumper.clouddumper.DriverRetriever.DriverInformationMapBuilder;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,19 +65,15 @@ public class DriverRetrieverTest {
         new DriverRetriever(
             httpClient,
             driverOutputPath,
-            ImmutableList.<DriverInformation>of(
-                DriverInformation.builder("test", new URI("http://test.google.com/my/driver.jar"))
-                    .setAliases("test_alias")
-                    .build(),
-                DriverInformation.builder(
-                        "test_with_checksum",
-                        new URI("http://test.google.com/my/checked_driver.jar"))
-                    .setChecksum(
-                        BaseEncoding.base16()
-                            .lowerCase()
-                            .decode(
-                                "202d40302f856f7f6ec75335254169c600549427e13d712de10f8029854ca99a"))
-                    .build()));
+            new DriverInformationMapBuilder()
+                .addDriver("test", new URI("http://test.google.com/my/driver.jar"), "test_alias")
+                .addDriver(
+                    "test_with_checksum",
+                    new URI("http://test.google.com/my/checked_driver.jar"),
+                    BaseEncoding.base16()
+                        .lowerCase()
+                        .decode("202d40302f856f7f6ec75335254169c600549427e13d712de10f8029854ca99a"))
+                .build());
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/MainTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/MainTest.java
@@ -42,11 +42,12 @@ public class MainTest {
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
 
   @Mock private MetadataRetriever metadataRetriever;
+  @Mock private DriverRetriever driverRetriever;
 
   @Test
   public void run_successSingleConnector() throws Exception {
     MetadataDumper metadataDumper = mock(MetadataDumper.class);
-    Main underTest = new Main(() -> metadataDumper, metadataRetriever);
+    Main underTest = new Main(() -> metadataDumper, metadataRetriever, driverRetriever);
     when(metadataRetriever.getAttribute("dwh_extractor_configuration"))
         .thenReturn(
             Optional.of(
@@ -70,7 +71,7 @@ public class MainTest {
     MetadataDumper metadataDumper2 = mock(MetadataDumper.class);
     Supplier<MetadataDumper> metadataDumperSupplier = mock(Supplier.class);
     when(metadataDumperSupplier.get()).thenReturn(metadataDumper1, metadataDumper2);
-    Main underTest = new Main(metadataDumperSupplier, metadataRetriever);
+    Main underTest = new Main(metadataDumperSupplier, metadataRetriever, driverRetriever);
     when(metadataRetriever.getAttribute("dwh_extractor_configuration"))
         .thenReturn(
             Optional.of(
@@ -103,7 +104,7 @@ public class MainTest {
   @Test
   public void run_failsOnMissingConnectorConfiguration() throws Exception {
     MetadataDumper metadataDumper = mock(MetadataDumper.class);
-    Main underTest = new Main(() -> metadataDumper, metadataRetriever);
+    Main underTest = new Main(() -> metadataDumper, metadataRetriever, driverRetriever);
     when(metadataRetriever.getAttribute("dwh_extractor_configuration"))
         .thenReturn(Optional.of("{}"));
 


### PR DESCRIPTION
Integrate the JDBC `DriverRetriever` into the cloud extractor `Main`
class. If the retriever returns a `Path`, it must be propagated to
the arguments as the `--driver` parameter.

BUG=290102538