### PR TITLE
add cleanup variable

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -214,6 +214,7 @@ run locally:
 - `BQMS_MULTITHREADED`: Set to `True` to enable multithreaded
   pre/postprocessing and uploads/downloads.
 - `BQMS_VERBOSE`: Set to `True` to enable debug logging.
+- `BQMS_CLEANUP_FILES`: Set to `True` to cleanup GCS directory after transaltion.
 
 For a list of environment variables accepted by the `run.sh` script when using
 Cloud Run, see [Deploying to Cloud Run](#deploying-to-cloud-run).

--- a/client/examples/teradata/bteq/run.sh
+++ b/client/examples/teradata/bteq/run.sh
@@ -251,4 +251,10 @@ else
     fi
 fi
 
+if [[ -n "${BQMS_CLEANUP_FILES}" ]] 
+then
+    log_exec "Cleaining gs://${BQMS_GCS_BUCKET}/${BQMS_GCS_PREFIX}." \
+            "Could not clean gs://${BQMS_GCS_BUCKET}/${BQMS_GCS_PREFIX}." \
+                gsutil ${MULTITHREADED:+ -m} rm -rf "gs://${BQMS_GCS_BUCKET}/${BQMS_GCS_PREFIX}"
+fi
 log_info "Preprocessing, translation and postprocessing has completed successfully."

--- a/client/examples/teradata/sql/run.sh
+++ b/client/examples/teradata/sql/run.sh
@@ -251,4 +251,10 @@ else
     fi
 fi
 
+if [[ -n "${BQMS_CLEANUP_FILES}" ]] 
+then
+    log_exec "Cleaining gs://${BQMS_GCS_BUCKET}/${BQMS_GCS_PREFIX}." \
+            "Could not clean gs://${BQMS_GCS_BUCKET}/${BQMS_GCS_PREFIX}." \
+                gsutil ${MULTITHREADED:+ -m} rm -rf "gs://${BQMS_GCS_BUCKET}/${BQMS_GCS_PREFIX}"
+fi
 log_info "Preprocessing, translation and postprocessing has completed successfully."


### PR DESCRIPTION
run.sh after some time leaves quite a mess in a bucket. In most cases this can be safely removed as translated artifacts are downloaded. It's up to the user if they want to keep those files or remove them and that's why we should introduce variable 