### PR TITLE
Add memoization to the driver retriever

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetriever.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverRetriever.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.clouddumper;
 
+import static com.google.edwmigration.dumper.application.dumper.utils.MemoizationUtil.createMemoizer;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -25,11 +27,11 @@ import com.google.common.io.BaseEncoding;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
+import org.apache.commons.io.function.IOFunction;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpStatus;
@@ -48,6 +50,7 @@ public class DriverRetriever {
   private final CloseableHttpClient httpClient;
   private final Path driverPath;
   private final ImmutableMap<String, DriverInformation> driverInformationMap;
+  private final IOFunction<DriverInformation, Path> downloader = createMemoizer(this::download);
 
   @VisibleForTesting
   DriverRetriever(
@@ -90,48 +93,41 @@ public class DriverRetriever {
   }
 
   public static DriverRetriever create(CloseableHttpClient httpClient, Path driverPath) {
-    ImmutableMap<String, DriverInformation> driverInformationMap;
-    try {
-      driverInformationMap =
-          new DriverInformationMapBuilder()
-              .addDriver(
-                  "redshift",
-                  new URI(
-                      "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.17/redshift-jdbc42-2.1.0.17.zip"),
-                  HEX_ENCODER.decode(
-                      "258c2e193e1d70ef637e5a0db08256dcf68c53ace87d0627e3c81339d8d6a449"),
-                  "redshift-logs",
-                  "redshift-raw-logs")
-              .addDriver(
-                  "bigquery",
-                  new URI(
-                      "https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip"),
-                  HEX_ENCODER.decode(
-                      "51eb2186a167f76671546cf98f612a1e772a20c4db867d986b0b1fe7f8acfffb"),
-                  "bigquery-logs")
-              .addDriver(
-                  "snowflake",
-                  new URI(
-                      "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.33/snowflake-jdbc-3.13.33.jar"),
-                  HEX_ENCODER.decode(
-                      "84f60f5c2d53f7cbc03ecb6ebf6f78b0e626f450cc7adeb49123959acc440811"),
-                  "snowflake-account-usage-logs",
-                  "snowflake-account-usage-metadata",
-                  "snowflake-information-schema-logs",
-                  "snowflake-information-schema-metadata",
-                  "snowflake-logs")
-              .addDriver(
-                  "hive",
-                  new URI(
-                      "https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3.jar"),
-                  HEX_ENCODER.decode(
-                      "f9fa451cf20598013df335e4328b9580fdec0c3fd72d7149dd2ceadb043be7c6"))
-              .build();
-    } catch (URISyntaxException e) {
-      // This should not happen unless there is an error above which would cause a unit test to
-      // fail.
-      throw new RuntimeException("Got unexpected exception.", e);
-    }
+    ImmutableMap<String, DriverInformation> driverInformationMap =
+        new DriverInformationMapBuilder()
+            .addDriver(
+                "redshift",
+                URI.create(
+                    "https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/2.1.0.17/redshift-jdbc42-2.1.0.17.zip"),
+                HEX_ENCODER.decode(
+                    "258c2e193e1d70ef637e5a0db08256dcf68c53ace87d0627e3c81339d8d6a449"),
+                "redshift-logs",
+                "redshift-raw-logs")
+            .addDriver(
+                "bigquery",
+                URI.create(
+                    "https://storage.googleapis.com/simba-bq-release/jdbc/SimbaJDBCDriverforGoogleBigQuery42_1.3.3.1004.zip"),
+                HEX_ENCODER.decode(
+                    "51eb2186a167f76671546cf98f612a1e772a20c4db867d986b0b1fe7f8acfffb"),
+                "bigquery-logs")
+            .addDriver(
+                "snowflake",
+                URI.create(
+                    "https://repo1.maven.org/maven2/net/snowflake/snowflake-jdbc/3.13.33/snowflake-jdbc-3.13.33.jar"),
+                HEX_ENCODER.decode(
+                    "84f60f5c2d53f7cbc03ecb6ebf6f78b0e626f450cc7adeb49123959acc440811"),
+                "snowflake-account-usage-logs",
+                "snowflake-account-usage-metadata",
+                "snowflake-information-schema-logs",
+                "snowflake-information-schema-metadata",
+                "snowflake-logs")
+            .addDriver(
+                "hive",
+                URI.create(
+                    "https://repo1.maven.org/maven2/org/apache/hive/hive-jdbc/3.1.3/hive-jdbc-3.1.3.jar"),
+                HEX_ENCODER.decode(
+                    "f9fa451cf20598013df335e4328b9580fdec0c3fd72d7149dd2ceadb043be7c6"))
+            .build();
     return new DriverRetriever(httpClient, driverPath, driverInformationMap);
   }
 
@@ -144,7 +140,10 @@ public class DriverRetriever {
       LOG.info("Got no driver for connector '{}'.", name);
       return Optional.empty();
     }
-    DriverInformation driverInformation = driverInformationMap.get(name);
+    return Optional.of(this.downloader.apply(driverInformationMap.get(name)));
+  }
+
+  private Path download(DriverInformation driverInformation) throws IOException {
     ClassicHttpRequest httpGet = ClassicRequestBuilder.get(driverInformation.uri()).build();
     return httpClient.execute(
         httpGet,
@@ -152,7 +151,7 @@ public class DriverRetriever {
           Preconditions.checkState(
               response.getCode() == HttpStatus.SC_OK,
               "Failed to get driver for '%s': Got unexpected response code %s for URI '%s'.",
-              name,
+              driverInformation.name(),
               response.getCode(),
               driverInformation.uri());
           Path outputPath = driverPath.resolve(driverInformation.getDriverFileName());
@@ -160,11 +159,11 @@ public class DriverRetriever {
             FileEntity.writeTo(response.getEntity(), output);
           }
           checkChecksum(driverInformation, outputPath);
-          return Optional.of(outputPath);
+          return outputPath;
         });
   }
 
-  private void checkChecksum(DriverInformation driverInformation, Path outputPath)
+  private static void checkChecksum(DriverInformation driverInformation, Path outputPath)
       throws IOException {
     if (driverInformation.checksum().isPresent()) {
       byte[] checksum = driverInformation.checksum().get();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/MemoizationUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/MemoizationUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.utils;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.io.function.IOFunction;
+
+/** Utility class for memoization. */
+public class MemoizationUtil {
+
+  private static class Memoizer<T, R> implements IOFunction<T, R> {
+
+    private final IOFunction<T, R> delegate;
+    private final Map<T, R> cache = new HashMap<>();
+
+    public Memoizer(IOFunction<T, R> delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public R apply(T t) throws IOException {
+      if (cache.containsKey(t)) {
+        return cache.get(t);
+      }
+      R result = delegate.apply(t);
+      cache.put(t, result);
+      return result;
+    }
+  }
+
+  /**
+   * Creates a memoizer that stores results in a map using the key created by the key function. When
+   * called with a value v, the map is checked if there already is an entry for keyFunction(v). If
+   * so, the corresponding value is returned. Otherwise, the delegate is called and the result is
+   * stored.
+   */
+  public static <T, R> IOFunction<T, R> createMemoizer(IOFunction<T, R> delegate) {
+    return new Memoizer<>(delegate);
+  }
+
+  private MemoizationUtil() {}
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/util/MemoizationUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/util/MemoizationUtilTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import com.google.edwmigration.dumper.application.dumper.utils.MemoizationUtil;
+import java.io.IOException;
+import org.apache.commons.io.function.IOFunction;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class MemoizationUtilTest {
+
+  @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();
+
+  @Mock private IOFunction<String, Integer> delegateIoFunction;
+
+  @Test
+  public void memoization_success() throws Exception {
+    when(delegateIoFunction.apply("input")).thenReturn(42);
+    IOFunction<String, Integer> underTest = MemoizationUtil.createMemoizer(delegateIoFunction);
+
+    // Act
+    Integer result1 = underTest.apply("input");
+    Integer result2 = underTest.apply("input");
+
+    // Verify
+    assertEquals(Integer.valueOf(42), result1);
+    assertEquals(Integer.valueOf(42), result2);
+    verify(delegateIoFunction).apply("input");
+    verifyNoMoreInteractions(delegateIoFunction);
+  }
+
+  @Test
+  public void memoization_ioExceptionGetsPropagated() throws Exception {
+    when(delegateIoFunction.apply("input")).thenThrow(new IOException("test IO error"));
+    IOFunction<String, Integer> underTest = MemoizationUtil.createMemoizer(delegateIoFunction);
+
+    // Act
+    IOException exception = assertThrows(IOException.class, () -> underTest.apply("input"));
+
+    // Verify
+    assertEquals(exception.getMessage(), "test IO error");
+  }
+
+  @Test
+  public void memoization_runtimeExceptionGetsPropagated() throws Exception {
+    when(delegateIoFunction.apply("input"))
+        .thenThrow(new IllegalStateException("test illegal state error"));
+    IOFunction<String, Integer> underTest = MemoizationUtil.createMemoizer(delegateIoFunction);
+
+    // Act
+    RuntimeException exception =
+        assertThrows(RuntimeException.class, () -> underTest.apply("input"));
+
+    // Verify
+    assertEquals(exception.getMessage(), "test illegal state error");
+    assertEquals(exception.getClass(), IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
The cloud extractor can do multiple dumps and will likely require the same driver for all runs (e.g. metadata and logs for the same DB). Thus, the driver for it only needs to be downloaded once.