### PR TITLE
Bring in runtime dependencies for redshift

### DIFF
--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     constraints {
         // Define dependency versions as constraints
-        def guavaVersion =  '31.1-jre'
+        def guavaVersion = '31.1-jre'
         implementation "com.google.guava:guava:$guavaVersion"
         testFixturesImplementation "com.google.guava:guava:$guavaVersion"
         def jacksonVersion = '2.14.2'
@@ -78,7 +78,8 @@ dependencies {
 
         runtimeOnly "org.postgresql:postgresql:42.5.4"
         runtimeOnly "net.snowflake:snowflake-jdbc:3.13.20"
-        runtimeOnly "com.amazon.redshift:redshift-jdbc42:2.1.0.8"
+        runtimeOnly "com.amazon.redshift:redshift-jdbc42:2.1.0.18"
+        runtimeOnly "com.amazonaws:aws-java-sdk-redshift:1.12.520"
 
         testFixturesApi "org.apache.commons:commons-compress:1.18"
         testFixturesApi "commons-io:commons-io:2.11.0"
@@ -142,7 +143,7 @@ tasks.named('test') {
             else if (k.equals("test.parameter"))
                 systemProperty k, v
             else if (k.equals("test.verbose"))
-                    systemProperty k, v
+                systemProperty k, v
         }
     }
     if (Boolean.getBoolean('test.debug'))

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     runtimeOnly "org.postgresql:postgresql"
     runtimeOnly "net.snowflake:snowflake-jdbc"
     runtimeOnly "com.amazon.redshift:redshift-jdbc42"
+    runtimeOnly "com.amazonaws:aws-java-sdk-redshift"
 
     testFixturesApi testFixtures(project(':dumper:lib-common'))
 
@@ -94,7 +95,7 @@ dependencies {
 }
 
 startScripts {
-    classpath = files( '$APP_HOME/lib/*' )
+    classpath = files('$APP_HOME/lib/*')
 }
 
 application {
@@ -131,8 +132,8 @@ tasks.register('generateSourceMirror', Copy) {
     from {
         dependencies.createArtifactResolutionQuery()
             .forComponents(
-                 configurations.runtimeClasspath.incoming.resolutionResult
-                     .allDependencies.collect { it.selected.id }
+                configurations.runtimeClasspath.incoming.resolutionResult
+                    .allDependencies.collect { it.selected.id }
             )
             .withArtifacts(JvmLibrary, SourcesArtifact)
             .execute()
@@ -161,7 +162,7 @@ distributions {
         distributionBaseName = "dwh-migration-dumper"
         contents {
             from installDist
-            from (cloudExtractorStartScripts) {
+            from(cloudExtractorStartScripts) {
                 into "bin"
             }
             from(generateLicenseReport) {


### PR DESCRIPTION
Bring in explicit runtime dependencies for redshift needed for IAM credentials access. Without them, using `iam-accesskeyid` / `iam-secretaccesskey` instead of `password` fails with `ClassNotFoundException`s.

BUG=294435345