### PR TITLE
Add support for LogDate column (teradata-logs)

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -868,6 +868,7 @@ public class ConnectorArguments extends DefaultArguments {
     return toStringHelper.toString();
   }
 
+  @CheckForNull
   public String getDefinitionOrDefault(TeradataLogsConnectorProperty property) {
     String stringValue = getDefinition(property);
     if (StringUtils.isEmpty(stringValue)) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
@@ -22,6 +22,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
 import java.util.List;
 import java.util.function.Predicate;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
@@ -160,8 +161,9 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
       String queryTable,
       List<String> conditions,
       ZonedInterval interval,
+      @CheckForNull String logDateColumn,
       List<String> orderBy) {
-    super(targetPath, state, logTable, queryTable, conditions, interval, orderBy);
+    super(targetPath, state, logTable, queryTable, conditions, interval, logDateColumn, orderBy);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -63,7 +63,12 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
     UTILITY_LOGS_TABLE(
         "utility-logs-table",
         "The name of the table to dump utility logs from.",
-        "dbc.DBQLUtilityTbl");
+        "dbc.DBQLUtilityTbl"),
+    LOG_DATE_COLUMN(
+        "log-date-column",
+        "The name of the column of type DATE to include in the WHERE clause when dumping"
+            + " query log tables (see --query-log-alternates for query log table names).",
+        /* defaultValue= */ null);
 
     private final String name;
     private final String description;
@@ -85,7 +90,6 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
       return description;
     }
 
-    @Nonnull
     public String getDefaultValue() {
       return defaultValue;
     }
@@ -158,13 +162,21 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
     SharedState utilityLogsState = new SharedState();
     String utilityLogsTable =
         arguments.getDefinitionOrDefault(TeradataLogsConnectorProperty.UTILITY_LOGS_TABLE);
+    String logDateColumn = arguments.getDefinition(TeradataLogsConnectorProperty.LOG_DATE_COLUMN);
     for (ZonedInterval interval : intervals) {
       String file = createFilename(ZIP_ENTRY_PREFIX, interval);
       if (isAssessment) {
         List<String> orderBy = Arrays.asList("ST.QueryID", "ST.SQLRowNo");
         out.add(
             new TeradataAssessmentLogsJdbcTask(
-                    file, queryLogsState, logTable, queryTable, conditions, interval, orderBy)
+                    file,
+                    queryLogsState,
+                    logTable,
+                    queryTable,
+                    conditions,
+                    interval,
+                    logDateColumn,
+                    orderBy)
                 .withHeaderClass(HeaderForAssessment.class));
         out.addAll(createTimeSeriesTasks(interval));
         out.add(


### PR DESCRIPTION
If the historic Teradata query logs tables are partitioned by the column of type DATE, the dumper used inefficient WHERE clause that didn't take advantage of the partitioning column. This change adds the possibility to partition by the user-specified column.