### PR TITLE
Use Gradle version catalogs to manage dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,16 @@ distributions {
 
 versionCatalogUpdate {
     sortByKey = true
+    def isNonStable = { String version -> // from the examples in ben-manes plugin; may need adjustment for the particular dependencies of this repo
+        def stableKeyword = ['RELEASE', 'FINAL', 'GA'].any { k -> version.toUpperCase().contains(k) }
+        def regex = /^[0-9,.v-]+(-r)?$/
+        return !stableKeyword && !(version ==~ regex)
+    }
+    tasks.named("dependencyUpdates").configure {
+        rejectVersionIf {
+            isNonStable(it.candidate.version)
+        }
+    }
     pin {
     }
     keep {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'java-library-distribution'
-    id "com.github.ben-manes.versions" version "0.46.0"
+    alias libs.plugins.ben.manes.versions
+    alias libs.plugins.version.catalog.update
 }
 
 distributions {
@@ -18,5 +19,16 @@ distributions {
                 from it.tasks.installPublishedDist
             }
         }
+    }
+}
+
+versionCatalogUpdate {
+    sortByKey = true
+    pin {
+    }
+    keep {
+        keepUnusedVersions = true
+        keepUnusedLibraries = true
+        keepUnusedPlugins = true
     }
 }

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -9,8 +9,8 @@ repositories {
 }
 
 dependencies {
-    implementation "com.diffplug.spotless:spotless-plugin-gradle:6.4.1"
-    implementation "com.netflix.nebula:gradle-info-plugin:11.4.1"
-    implementation "com.github.jk1:gradle-license-report:1.17"
-    implementation "org.apache.commons:commons-csv:1.10.0"
+    implementation libs.spotless.plugin.gradle
+    implementation libs.gradle.info.plugin
+    implementation libs.gradle.license.report
+    implementation libs.apache.commons.csv
 }

