### PR TITLE
Bring common CSV version back up to 1.10.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # TO UPGRADE: run ./gradlew versionCatalogUpdate (accepts an --interactive flag)
 [versions]
 apache-commons-compress = "1.18"
-apache-commons-csv = "1.9.0"
+apache-commons-csv = "1.10.0"
 apache-commons-lang3 = "3.8.1"
 auto-service = "1.0.1"
 auto-value = "1.10.2"


### PR DESCRIPTION
The commit 1a99cef4a4e4f8828b98a93d822404ca80ae3889 to make Gradle use a version catalog accidentally downgraded the common CSV library version to 1.9.0 but the license report uses a method signature that was introduced in 1.10.0.