### PR TITLE
Fix dumping temp tables.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -116,7 +116,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
     // Most likely caused by some operation (equality?) being performed on a datum which is too long
     // for a varchar.
     ZonedIntervalIterable intervals = ZonedIntervalIterable.forConnectorArguments(arguments);
-    LOG.info("Exporting query log for " + intervals);
+    LOG.info("Exporting query logs for '{}'", intervals);
     SharedState queryLogsState = new SharedState();
     SharedState utilityLogsState = new SharedState();
     for (ZonedInterval interval : intervals) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.formatQuery;
+import static java.util.stream.Collectors.toList;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -103,7 +104,9 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
             .toWhereClause();
     String whereBDatabaseNameClause =
         new SqlBuilder()
-            .withWhereInVals("\"B_DatabaseName\"", arguments.getDatabases())
+            .withWhereInVals(
+                "\"B_DatabaseName\"",
+                arguments.getDatabases().stream().map(String::toUpperCase).collect(toList()))
             .toWhereClause();
     String whereChildDBClause =
         new SqlBuilder().withWhereInVals("\"ChildDB\"", arguments.getDatabases()).toWhereClause();


### PR DESCRIPTION
The `AllTempTablesVX` view contains the database name in upper-case.