--- a/buildSrc/settings.gradle
+++ b/buildSrc/settings.gradle
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        libs {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -37,90 +37,77 @@ configurations {
 }
 
 dependencies {
-    def autoserviceVersion = '1.0.1'
-    def autoValueVersion = '1.8.1'
-    def checkerFrameworkVersion = '3.19.0'
-    def jclOverSlf4jVersion = '1.7.14'
-    def jsr305Version = '3.0.2'
-    def junitVersion = '4.13.2'
-    def log4jOverSlf4jVersion = '1.7.14'
-    def scJcipVersion = '1.0-1'
-    def slf4jVersion = '1.7.30'
-    def logbackVersion = '1.2.11'
 
     constraints {
         // Define dependency versions as constraints
-        def guavaVersion = '32.1.2-jre'
-        implementation "com.google.guava:guava:$guavaVersion"
-        testFixturesImplementation "com.google.guava:guava:$guavaVersion"
-        def jacksonVersion = '2.14.2'
-        implementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
-        implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+        implementation libs.guava
+        testFixturesImplementation libs.guava
+        implementation libs.jackson.databind
+        implementation libs.jackson.dataformat.yaml
 
-        implementation "net.sf.jopt-simple:jopt-simple:5.0.4"
-        implementation "org.anarres.jdiagnostics:jdiagnostics:1.0.7"
-        implementation "commons-io:commons-io:2.11.0"
-        implementation "org.apache.commons:commons-csv:1.9.0"
-        implementation "org.apache.commons:commons-lang3:3.8.1"
-        testFixturesImplementation "org.apache.commons:commons-lang3:3.8.1"
-        def springVersion = '5.3.25'
-        implementation "org.springframework:spring-core:$springVersion"
-        implementation "org.springframework:spring-jdbc:$springVersion"
-        implementation "com.zaxxer:HikariCP:3.2.0"
-        implementation "com.swrve:rate-limited-logger:2.0.0"
+        implementation libs.jopt.simple
+        implementation libs.jdiagnostics
+        implementation libs.commons.io
+        implementation libs.apache.commons.csv
+        implementation libs.apache.commons.lang3
+        testFixturesImplementation libs.apache.commons.lang3
+        implementation libs.spring.core
+        implementation libs.spring.jdbc
+        implementation libs.hikaricp
+        implementation libs.rate.limited.logger
 
-        implementation "com.google.cloud:google-cloud-bigquery:2.23.2"
+        implementation libs.google.cloud.bigquery
 
-        implementation "org.yaml:snakeyaml:2.0" // 1.x has multiple vulnerabilities
+        implementation libs.snakeyaml
 
-        runtimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
-        runtimeOnly "org.slf4j:jcl-over-slf4j:$jclOverSlf4jVersion"
+        runtimeOnly libs.logback.classic
+        runtimeOnly libs.jcl.over.slf4j
 
-        runtimeOnly "org.postgresql:postgresql:42.5.4"
-        runtimeOnly "net.snowflake:snowflake-jdbc:3.13.20"
-        runtimeOnly "com.amazon.redshift:redshift-jdbc42:2.1.0.18"
-        runtimeOnly "com.amazonaws:aws-java-sdk-redshift:1.12.520"
+        runtimeOnly libs.postgresql
+        runtimeOnly libs.snowflake.jdbc
+        runtimeOnly libs.redshift.jdbc
+        runtimeOnly libs.aws.java.sdk.redshift
 
-        testFixturesApi "org.apache.commons:commons-compress:1.18"
-        testFixturesApi "commons-io:commons-io:2.11.0"
-        testImplementation "org.xerial:sqlite-jdbc:3.42.0.0"
-        testImplementation "com.github.stefanbirkner:system-rules:1.18.0"
-        testImplementation "org.postgresql:postgresql:42.5.4"
-        testImplementation "joda-time:joda-time:2.3"
+        testFixturesApi libs.apache.commons.compress
+        testFixturesApi libs.commons.io
+        testImplementation libs.sqlite.jdbc
+        testImplementation libs.system.rules
+        testImplementation libs.postgresql
+        testImplementation libs.joda.time
     }
 
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    testFixturesApi "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    testFixturesImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    testImplementation "com.google.code.findbugs:jsr305:$jsr305Version"
-    implementation "com.github.stephenc.jcip:jcip-annotations:$scJcipVersion"
-    testFixturesImplementation "com.github.stephenc.jcip:jcip-annotations:$scJcipVersion"
-    testImplementation "com.github.stephenc.jcip:jcip-annotations:$scJcipVersion"
+    implementation libs.slf4j.api
+    testFixturesApi libs.slf4j.api
+    implementation libs.jsr305
+    testFixturesImplementation libs.jsr305
+    testImplementation libs.jsr305
+    implementation libs.jcip.annotations
+    testFixturesImplementation libs.jcip.annotations
+    testImplementation libs.jcip.annotations
     // Ideally, implementation, but this annotation is preserved/exposed.
-    implementation "org.checkerframework:checker-qual:$checkerFrameworkVersion"
-    testFixturesImplementation "org.checkerframework:checker-qual:$checkerFrameworkVersion"
-    testImplementation "org.checkerframework:checker-qual:$checkerFrameworkVersion"
+    implementation libs.checker.qual
+    testFixturesImplementation libs.checker.qual
+    testImplementation libs.checker.qual
 
-    compileOnly "com.google.auto.value:auto-value-annotations:$autoValueVersion"
-    annotationProcessor "com.google.auto.value:auto-value:$autoValueVersion";
-    testFixturesCompileOnly "com.google.auto.value:auto-value-annotations:$autoValueVersion"
-    testFixturesAnnotationProcessor "com.google.auto.value:auto-value:$autoValueVersion";
-    testCompileOnly "com.google.auto.value:auto-value-annotations:$autoValueVersion"
-    testAnnotationProcessor "com.google.auto.value:auto-value:$autoValueVersion";
+    compileOnly libs.auto.value.annotations
+    annotationProcessor libs.auto.value
+    testFixturesCompileOnly libs.auto.value.annotations
+    testFixturesAnnotationProcessor libs.auto.value
+    testCompileOnly libs.auto.value.annotations
+    testAnnotationProcessor libs.auto.value
 
-    compileOnly "com.google.auto.service:auto-service:$autoserviceVersion"
-    annotationProcessor "com.google.auto.service:auto-service:$autoserviceVersion"
-    testFixturesCompileOnly "com.google.auto.service:auto-service:$autoserviceVersion"
-    testFixturesAnnotationProcessor "com.google.auto.service:auto-service:$autoserviceVersion"
-    testCompileOnly "com.google.auto.service:auto-service:$autoserviceVersion"
-    testAnnotationProcessor "com.google.auto.service:auto-service:$autoserviceVersion"
+    compileOnly libs.auto.service
+    annotationProcessor libs.auto.service
+    testFixturesCompileOnly libs.auto.service
+    testFixturesAnnotationProcessor libs.auto.service
+    testCompileOnly libs.auto.service
+    testAnnotationProcessor libs.auto.service
 
-    testImplementation "junit:junit:$junitVersion"
-    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
-    testRuntimeOnly "org.slf4j:jul-to-slf4j:$slf4jVersion"
-    testRuntimeOnly "org.slf4j:log4j-over-slf4j:$log4jOverSlf4jVersion"
-    testRuntimeOnly "org.slf4j:jcl-over-slf4j:$jclOverSlf4jVersion"
+    testImplementation libs.junit
+    testRuntimeOnly libs.logback.classic
+    testRuntimeOnly libs.jul.to.slf4j
+    testRuntimeOnly libs.log4j.over.slf4j
+    testRuntimeOnly libs.jcl.over.slf4j
 }
 
 java {

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -18,7 +18,7 @@ import org.apache.tools.ant.filters.ReplaceTokens
 
 buildscript {
     dependencies {
-        classpath 'com.github.jk1:gradle-license-report:1.17'
+        classpath libs.gradle.license.report
     }
 }
 
@@ -34,64 +34,61 @@ configurations {
     }
 }
 
-def mockitoVersion = '4.11.0'
-def autoValueVersion = '1.10.2'
-
 dependencies {
-    compileOnly "com.google.auto.value:auto-value-annotations:${autoValueVersion}"
+    compileOnly libs.auto.value.annotations
 
-    annotationProcessor "com.google.auto.value:auto-value:${autoValueVersion}"
+    annotationProcessor libs.auto.value
 
     implementation project(':dumper:lib-common')
     implementation project(':dumper:lib-dumper-spi')
     implementation project(':dumper:lib-ext-bigquery')
     implementation project(':dumper:lib-ext-hive-metastore')
 
-    implementation "com.google.guava:guava"
-    implementation "net.sf.jopt-simple:jopt-simple"
-    implementation "org.anarres.jdiagnostics:jdiagnostics"
-    implementation "commons-io:commons-io"
-    implementation "org.apache.commons:commons-csv"
-    implementation "org.apache.commons:commons-lang3"
-    implementation "org.springframework:spring-core"
-    implementation "org.springframework:spring-jdbc"
-    implementation "com.zaxxer:HikariCP"
-    implementation "com.swrve:rate-limited-logger"
-    implementation "com.fasterxml.jackson.core:jackson-databind"
-    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml"
-    implementation "com.google.cloud:google-cloud-bigquery"
-    implementation "com.google.cloud:google-cloud-nio:0.127.1"
-    implementation "com.google.cloud:google-cloud-kms:2.23.0"
-    implementation "org.apache.httpcomponents.client5:httpclient5:5.2.1"
+    implementation libs.guava
+    implementation libs.jopt.simple
+    implementation libs.jdiagnostics
+    implementation libs.commons.io
+    implementation libs.apache.commons.csv
+    implementation libs.apache.commons.lang3
+    implementation libs.spring.core
+    implementation libs.spring.jdbc
+    implementation libs.hikaricp
+    implementation libs.rate.limited.logger
+    implementation libs.jackson.databind
+    implementation libs.jackson.dataformat.yaml
+    implementation libs.google.cloud.bigquery
+    implementation libs.google.cloud.nio
+    implementation libs.google.cloud.kms
+    implementation libs.httpclient5
 
-    runtimeOnly "ch.qos.logback:logback-classic"
-    runtimeOnly "org.slf4j:jcl-over-slf4j"
+    runtimeOnly libs.logback.classic
+    runtimeOnly libs.jcl.over.slf4j
 
-    runtimeOnly "org.postgresql:postgresql"
-    runtimeOnly "net.snowflake:snowflake-jdbc"
-    runtimeOnly "com.amazon.redshift:redshift-jdbc42"
-    runtimeOnly "com.amazonaws:aws-java-sdk-redshift"
+    runtimeOnly libs.postgresql
+    runtimeOnly libs.snowflake.jdbc
+    runtimeOnly libs.redshift.jdbc
+    runtimeOnly libs.aws.java.sdk.redshift
 
     testFixturesApi testFixtures(project(':dumper:lib-common'))
 
-    testImplementation "org.xerial:sqlite-jdbc"
-    testImplementation "org.postgresql:postgresql"
-    testImplementation "com.github.stefanbirkner:system-rules"
-    testImplementation "joda-time:joda-time"
-    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
-    testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
+    testImplementation libs.sqlite.jdbc
+    testImplementation libs.postgresql
+    testImplementation libs.system.rules
+    testImplementation libs.joda.time
+    testImplementation libs.mockito.core
+    testImplementation libs.mockito.junit.jupiter
 
 
     // Test Hive 3.1.2
     testImplementation project(path: ':dumper:lib-ext-hive-metastore', configuration: 'shadow')
     // Excluded during shadowJar step, same versions as exclusions
-    testRuntimeOnly "org.datanucleus:datanucleus-api-jdo:4.2.4"
-    testRuntimeOnly "org.datanucleus:datanucleus-core:4.1.17"
-    testRuntimeOnly "org.datanucleus:javax.jdo:3.2.0-m3"
-    testRuntimeOnly "org.datanucleus:datanucleus-rdbms:4.1.19"
+    testRuntimeOnly libs.datanucleus.api.jdo
+    testRuntimeOnly libs.datanucleus.core
+    testRuntimeOnly libs.datanucleus.javax.jdo
+    testRuntimeOnly libs.datanucleus.rdbms
 
-    sources "org.slf4j:jcl-over-slf4j:1.7.14@sources"
-    sources "ch.qos.logback:logback-classic:1.2.11@sources"
+    sources "org.slf4j:jcl-over-slf4j:${libs.versions.jcl.over.slf4j.get()}@sources"
+    sources "ch.qos.logback:logback-classic:${libs.versions.logback.get()}@sources"
 }
 
 startScripts {

--- a/dumper/lib-ext-hive-metastore/build.gradle
+++ b/dumper/lib-ext-hive-metastore/build.gradle
@@ -19,7 +19,7 @@ import java.util.stream.Collectors
 
 plugins {
     id 'dwh-migration-dumper.java-library-conventions'
-    id 'com.github.johnrengelman.shadow' version '8.1.1'
+    alias libs.plugins.shadow
 }
 
 sourceSets {
@@ -27,18 +27,17 @@ sourceSets {
 }
 
 dependencies {
-    api "org.apache.thrift:libthrift:0.16.0"
-    implementation "com.google.guava:guava"
+    api libs.libthrift
+    implementation libs.guava
 
-    def hiveVersion = '3.1.2'
-    hive312RuntimeOnly "org.apache.hive:hive-common:$hiveVersion"
-    hive312RuntimeOnly "org.apache.hive:hive-exec:$hiveVersion"
-    hive312RuntimeOnly "org.apache.hive:hive-service:$hiveVersion"
-    hive312RuntimeOnly "org.apache.hive:hive-metastore:$hiveVersion"
-    hive312RuntimeOnly "org.apache.hive:hive-jdbc:$hiveVersion"
+    hive312RuntimeOnly libs.hive.common
+    hive312RuntimeOnly libs.hive.exec
+    hive312RuntimeOnly libs.hive.service
+    hive312RuntimeOnly libs.hive.metastore
+    hive312RuntimeOnly libs.hive.jdbc
     // For HiveServer2
-    hive312RuntimeOnly "org.apache.tez:tez-common:0.9.1"
-    hive312RuntimeOnly "org.apache.tez:tez-dag:0.9.1"
+    hive312RuntimeOnly libs.tez.common
+    hive312RuntimeOnly libs.tez.dag
     // Starting from version 1.8 the binding mechanics changed
     hive312RuntimeOnly("org.slf4j:slf4j-api") {
         version {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,112 @@
+# TO FORMAT: run ./gradlew versionCatalogFormat
+# TO UPGRADE: run ./gradlew versionCatalogUpdate (accepts an --interative flag)
+
+[versions]
+ben-manes-versions-plugin = '0.46.0'
+auto-service = '1.0.1'
+auto-value = '1.10.2'
+guava = '32.1.2-jre'
+snakeyaml = '2.0' # 1.x has multiple vulnerabilities
+checkerframework = '3.19.0'
+jcl-over-slf4j = '1.7.14'
+system-rules = '1.18.0'
+jackson = '2.14.2'
+spring = '5.3.25'
+jsr305 = '3.0.2'
+junit = '4.13.2'
+log4j-over-slf4j = '1.7.14'
+jcip = '1.0-1'
+slf4j = '1.7.30'
+logback = '1.2.11'
+httpclient5 = '5.2.1'
+mockito = '4.11.0'
+google-cloud-bigquery = '2.23.2'
+google-cloud-nio = '0.127.1'
+google-cloud-kms = '2.23.0'
+postgresql = "42.5.4"
+snowflake = "3.13.20"
+apache-commons-csv = '1.9.0'
+joda-time = '2.3'
+apache-commons-lang3 = '3.8.1'
+jopt-simple = '5.0.4'
+sqlite-jdbc = '3.42.0.0'
+jdiagnostics = '1.0.7'
+tez = '0.9.1'
+commons-io = '2.11.0'
+hikaricp = '3.2.0'
+rate-limited-logger = '2.0.0'
+redshift-jdbc = '2.1.0.18'
+aws-java-sdk = '1.12.520'
+apache-commons-compress = '1.18'
+version-catalog-update-plugin = '0.8.1'
+datanucleus-api-jdo = '4.2.4'
+datanucleus-core = '4.1.17'
+datanucleus-javax-jdo = '3.2.0-m3'
+datanucleus-rdbms = '4.1.19'
+spotless-plugin-gradle = '6.4.1'
+gradle-info-plugin = '11.4.1'
+gradle-license-report = '1.17'
+hive = '3.1.2'
+shadow-plugin = '8.1.1'
+thrift = '0.16.0'
+
+[libraries]
+guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
+auto-service = { group = "com.google.auto.service", name = "auto-service", version.ref = "auto-service"}
+jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version.ref = "jsr305"}
+jcip-annotations =  {group = "com.github.stephenc.jcip", name = "jcip-annotations", version.ref = "jcip"}
+slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j"}
+checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
+junit = { group = "junit", name = "junit", version.ref = "junit" }
+auto-value-annotations = { group = "com.google.auto.value", name = "auto-value-annotations", version.ref = "auto-value" }
+auto-value = { group = "com.google.auto.value", name = "auto-value", version.ref = "auto-value" }
+logback-classic = {group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
+jul-to-slf4j = { group = "org.slf4j", name = "jul-to-slf4j", version.ref = "slf4j" }
+log4j-over-slf4j = { group = "org.slf4j", name = "log4j-over-slf4j", version.ref = "log4j-over-slf4j" }
+jcl-over-slf4j = { group = "org.slf4j", name = "jcl-over-slf4j", version.ref = "jcl-over-slf4j" }
+jackson-databind = { group = "com.fasterxml.jackson.core", name="jackson-databind", version.ref= "jackson" }
+jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name="jackson-dataformat-yaml", version.ref= "jackson" }
+spring-core = { group = "org.springframework", name = "spring-core", version.ref = "spring" }
+spring-jdbc = { group = "org.springframework", name = "spring-jdbc", version.ref = "spring" }
+snakeyaml = { group = "org.yaml", name = "snakeyaml", version.ref = "snakeyaml" }
+google-cloud-bigquery = { group = "com.google.cloud", name = "google-cloud-bigquery", version.ref = "google-cloud-bigquery" }
+postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql" }
+snowflake-jdbc = { group ="net.snowflake", name = "snowflake-jdbc", version.ref = "snowflake" }
+apache-commons-csv = {group = "org.apache.commons", name = "commons-csv", version.ref = "apache-commons-csv" }
+apache-commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "apache-commons-lang3" }
+jopt-simple = { group = "net.sf.jopt-simple", name = "jopt-simple", version.ref = "jopt-simple" }
+jdiagnostics = {group = "org.anarres.jdiagnostics", name = "jdiagnostics", version.ref = "jdiagnostics" }
+commons-io = {group = "commons-io", name = "commons-io", version.ref = "commons-io"}
+hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikaricp" }
+rate-limited-logger = {group = "com.swrve", name = "rate-limited-logger", version.ref = "rate-limited-logger"}
+redshift-jdbc = { group = "com.amazon.redshift", name = "redshift-jdbc42", version.ref = "redshift-jdbc" }
+aws-java-sdk-redshift = { group = "com.amazonaws", name = "aws-java-sdk-redshift", version.ref = "aws-java-sdk" }
+apache-commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "apache-commons-compress" }
+joda-time = { group = "joda-time", name = "joda-time", version.ref = "joda-time" }
+sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref= "sqlite-jdbc" }
+system-rules = {group = "com.github.stefanbirkner", name = "system-rules", version.ref = "system-rules" }
+mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito"}
+mockito-junit-jupiter = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito"}
+google-cloud-nio = { group = "com.google.cloud", name = "google-cloud-nio", version.ref = "google-cloud-nio" }
+google-cloud-kms = { group = "com.google.cloud", name = "google-cloud-kms", version.ref = "google-cloud-kms" }
+httpclient5= { group = "org.apache.httpcomponents.client5", name = "httpclient5", version.ref = "httpclient5" }
+datanucleus-api-jdo = { group = "org.datanucleus", name = "datanucleus-api-jdo", version.ref = "datanucleus-api-jdo" }
+datanucleus-core = { group = "org.datanucleus", name = "datanucleus-core", version.ref = "datanucleus-core" }
+datanucleus-javax-jdo = { group = "org.datanucleus", name = "javax.jdo", version.ref = "datanucleus-javax-jdo" }
+datanucleus-rdbms = { group = "org.datanucleus", name = "datanucleus-rdbms", version.ref = "datanucleus-rdbms" }
+spotless-plugin-gradle = {group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless-plugin-gradle"}
+gradle-info-plugin = {group = "com.netflix.nebula", name = "gradle-info-plugin", version.ref = "gradle-info-plugin"}
+gradle-license-report = {group = "com.github.jk1", name = "gradle-license-report", version.ref = "gradle-license-report"}
+hive-common = {group = "org.apache.hive", name = "hive-common", version.ref = "hive" }
+hive-exec = {group = "org.apache.hive", name = "hive-exec", version.ref = "hive" }
+hive-service = {group = "org.apache.hive", name = "hive-service", version.ref = "hive" }
+hive-metastore = {group = "org.apache.hive", name = "hive-metastore", version.ref = "hive" }
+hive-jdbc = {group = "org.apache.hive", name = "hive-jdbc", version.ref = "hive" }
+libthrift = { group = "org.apache.thrift", name = "libthrift", version.ref = "thrift" }
+tez-common = {group = "org.apache.tez", name = "tez-common", version.ref = "tez" }
+tez-dag = {group = "org.apache.tez", name = "tez-dag", version.ref = "tez" }
+
+[plugins]
+ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions-plugin" }
+shadow = {id = 'com.github.johnrengelman.shadow', version.ref = "shadow-plugin" }
+version-catalog-update = {id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update-plugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,112 +1,111 @@
 # TO FORMAT: run ./gradlew versionCatalogFormat
 # TO UPGRADE: run ./gradlew versionCatalogUpdate (accepts an --interative flag)
-
 [versions]
-ben-manes-versions-plugin = '0.46.0'
-auto-service = '1.0.1'
-auto-value = '1.10.2'
-guava = '32.1.2-jre'
-snakeyaml = '2.0' # 1.x has multiple vulnerabilities
-checkerframework = '3.19.0'
-jcl-over-slf4j = '1.7.14'
-system-rules = '1.18.0'
-jackson = '2.14.2'
-spring = '5.3.25'
-jsr305 = '3.0.2'
-junit = '4.13.2'
-log4j-over-slf4j = '1.7.14'
-jcip = '1.0-1'
-slf4j = '1.7.30'
-logback = '1.2.11'
-httpclient5 = '5.2.1'
-mockito = '4.11.0'
-google-cloud-bigquery = '2.23.2'
-google-cloud-nio = '0.127.1'
-google-cloud-kms = '2.23.0'
+apache-commons-compress = "1.18"
+apache-commons-csv = "1.9.0"
+apache-commons-lang3 = "3.8.1"
+auto-service = "1.0.1"
+auto-value = "1.10.2"
+aws-java-sdk = "1.12.520"
+ben-manes-versions-plugin = "0.46.0"
+checkerframework = "3.19.0"
+commons-io = "2.11.0"
+datanucleus-api-jdo = "4.2.4"
+datanucleus-core = "4.1.17"
+datanucleus-javax-jdo = "3.2.0-m3"
+datanucleus-rdbms = "4.1.19"
+google-cloud-bigquery = "2.23.2"
+google-cloud-kms = "2.23.0"
+google-cloud-nio = "0.127.1"
+gradle-info-plugin = "11.4.1"
+gradle-license-report = "1.17"
+guava = "32.1.2-jre"
+hikaricp = "3.2.0"
+hive = "3.1.2"
+httpclient5 = "5.2.1"
+jackson = "2.14.2"
+jcip = "1.0-1"
+jcl-over-slf4j = "1.7.14"
+jdiagnostics = "1.0.7"
+joda-time = "2.3"
+jopt-simple = "5.0.4"
+jsr305 = "3.0.2"
+junit = "4.13.2"
+log4j-over-slf4j = "1.7.14"
+logback = "1.2.11"
+mockito = "4.11.0"
 postgresql = "42.5.4"
+rate-limited-logger = "2.0.0"
+redshift-jdbc = "2.1.0.18"
+shadow-plugin = "8.1.1"
+slf4j = "1.7.30"
+snakeyaml = "2.0"
 snowflake = "3.13.20"
-apache-commons-csv = '1.9.0'
-joda-time = '2.3'
-apache-commons-lang3 = '3.8.1'
-jopt-simple = '5.0.4'
-sqlite-jdbc = '3.42.0.0'
-jdiagnostics = '1.0.7'
-tez = '0.9.1'
-commons-io = '2.11.0'
-hikaricp = '3.2.0'
-rate-limited-logger = '2.0.0'
-redshift-jdbc = '2.1.0.18'
-aws-java-sdk = '1.12.520'
-apache-commons-compress = '1.18'
-version-catalog-update-plugin = '0.8.1'
-datanucleus-api-jdo = '4.2.4'
-datanucleus-core = '4.1.17'
-datanucleus-javax-jdo = '3.2.0-m3'
-datanucleus-rdbms = '4.1.19'
-spotless-plugin-gradle = '6.4.1'
-gradle-info-plugin = '11.4.1'
-gradle-license-report = '1.17'
-hive = '3.1.2'
-shadow-plugin = '8.1.1'
-thrift = '0.16.0'
+spotless-plugin-gradle = "6.4.1"
+spring = "5.3.25"
+sqlite-jdbc = "3.42.0.0"
+system-rules = "1.18.0"
+tez = "0.9.1"
+thrift = "0.16.0"
+version-catalog-update-plugin = "0.8.1"
 
 [libraries]
-guava = { group = "com.google.guava", name = "guava", version.ref = "guava" }
-auto-service = { group = "com.google.auto.service", name = "auto-service", version.ref = "auto-service"}
-jsr305 = { group = "com.google.code.findbugs", name = "jsr305", version.ref = "jsr305"}
-jcip-annotations =  {group = "com.github.stephenc.jcip", name = "jcip-annotations", version.ref = "jcip"}
-slf4j-api = { group = "org.slf4j", name = "slf4j-api", version.ref = "slf4j"}
-checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
-junit = { group = "junit", name = "junit", version.ref = "junit" }
-auto-value-annotations = { group = "com.google.auto.value", name = "auto-value-annotations", version.ref = "auto-value" }
-auto-value = { group = "com.google.auto.value", name = "auto-value", version.ref = "auto-value" }
-logback-classic = {group = "ch.qos.logback", name = "logback-classic", version.ref = "logback" }
-jul-to-slf4j = { group = "org.slf4j", name = "jul-to-slf4j", version.ref = "slf4j" }
-log4j-over-slf4j = { group = "org.slf4j", name = "log4j-over-slf4j", version.ref = "log4j-over-slf4j" }
-jcl-over-slf4j = { group = "org.slf4j", name = "jcl-over-slf4j", version.ref = "jcl-over-slf4j" }
-jackson-databind = { group = "com.fasterxml.jackson.core", name="jackson-databind", version.ref= "jackson" }
-jackson-dataformat-yaml = { group = "com.fasterxml.jackson.dataformat", name="jackson-dataformat-yaml", version.ref= "jackson" }
-spring-core = { group = "org.springframework", name = "spring-core", version.ref = "spring" }
-spring-jdbc = { group = "org.springframework", name = "spring-jdbc", version.ref = "spring" }
-snakeyaml = { group = "org.yaml", name = "snakeyaml", version.ref = "snakeyaml" }
-google-cloud-bigquery = { group = "com.google.cloud", name = "google-cloud-bigquery", version.ref = "google-cloud-bigquery" }
-postgresql = { group = "org.postgresql", name = "postgresql", version.ref = "postgresql" }
-snowflake-jdbc = { group ="net.snowflake", name = "snowflake-jdbc", version.ref = "snowflake" }
-apache-commons-csv = {group = "org.apache.commons", name = "commons-csv", version.ref = "apache-commons-csv" }
-apache-commons-lang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "apache-commons-lang3" }
-jopt-simple = { group = "net.sf.jopt-simple", name = "jopt-simple", version.ref = "jopt-simple" }
-jdiagnostics = {group = "org.anarres.jdiagnostics", name = "jdiagnostics", version.ref = "jdiagnostics" }
-commons-io = {group = "commons-io", name = "commons-io", version.ref = "commons-io"}
-hikaricp = { group = "com.zaxxer", name = "HikariCP", version.ref = "hikaricp" }
-rate-limited-logger = {group = "com.swrve", name = "rate-limited-logger", version.ref = "rate-limited-logger"}
-redshift-jdbc = { group = "com.amazon.redshift", name = "redshift-jdbc42", version.ref = "redshift-jdbc" }
-aws-java-sdk-redshift = { group = "com.amazonaws", name = "aws-java-sdk-redshift", version.ref = "aws-java-sdk" }
-apache-commons-compress = { group = "org.apache.commons", name = "commons-compress", version.ref = "apache-commons-compress" }
-joda-time = { group = "joda-time", name = "joda-time", version.ref = "joda-time" }
-sqlite-jdbc = { group = "org.xerial", name = "sqlite-jdbc", version.ref= "sqlite-jdbc" }
-system-rules = {group = "com.github.stefanbirkner", name = "system-rules", version.ref = "system-rules" }
-mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito"}
-mockito-junit-jupiter = { group = "org.mockito", name = "mockito-junit-jupiter", version.ref = "mockito"}
-google-cloud-nio = { group = "com.google.cloud", name = "google-cloud-nio", version.ref = "google-cloud-nio" }
-google-cloud-kms = { group = "com.google.cloud", name = "google-cloud-kms", version.ref = "google-cloud-kms" }
-httpclient5= { group = "org.apache.httpcomponents.client5", name = "httpclient5", version.ref = "httpclient5" }
-datanucleus-api-jdo = { group = "org.datanucleus", name = "datanucleus-api-jdo", version.ref = "datanucleus-api-jdo" }
-datanucleus-core = { group = "org.datanucleus", name = "datanucleus-core", version.ref = "datanucleus-core" }
-datanucleus-javax-jdo = { group = "org.datanucleus", name = "javax.jdo", version.ref = "datanucleus-javax-jdo" }
-datanucleus-rdbms = { group = "org.datanucleus", name = "datanucleus-rdbms", version.ref = "datanucleus-rdbms" }
-spotless-plugin-gradle = {group = "com.diffplug.spotless", name = "spotless-plugin-gradle", version.ref = "spotless-plugin-gradle"}
-gradle-info-plugin = {group = "com.netflix.nebula", name = "gradle-info-plugin", version.ref = "gradle-info-plugin"}
-gradle-license-report = {group = "com.github.jk1", name = "gradle-license-report", version.ref = "gradle-license-report"}
-hive-common = {group = "org.apache.hive", name = "hive-common", version.ref = "hive" }
-hive-exec = {group = "org.apache.hive", name = "hive-exec", version.ref = "hive" }
-hive-service = {group = "org.apache.hive", name = "hive-service", version.ref = "hive" }
-hive-metastore = {group = "org.apache.hive", name = "hive-metastore", version.ref = "hive" }
-hive-jdbc = {group = "org.apache.hive", name = "hive-jdbc", version.ref = "hive" }
-libthrift = { group = "org.apache.thrift", name = "libthrift", version.ref = "thrift" }
-tez-common = {group = "org.apache.tez", name = "tez-common", version.ref = "tez" }
-tez-dag = {group = "org.apache.tez", name = "tez-dag", version.ref = "tez" }
+apache-commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "apache-commons-compress" }
+apache-commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "apache-commons-csv" }
+apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "apache-commons-lang3" }
+auto-service = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
+auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
+auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }
+aws-java-sdk-redshift = { module = "com.amazonaws:aws-java-sdk-redshift", version.ref = "aws-java-sdk" }
+checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checkerframework" }
+commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
+datanucleus-api-jdo = { module = "org.datanucleus:datanucleus-api-jdo", version.ref = "datanucleus-api-jdo" }
+datanucleus-core = { module = "org.datanucleus:datanucleus-core", version.ref = "datanucleus-core" }
+datanucleus-javax-jdo = { module = "org.datanucleus:javax.jdo", version.ref = "datanucleus-javax-jdo" }
+datanucleus-rdbms = { module = "org.datanucleus:datanucleus-rdbms", version.ref = "datanucleus-rdbms" }
+google-cloud-bigquery = { module = "com.google.cloud:google-cloud-bigquery", version.ref = "google-cloud-bigquery" }
+google-cloud-kms = { module = "com.google.cloud:google-cloud-kms", version.ref = "google-cloud-kms" }
+google-cloud-nio = { module = "com.google.cloud:google-cloud-nio", version.ref = "google-cloud-nio" }
+gradle-info-plugin = { module = "com.netflix.nebula:gradle-info-plugin", version.ref = "gradle-info-plugin" }
+gradle-license-report = { module = "com.github.jk1:gradle-license-report", version.ref = "gradle-license-report" }
+guava = { module = "com.google.guava:guava", version.ref = "guava" }
+hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikaricp" }
+hive-common = { module = "org.apache.hive:hive-common", version.ref = "hive" }
+hive-exec = { module = "org.apache.hive:hive-exec", version.ref = "hive" }
+hive-jdbc = { module = "org.apache.hive:hive-jdbc", version.ref = "hive" }
+hive-metastore = { module = "org.apache.hive:hive-metastore", version.ref = "hive" }
+hive-service = { module = "org.apache.hive:hive-service", version.ref = "hive" }
+httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpclient5" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-dataformat-yaml = { module = "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml", version.ref = "jackson" }
+jcip-annotations = { module = "com.github.stephenc.jcip:jcip-annotations", version.ref = "jcip" }
+jcl-over-slf4j = { module = "org.slf4j:jcl-over-slf4j", version.ref = "jcl-over-slf4j" }
+jdiagnostics = { module = "org.anarres.jdiagnostics:jdiagnostics", version.ref = "jdiagnostics" }
+joda-time = { module = "joda-time:joda-time", version.ref = "joda-time" }
+jopt-simple = { module = "net.sf.jopt-simple:jopt-simple", version.ref = "jopt-simple" }
+jsr305 = { module = "com.google.code.findbugs:jsr305", version.ref = "jsr305" }
+jul-to-slf4j = { module = "org.slf4j:jul-to-slf4j", version.ref = "slf4j" }
+junit = { module = "junit:junit", version.ref = "junit" }
+libthrift = { module = "org.apache.thrift:libthrift", version.ref = "thrift" }
+log4j-over-slf4j = { module = "org.slf4j:log4j-over-slf4j", version.ref = "log4j-over-slf4j" }
+logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockito" }
+postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
+rate-limited-logger = { module = "com.swrve:rate-limited-logger", version.ref = "rate-limited-logger" }
+redshift-jdbc = { module = "com.amazon.redshift:redshift-jdbc42", version.ref = "redshift-jdbc" }
+slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
+snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
+snowflake-jdbc = { module = "net.snowflake:snowflake-jdbc", version.ref = "snowflake" }
+spotless-plugin-gradle = { module = "com.diffplug.spotless:spotless-plugin-gradle", version.ref = "spotless-plugin-gradle" }
+spring-core = { module = "org.springframework:spring-core", version.ref = "spring" }
+spring-jdbc = { module = "org.springframework:spring-jdbc", version.ref = "spring" }
+sqlite-jdbc = { module = "org.xerial:sqlite-jdbc", version.ref = "sqlite-jdbc" }
+system-rules = { module = "com.github.stefanbirkner:system-rules", version.ref = "system-rules" }
+tez-common = { module = "org.apache.tez:tez-common", version.ref = "tez" }
+tez-dag = { module = "org.apache.tez:tez-dag", version.ref = "tez" }
 
 [plugins]
 ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions-plugin" }
-shadow = {id = 'com.github.johnrengelman.shadow', version.ref = "shadow-plugin" }
-version-catalog-update = {id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update-plugin" }
+shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadow-plugin" }
+version-catalog-update = { id = "nl.littlerobots.version-catalog-update", version.ref = "version-catalog-update-plugin" }


### PR DESCRIPTION
This will ease future dependency upgrades, by allowing us to run `./gradlew versionCatalogUpdate`.

This PR does not modify the version numbers of any dependencies, it only moves their declarations to the version catalog. 