### PR TITLE
Update java-storage-nio to fix bucket name issue

### DIFF
--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -50,7 +50,7 @@ dependencies {
 
     constraints {
         // Define dependency versions as constraints
-        def guavaVersion = '31.1-jre'
+        def guavaVersion = '32.1.2-jre'
         implementation "com.google.guava:guava:$guavaVersion"
         testFixturesImplementation "com.google.guava:guava:$guavaVersion"
         def jacksonVersion = '2.14.2'

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation "com.fasterxml.jackson.core:jackson-databind"
     implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
     implementation "com.google.cloud:google-cloud-bigquery"
-    implementation "com.google.cloud:google-cloud-nio:0.126.15"
+    implementation "com.google.cloud:google-cloud-nio:0.127.1"
     implementation "com.google.cloud:google-cloud-kms:2.23.0"
     implementation "org.apache.httpcomponents.client5:httpclient5:5.2.1"
 

--- a/gradle/license-allowed.json
+++ b/gradle/license-allowed.json
@@ -100,6 +100,10 @@
 		{
 			"moduleLicense": null,
 			"moduleName": "com.fasterxml.jackson:jackson-bom"
+		},
+		{
+			"moduleLicense": null,
+			"moduleName": "com.google.guava:guava-parent"
 		}
 	]
 }


### PR DESCRIPTION
The library java-storage-nio did not allow buckets with underscores
(https://github.com/googleapis/java-storage-nio/issues/1218). Updating
to the latest version to get the fix for this issue.

BUG=296379989