### PR TITLE
Use a simplified classpath that uses a glob

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -93,6 +93,10 @@ dependencies {
     sources "ch.qos.logback:logback-classic:1.2.11@sources"
 }
 
+startScripts {
+    classpath = files( '$APP_HOME/lib/*' )
+}
+
 application {
     // Define the main class for the application.
     mainClass = 'com.google.edwmigration.dumper.application.dumper.Main'


### PR DESCRIPTION
The generated scripts (Windows and Unix) list each JAR individually. This creates a very classpath which is fine under Unix but generates an input line that is too long for Windows. This is discussed in https://gist.github.com/jlmelville/2bfe9277e9e2c0ff79b6

This change applies the workaround to use a wildcard (`${APP_HOME}/lib/*`). This feature was introduced in Java 6: https://docs.oracle.com/javase/6/docs/technotes/tools/windows/classpath.html

BUG=284024465