### PR TITLE
Ensure licenses are retrieved from POM/manifest

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,4 +11,6 @@ repositories {
 dependencies {
     implementation "com.diffplug.spotless:spotless-plugin-gradle:6.4.1"
     implementation "com.netflix.nebula:gradle-info-plugin:8.0.0"
+    implementation "com.github.jk1:gradle-license-report:1.17"
+    implementation "org.apache.commons:commons-csv:1.10.0"
 }

--- a/buildSrc/src/main/groovy/com/google/edwmigration/dumper/build/licensereport/CsvReportRenderer.groovy
+++ b/buildSrc/src/main/groovy/com/google/edwmigration/dumper/build/licensereport/CsvReportRenderer.groovy
@@ -1,0 +1,76 @@
+package com.google.edwmigration.dumper.build.licensereport
+
+import static com.github.jk1.license.render.LicenseDataCollector.singleModuleLicenseInfo
+
+import org.gradle.api.tasks.Input
+import com.github.jk1.license.License
+import com.github.jk1.license.LicenseReportExtension
+import com.github.jk1.license.ModuleData
+import com.github.jk1.license.ProjectData
+import com.github.jk1.license.render.ReportRenderer
+import org.apache.commons.csv.CSVPrinter
+import org.apache.commons.csv.CSVFormat
+
+import java.util.stream.Collectors
+
+/**
+ * Custom CSV reporter that gets the license from the POM or the manifest but
+ * does not try to deduce it from a LICENSE file.
+ *
+ * Project overrides can be provided for example to provide license URLs for
+ * projects where the license is not declared in a POM or manifest.
+ **/
+class CsvReportRenderer implements ReportRenderer {
+    String[] header = ["artifact", "project url", "module license", "module license url"]
+    CSVFormat csvFormat = CSVFormat.EXCEL.builder().setHeader(header).build()
+
+    @Input
+    String filename
+    @Input
+    /** Custom CSV reporter that gets the license from the POM or the manifest but does not try to deduce it from a LICENSE file. */
+    Map<String, Map<String, String>> projectInfoOverrides
+
+    CsvReportRenderer(String filename = 'licenses.csv', Map<String, Map<String, String>> projectInfoOverrides) {
+        this.filename = filename
+        this.projectInfoOverrides = projectInfoOverrides
+    }
+
+    @Override
+    void render(ProjectData projectData) {
+        List<Map<String, ?>> records = projectData.allDependencies.sort().stream().map {
+            String project = "${it.group}:${it.name}"
+            String artifact = "${it.group}:${it.name}:${it.version}"
+            Map<String, String> projectInfoOverride = projectInfoOverrides.getOrDefault(project, [:])
+            License license = getLicense(it)
+            String projectUrl = it.poms.find { it.projectUrl }?.projectUrl
+            [
+                artifact            : artifact,
+                "project url"       : projectInfoOverride.getOrDefault("projectUrl", projectUrl),
+                "module license"    : projectInfoOverride.getOrDefault("licenseName", license?.name),
+                "module license url": projectInfoOverride.getOrDefault("licenseUrl", license?.url),
+            ]
+        }.collect(Collectors.toList())
+
+        LicenseReportExtension config = projectData.project.licenseReport
+        FileWriter writer = new FileWriter(new File(config.outputDir, filename))
+        CSVPrinter csv = new CSVPrinter(writer, csvFormat)
+        try {
+            csv.printRecords(records.stream().map { record -> header.collect { record[it] } })
+        } finally {
+            csv.close()
+        }
+    }
+
+    License getLicense(ModuleData moduleData) {
+        License license = moduleData.poms.collectMany { it.licenses }.find()
+        if (license) {
+            return license
+        }
+        String licenseName = moduleData.manifests.find { it.license }?.license
+        String licenseUrl = moduleData.manifests.find { it.licenseUrl }?.licenseUrl
+        if (licenseName || licenseUrl) {
+            return new License(name: licenseName, url: licenseUrl)
+        }
+        return null
+    }
+}

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -117,8 +117,14 @@ licenseReport {
         new com.github.jk1.license.filter.LicenseBundleNormalizer(bundlePath: rootProject.file("gradle/license-bundle-normalizer.json"), createDefaultTransformationRules: true)
     ]
     renderers = [
-        // new com.github.jk1.license.render.XmlReportRenderer("licenses.xml", "Licenses of Third Party Dependencies"),
-        new com.github.jk1.license.render.CsvReportRenderer(),
+        new com.google.edwmigration.dumper.build.licensereport.CsvReportRenderer("licenses.csv", [
+            "com.fasterxml.jackson:jackson-bom": [
+                projectUrl: "https://github.com/FasterXML/jackson-bom",
+                licenseName: "Apache License, Version 2.0",
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-bom/2.16/LICENSE",
+            ],
+        ]),
+        new com.github.jk1.license.render.JsonReportRenderer('index.json', false),
         new com.github.jk1.license.render.InventoryHtmlReportRenderer("index.html", "Licenses of Third Party Dependencies")
     ]
     allowedLicensesFile = rootProject.file("gradle/license-allowed.json")


### PR DESCRIPTION
The CSV license report renderer from the JK1 license plugin collects licenses for a project in a list in the following order:

1. License information from the POM files.
2. License information from manifest files.
3. Deducing the license by looking at the contents of license files.

It then uses the last entry from that list. If there is license information from a POM or metadata file, we should rather use that. The custom CSV reporter in the commit uses the first license information that it finds using the step 1 and 2, but not 3 as in that case we should rather make sure we provide the URL to the license file in the corresponding source repository.

Furthermore, it allows overriding license information for a project.