### PR TITLE
Move duration and file size to summary

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -182,6 +182,7 @@ public class MetadataDumper {
       TaskSetState.Impl state = new TaskSetState.Impl();
 
       LOG.info("Using " + connector);
+      SummaryPrinter summaryPrinter = new SummaryPrinter();
       try (Closer closer = Closer.create()) {
         Path outputPath = prepareOutputPath(outputFileLocation, closer, arguments);
 
@@ -203,14 +204,16 @@ public class MetadataDumper {
         new TasksRunner(sinkFactory, handle, arguments.getThreadPoolSize(), state, tasks).run();
       } finally {
         // We must do this in finally after the ZipFileSystem has been closed.
-        File outputFile = new File(outputFileLocation);
-        if (outputFile.isFile()) {
-          LOG.debug("Dumper wrote " + outputFile.length() + " bytes.");
-        }
-        LOG.debug("Dumper took " + stopwatch + ".");
+        summaryPrinter.printSummarySection(
+            linePrinter -> {
+              File outputFile = new File(outputFileLocation);
+              if (outputFile.isFile()) {
+                linePrinter.println("Dumper wrote " + outputFile.length() + " bytes.");
+              }
+              linePrinter.println("Dumper took " + stopwatch + ".");
+            });
       }
 
-      SummaryPrinter summaryPrinter = new SummaryPrinter();
       printTaskResults(summaryPrinter, state);
       printDumperSummary(summaryPrinter, connector, outputFileLocation);
       checkRequiredTaskSuccess(summaryPrinter, state, outputFileLocation);


### PR DESCRIPTION
Before:

```
10:15:31.724 [main] DEBUG com.google.edwmigration.dumper.application.dumper.MetadataDumper - Dumper wrote 9625757 bytes.
10:15:31.725 [main] DEBUG com.google.edwmigration.dumper.application.dumper.MetadataDumper - Dumper took 2.063 min.
********************************************************************
* Task Summary:
* Task SUCCEEDED (REQUIRED) Write compilerworks-format.txt containing 'teradata.dump.zip'.
...
********************************************************************
* Metadata has been saved to /path/to/dwh-migration-teradata-metadata.zip
********************************************************************
* 79 TASKS SUCCEEDED
********************************************************************
```

After:

```
********************************************************************
* Dumper wrote 9625757 bytes.
* Dumper took 2.063 min.
********************************************************************
* Task Summary:
* Task SUCCEEDED (REQUIRED) Write compilerworks-format.txt containing 'teradata.dump.zip'.
...
********************************************************************
* Metadata has been saved to /path/to/dwh-migration-teradata-metadata.zip
********************************************************************
* 79 TASKS SUCCEEDED
********************************************************************
```