### PR TITLE
Add license information

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -118,10 +118,420 @@ licenseReport {
     ]
     renderers = [
         new com.google.edwmigration.dumper.build.licensereport.CsvReportRenderer("licenses.csv", [
+            "ch.qos.logback:logback-classic": [
+                projectUrl: "https://github.com/qos-ch/logback",
+                licenseUrl: "https://raw.githubusercontent.com/qos-ch/logback/master/LICENSE.txt",
+            ],
+            "ch.qos.logback:logback-core": [
+                projectUrl: "https://github.com/qos-ch/logback",
+                licenseUrl: "https://raw.githubusercontent.com/qos-ch/logback/master/LICENSE.txt",
+            ],
+            "com.amazon.redshift:redshift-jdbc42": [
+                licenseUrl: "https://raw.githubusercontent.com/aws/amazon-redshift-jdbc-driver/master/LICENSE",
+            ],
+            "com.amazonaws:aws-java-sdk-core": [
+                licenseUrl: "https://raw.githubusercontent.com/aws/aws-sdk-java/master/LICENSE.txt",
+            ],
+            "com.amazonaws:aws-java-sdk-redshift": [
+                licenseUrl: "https://raw.githubusercontent.com/aws/aws-sdk-java/master/LICENSE.txt",
+            ],
+            "com.amazonaws:jmespath-java": [
+                licenseUrl: "https://raw.githubusercontent.com/aws/aws-sdk-java/master/LICENSE.txt",
+            ],
             "com.fasterxml.jackson:jackson-bom": [
                 projectUrl: "https://github.com/FasterXML/jackson-bom",
                 licenseName: "Apache License, Version 2.0",
                 licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-bom/2.16/LICENSE",
+            ],
+            "com.fasterxml.jackson.core:jackson-annotations": [
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-core/2.16/LICENSE",
+            ],
+            "com.fasterxml.jackson.core:jackson-core": [
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-core/2.16/LICENSE",
+            ],
+            "com.fasterxml.jackson.core:jackson-databind": [
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-dataformats-binary/2.16/LICENSE",
+            ],
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-cbor": [
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-dataformats-binary/2.16/LICENSE",
+            ],
+            "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml": [
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-dataformats-text/2.16/LICENSE",
+            ],
+            "com.fasterxml.jackson.datatype:jackson-datatype-jsr310": [
+                projectUrl: "https://github.com/FasterXML/jackson-modules-java8",
+                licenseUrl: "https://raw.githubusercontent.com/FasterXML/jackson-modules-java8/2.16/LICENSE",
+            ],
+            "com.github.stephenc.jcip:jcip-annotations": [
+                projectUrl: "https://github.com/stephenc/jcip-annotations",
+                licenseUrl: "https://raw.githubusercontent.com/stephenc/jcip-annotations/master/LICENSE.txt,"
+            ],
+            "com.google.android:annotations": [
+                licenseUrl: "https://raw.githubusercontent.com/androidannotations/androidannotations/develop/LICENSE.txt",
+            ],
+            "com.google.api:api-common": [
+                projectUrl: "https://github.com/googleapis/api-common-java",
+                licenseName: "The 3-Clause BSD License",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/api-common-java/main/LICENSE",
+            ],
+            "com.google.api:gax": [
+                projectUrl: "https://github.com/googleapis/gax-java",
+                licenseName: "The 3-Clause BSD License",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/gax-java/main/LICENSE",
+            ],
+            "com.google.api:gax-grpc": [
+                projectUrl: "https://github.com/googleapis/gax-java",
+                licenseName: "The 3-Clause BSD License",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/gax-java/main/LICENSE",
+            ],
+            "com.google.api:gax-httpjson": [
+                projectUrl: "https://github.com/googleapis/gax-java",
+                licenseName: "The 3-Clause BSD License",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/gax-java/main/LICENSE",
+            ],
+            "com.google.api-client:google-api-client": [
+                projectUrl: "https://github.com/googleapis/google-api-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-api-java-client/main/LICENSE",
+            ],
+            "com.google.api.grpc:gapic-google-cloud-storage-v2": [
+                projectUrl: "https://github.com/googleapis/googleapis",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/googleapis/master/LICENSE",
+            ],
+            "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1": [
+                licenseUrl: "https://raw.githubusercontent.com/google/flatbuffers/master/LICENSE",
+            ],
+            "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1beta1": [
+                licenseUrl: "https://raw.githubusercontent.com/google/flatbuffers/master/LICENSE",
+            ],
+            "com.google.api.grpc:grpc-google-cloud-bigquerystorage-v1beta2": [
+                licenseUrl: "https://raw.githubusercontent.com/google/flatbuffers/master/LICENSE",
+            ],
+            "com.google.api.grpc:grpc-google-cloud-storage-v2": [
+                projectUrl: "https://github.com/googleapis/java-storage",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-storage/main/LICENSE",
+            ],
+            "com.google.api.grpc:grpc-google-common-protos": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/sdk-platform-java/main/LICENSE",
+            ],
+            "com.google.api.grpc:grpc-google-iam-v1": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/sdk-platform-java/main/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1": [
+                projectUrl: "https://github.com/googleapis/googleapis",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/googleapis/master/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta1": [
+                projectUrl: "https://github.com/googleapis/googleapis",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/googleapis/master/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-cloud-bigquerystorage-v1beta2": [
+                projectUrl: "https://github.com/googleapis/googleapis",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/googleapis/master/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-cloud-kms-v1": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-cloud-java/main/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-cloud-storage-v2": [
+                projectUrl: "https://github.com/googleapis/googleapis",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/googleapis/master/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-common-protos": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/sdk-platform-java/main/LICENSE",
+            ],
+            "com.google.api.grpc:proto-google-iam-v1": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/sdk-platform-java/main/LICENSE",
+            ],
+            "com.google.apis:google-api-services-bigquery": [
+                projectUrl: "https://github.com/googleapis/java-bigquery",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-bigquery/main/LICENSE",
+            ],
+            "com.google.apis:google-api-services-storage": [
+                projectUrl: "https://github.com/googleapis/google-api-java-client-services",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-api-java-client-services/main/LICENSE",
+            ],
+            "com.google.auth:google-auth-library-credentials": [
+                projectUrl: "https://github.com/googleapis/google-auth-library-java",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-auth-library-java/main/LICENSE",
+            ],
+            "com.google.auth:google-auth-library-oauth2-http": [
+                projectUrl: "https://github.com/googleapis/google-auth-library-java",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-auth-library-java/main/LICENSE",
+            ],
+            "com.google.auto.value:auto-value": [
+                licenseUrl: "https://raw.githubusercontent.com/google/auto/main/LICENSE",
+            ],
+            "com.google.auto.value:auto-value-annotations": [
+                licenseUrl: "https://raw.githubusercontent.com/google/auto/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-bigquery": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-bigquery/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-bigquerystorage": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-bigquerystorage/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-core": [
+                projectUrl: "https://github.com/googleapis/java-core",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-core/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-core-grpc": [
+                projectUrl: "https://github.com/googleapis/java-core",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-core/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-core-http": [
+                projectUrl: "https://github.com/googleapis/java-core",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-core/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-kms": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-cloud-java/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-nio": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-storage-nio/main/LICENSE",
+            ],
+            "com.google.cloud:google-cloud-storage": [
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/java-storage/main/LICENSE",
+            ],
+            "com.google.code.findbugs:jsr305": [
+                projectUrl: "http://code.google.com/p/jsr-305/",
+                licenseName: "The 3-Clause BSD License",
+                licenseUrl: "https://raw.githubusercontent.com/findbugsproject/findbugs/master/findbugs/licenses/LICENSE-jsr305.txt",
+            ],
+            "com.google.code.gson:gson": [
+                projectUrl: "https://github.com/google/gson",
+                licenseUrl: "https://raw.githubusercontent.com/google/gson/main/LICENSE",
+            ],
+            "com.google.errorprone:error_prone_annotations": [
+                projectUrl: "https://github.com/google/error-prone",
+            ],
+            "com.google.flatbuffers:flatbuffers-java": [
+                licenseUrl: "https://raw.githubusercontent.com/google/flatbuffers/master/LICENSE",
+            ],
+            "com.google.guava:failureaccess": [
+                projectUrl: "https://github.com/google/guava",
+                licenseUrl: "https://raw.githubusercontent.com/google/guava/master/LICENSE",
+            ],
+            "com.google.guava:guava": [
+                licenseUrl: "https://raw.githubusercontent.com/google/guava/master/LICENSE",
+            ],
+            "com.google.guava:listenablefuture": [
+                projectUrl: "https://github.com/google/guava",
+                licenseUrl: "https://raw.githubusercontent.com/google/guava/master/LICENSE",
+            ],
+            "com.google.http-client:google-http-client": [
+                projectUrl: "https://github.com/googleapis/google-http-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-http-java-client/main/LICENSE",
+            ],
+            "com.google.http-client:google-http-client-apache-v2": [
+                projectUrl: "https://github.com/googleapis/google-http-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-http-java-client/main/LICENSE",
+            ],
+            "com.google.http-client:google-http-client-appengine": [
+                projectUrl: "https://github.com/googleapis/google-http-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-http-java-client/main/LICENSE",
+            ],
+            "com.google.http-client:google-http-client-gson": [
+                projectUrl: "https://github.com/googleapis/google-http-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-http-java-client/main/LICENSE",
+            ],
+            "com.google.http-client:google-http-client-jackson2": [
+                projectUrl: "https://github.com/googleapis/google-http-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-http-java-client/main/LICENSE",
+            ],
+            "com.google.j2objc:j2objc-annotations": [
+                licenseUrl: "https://raw.githubusercontent.com/google/j2objc/master/LICENSE",
+            ],
+            "com.google.oauth-client:google-oauth-client": [
+                projectUrl: "https://github.com/googleapis/google-oauth-java-client",
+                licenseUrl: "https://raw.githubusercontent.com/googleapis/google-oauth-java-client/main/LICENSE",
+            ],
+            "com.google.protobuf:protobuf-java": [
+                projectUrl: "https://github.com/protocolbuffers/protobuf",
+                licenseUrl: "https://raw.githubusercontent.com/protocolbuffers/protobuf/main/LICENSE",
+            ],
+            "com.google.protobuf:protobuf-java-util": [
+                projectUrl: "https://github.com/protocolbuffers/protobuf",
+                licenseUrl: "https://raw.githubusercontent.com/protocolbuffers/protobuf/main/LICENSE",
+            ],
+            "com.google.re2j:re2j": [
+                licenseUrl: "https://raw.githubusercontent.com/google/re2j/master/LICENSE",
+            ],
+            "com.swrve:rate-limited-logger": [
+                licenseUrl: "https://raw.githubusercontent.com/Swrve/rate-limited-logger/master/LICENSE",
+            ],
+            "com.zaxxer:HikariCP": [
+                licenseUrl: "https://raw.githubusercontent.com/brettwooldridge/HikariCP/dev/LICENSE",
+            ],
+            "commons-codec:commons-codec": [
+                licenseUrl: "https://raw.githubusercontent.com/apache/commons-codec/master/LICENSE.txt",
+            ],
+            "commons-io:commons-io": [
+                licenseUrl: "https://raw.githubusercontent.com/apache/commons-io/master/LICENSE.txt",
+            ],
+            "io.grpc:grpc-alts": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-api": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-auth": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-context": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-core": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-googleapis": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-grpclb": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-netty-shaded": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-protobuf": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-protobuf-lite": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-rls": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-services": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-stub": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.grpc:grpc-xds": [
+                licenseUrl: "https://raw.githubusercontent.com/grpc/grpc-java/master/LICENSE",
+            ],
+            "io.netty:netty-buffer": [
+                projectUrl: "https://github.com/netty/netty",
+                licenseUrl: "https://raw.githubusercontent.com/netty/netty/4.1/LICENSE.txt",
+            ],
+            "io.netty:netty-common": [
+                projectUrl: "https://github.com/netty/netty",
+                licenseUrl: "https://raw.githubusercontent.com/netty/netty/4.1/LICENSE.txt",
+            ],
+            "io.opencensus:opencensus-api": [
+                licenseUrl: "https://raw.githubusercontent.com/census-instrumentation/opencensus-java/master/LICENSE",
+            ],
+            "io.opencensus:opencensus-contrib-http-util": [
+                licenseUrl: "https://raw.githubusercontent.com/census-instrumentation/opencensus-java/master/LICENSE",
+            ],
+            "io.opencensus:opencensus-proto": [
+                licenseUrl: "https://raw.githubusercontent.com/census-instrumentation/opencensus-java/master/LICENSE",
+            ],
+            "io.perfmark:perfmark-api": [
+                licenseUrl: "https://raw.githubusercontent.com/perfmark/perfmark/master/LICENSE",
+            ],
+            "javax.inject:javax.inject": [
+                licenseUrl: "https://github.com/javax-inject/javax-inject#license",
+            ],
+            "joda-time:joda-time": [
+                licenseUrl: "https://raw.githubusercontent.com/JodaOrg/joda-time/main/LICENSE.txt",
+            ],
+            "net.sf.jopt-simple:jopt-simple": [
+                licenseUrl: "https://raw.githubusercontent.com/jopt-simple/jopt-simple/master/LICENSE.txt",
+            ],
+            "net.snowflake:snowflake-jdbc": [
+                licenseUrl: "https://raw.githubusercontent.com/snowflakedb/snowflake-jdbc/master/LICENSE.txt",
+            ],
+            "org.anarres.jdiagnostics:jdiagnostics": [
+                licenseUrl: "https://raw.githubusercontent.com/shevek/jdiagnostics/master/LICENSE",
+            ],
+            "org.apache.arrow:arrow-format": [
+                projectUrl: "https://github.com/apache/arrow",
+                licenseUrl: "https://raw.githubusercontent.com/apache/arrow/main/LICENSE.txt",
+            ],
+            "org.apache.arrow:arrow-memory-core": [
+                projectUrl: "https://github.com/apache/arrow",
+                licenseUrl: "https://raw.githubusercontent.com/apache/arrow/main/LICENSE.txt",
+            ],
+            "org.apache.arrow:arrow-memory-netty": [
+                projectUrl: "https://github.com/apache/arrow",
+                licenseUrl: "https://raw.githubusercontent.com/apache/arrow/main/LICENSE.txt",
+            ],
+            "org.apache.arrow:arrow-vector": [
+                projectUrl: "https://github.com/apache/arrow",
+                licenseUrl: "https://raw.githubusercontent.com/apache/arrow/main/LICENSE.txt",
+            ],
+            "org.apache.commons:commons-csv": [
+                licenseUrl: "https://raw.githubusercontent.com/apache/commons-csv/master/LICENSE.txt",
+            ],
+            "org.apache.commons:commons-lang3": [
+                licenseUrl: "https://raw.githubusercontent.com/apache/commons-lang/master/LICENSE.txt",
+            ],
+            "org.apache.httpcomponents:httpclient": [
+                licenseUrl: "https://raw.githubusercontent.com/apache/httpcomponents-client/master/LICENSE.txt",
+            ],
+            "org.apache.httpcomponents:httpcore": [
+                licenseUrl: "https://raw.githubusercontent.com/apache/httpcomponents-core/master/LICENSE.txt",
+            ],
+            "org.apache.httpcomponents.client5:httpclient5": [
+                projectUrl: "https://hc.apache.org/httpcomponents-client-5.2.x/",
+                licenseUrl: "https://raw.githubusercontent.com/apache/httpcomponents-client/master/LICENSE.txt",
+            ],
+            "org.apache.httpcomponents.core5:httpcore5": [
+                projectUrl: "https://hc.apache.org/httpcomponents-core-5.2.x/",
+                licenseUrl: "https://raw.githubusercontent.com/apache/httpcomponents-core/master/LICENSE.txt",
+            ],
+            "org.apache.httpcomponents.core5:httpcore5-h2": [
+                projectUrl: "https://hc.apache.org/httpcomponents-core-5.2.x/",
+                licenseUrl: "https://raw.githubusercontent.com/apache/httpcomponents-core/master/LICENSE.txt",
+            ],
+            "org.apache.thrift:libthrift" : [
+                licenseUrl: "https://raw.githubusercontent.com/apache/thrift/master/LICENSE",
+            ],
+            "org.checkerframework:checker-compat-qual": [
+                licenseUrl: "https://raw.githubusercontent.com/typetools/checker-framework/master/LICENSE.txt",
+            ],
+            "org.checkerframework:checker-qual": [
+                licenseUrl: "https://raw.githubusercontent.com/typetools/checker-framework/master/checker-qual/LICENSE.txt",
+            ],
+            "org.codehaus.mojo:animal-sniffer-annotations": [
+                projectUrl: "https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/",
+                licenseName: "MIT License",
+                licenseUrl: "https://raw.githubusercontent.com/mojohaus/animal-sniffer/master/LICENSE",
+            ],
+            "org.conscrypt:conscrypt-openjdk-uber": [
+                licenseUrl: "https://raw.githubusercontent.com/google/conscrypt/master/LICENSE",
+            ],
+            "org.postgresql:postgresql": [
+                licenseUrl: "https://raw.githubusercontent.com/pgjdbc/pgjdbc/master/LICENSE",
+            ],
+            "org.slf4j:jcl-over-slf4j": [
+                licenseUrl: "https://raw.githubusercontent.com/qos-ch/slf4j/master/LICENSE.txt",
+            ],
+            "org.slf4j:slf4j-api": [
+                licenseUrl: "https://raw.githubusercontent.com/qos-ch/slf4j/master/LICENSE.txt",
+            ],
+            "org.springframework:spring-beans": [
+                licenseUrl: "https://raw.githubusercontent.com/spring-projects/spring-framework/main/LICENSE.txt",
+            ],
+            "org.springframework:spring-core": [
+                licenseUrl: "https://raw.githubusercontent.com/spring-projects/spring-framework/main/LICENSE.txt",
+            ],
+            "org.springframework:spring-jdbc": [
+                licenseUrl: "https://raw.githubusercontent.com/spring-projects/spring-framework/main/LICENSE.txt",
+            ],
+            "org.springframework:spring-tx": [
+                licenseUrl: "https://raw.githubusercontent.com/spring-projects/spring-framework/main/LICENSE.txt",
+            ],
+            "org.threeten:threeten-extra": [
+                licenseUrl: "https://raw.githubusercontent.com/ThreeTen/threeten-extra/main/LICENSE.txt",
+            ],
+            "org.threeten:threetenbp": [
+                licenseUrl: "https://raw.githubusercontent.com/ThreeTen/threeten-extra/main/LICENSE.txt",
+            ],
+            "org.yaml:snakeyaml": [
+                licenseUrl: "https://raw.githubusercontent.com/snakeyaml/snakeyaml/master/LICENSE.txt",
+            ],
+            "software.amazon.ion:ion-java": [
+                licenseUrl: "https://raw.githubusercontent.com/amazon-ion/ion-java/master/LICENSE",
             ],
         ]),
         new com.github.jk1.license.render.JsonReportRenderer('index.json', false),


### PR DESCRIPTION
We got asked to provide the link to the license file in the libraries source repository. This provides this information for all dependencies (as of today) where that information is not available in the POM or metadata.