### PR TITLE
Set thread pool size to 1 if --assessment flag is used.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -744,6 +744,10 @@ public class ConnectorArguments extends DefaultArguments {
 
   public int getThreadPoolSize() {
     if (isAssessment()) {
+      // Dumping in a single thread lowers the probability that the dumper will put too much
+      // pressure on the Redshift cluster, which could cause other issues. The dumper should use
+      // less memory with a single thread only, thus lowering the probability of OOM. Even though
+      // the dumping may take longer, the execution is more robust (less likely to fail).
       return 1;
     }
     return getOptions().valueOf(optionThreadPoolSize);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -334,8 +334,9 @@ public class ConnectorArguments extends DefaultArguments {
       parser
           .accepts(
               OPT_THREAD_POOL_SIZE,
-              "Set thread pool size (affects connection pool size). Defaults to "
-                  + OPT_THREAD_POOL_SIZE_DEFAULT)
+              "Set thread pool size (affects connection pool size)."
+                  + " If the --assessment flag is enabled, this option is"
+                  + " ignored and thread pool size is set to 1.")
           .withRequiredArg()
           .ofType(Integer.class)
           .defaultsTo(OPT_THREAD_POOL_SIZE_DEFAULT);
@@ -742,6 +743,9 @@ public class ConnectorArguments extends DefaultArguments {
   }
 
   public int getThreadPoolSize() {
+    if (isAssessment()) {
+      return 1;
+    }
     return getOptions().valueOf(optionThreadPoolSize);
   }
 


### PR DESCRIPTION
Using thread pool size bigger than 1 causes the dumper to fail for large databases. Reducing it to 1 if the `--assessment` flag is used should improve user experience.