### PR TITLE
Add text splitting of the Teradata TableTextV table

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/SplitTextColumnQueryGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/SplitTextColumnQueryGenerator.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.formatQuery;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.math.IntMath;
+import java.math.RoundingMode;
+import java.util.Optional;
+
+/**
+ * Generator for queries that select from the table that contains a column of type VARCHAR, allowing
+ * it to be split into multiple rows in order to avoid exceeding the row size limit.
+ *
+ * <p>In case the VARCHAR column is not split and the 64kB row size limit is exceeded, Teradata
+ * server returns the error: <code>
+ * java.sql.SQLException: [Teradata Database] [TeraJDBC 16.20.00.10] [Error 9804] [SQLState HY000]
+ * Response Row size or Constant Row size overflow.
+ * </code>
+ */
+public class SplitTextColumnQueryGenerator {
+
+  private static final int MAX_PARTS_AFTER_SPLIT = 10;
+
+  private final ImmutableList<String> columnNames;
+  private final String textColumnName;
+  private final String counterColumnName;
+  private final String tableName;
+  private final Optional<String> whereCondition;
+  private final int textColumnOriginalLength;
+  private final int splitTextColumnMaxLength;
+
+  public SplitTextColumnQueryGenerator(
+      ImmutableList<String> columnNames,
+      String textColumnName,
+      String counterColumnName,
+      String tableName,
+      Optional<String> whereCondition,
+      int textColumnOriginalLength,
+      int splitTextColumnMaxLength) {
+    Preconditions.checkArgument(
+        textColumnOriginalLength > 0, "textColumnOriginalLength must be greater than 0");
+    Preconditions.checkArgument(
+        splitTextColumnMaxLength > 0, "splitTextColumnMaxLength must be greater than 0");
+    int partsCount =
+        IntMath.divide(textColumnOriginalLength, splitTextColumnMaxLength, RoundingMode.CEILING);
+    Preconditions.checkArgument(
+        partsCount <= MAX_PARTS_AFTER_SPLIT,
+        "Too many parts after splitting. Original length='%s', splitTextColumnMaxLength='%s',"
+            + " parts count='%s', max parts count='%s'.",
+        textColumnOriginalLength,
+        splitTextColumnMaxLength,
+        partsCount,
+        MAX_PARTS_AFTER_SPLIT);
+    this.columnNames = columnNames;
+    this.textColumnName = textColumnName;
+    this.counterColumnName = counterColumnName;
+    this.tableName = tableName;
+    this.whereCondition = whereCondition;
+    this.textColumnOriginalLength = textColumnOriginalLength;
+    this.splitTextColumnMaxLength = splitTextColumnMaxLength;
+  }
+
+  public String generate() {
+    int partsCount =
+        IntMath.divide(textColumnOriginalLength, splitTextColumnMaxLength, RoundingMode.CEILING);
+    StringBuilder query = new StringBuilder();
+    for (int i = 0; i < partsCount; i++) {
+      if (i > 0) {
+        query.append(" UNION ALL ");
+      }
+      appendSubQuery(query, i, splitTextColumnMaxLength, partsCount);
+    }
+    return formatQuery(query.toString());
+  }
+
+  private void appendSubQuery(StringBuilder query, int partIndex, int length, int partsCount) {
+    query.append("SELECT ").append(String.join(", ", columnNames));
+    if (partsCount > 1) {
+      query
+          .append(", CAST(SUBSTR(")
+          .append(textColumnName)
+          .append(',')
+          .append(1 + partIndex * length)
+          .append(',')
+          .append(length)
+          .append(") AS VARCHAR(")
+          .append(length)
+          .append(")) AS ")
+          .append(textColumnName)
+          .append(", (")
+          .append(counterColumnName)
+          .append(" - 1) * ")
+          .append(partsCount)
+          .append(" + ")
+          .append(partIndex + 1)
+          .append(" AS ")
+          .append(counterColumnName);
+    } else {
+      query.append(", ").append(textColumnName).append(", ").append(counterColumnName);
+    }
+    query.append(" FROM ").append(tableName);
+    whereCondition.ifPresent(condition -> query.append(" WHERE ").append(condition));
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/PropertyParser.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/PropertyParser.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.utils;
+
+import com.google.common.collect.Range;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
+import java.util.OptionalLong;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Parser of the command-line options specified with <code>-D</code> prefix, represented in code as
+ * {@link ConnectorProperty} classes.
+ */
+public class PropertyParser {
+
+  /**
+   * Parses a number passed as an argument to the command-line option and validates that the value
+   * is within the specified range.
+   *
+   * @param arguments all command-line options
+   * @param property command-line option
+   * @param allowedRange range to validate the number against
+   * @return the parsed number or empty, if the option was not provided on the command-line
+   * @throws MetadataDumperUsageException in case of parsing or validation error
+   */
+  public static OptionalLong parseNumber(
+      ConnectorArguments arguments, ConnectorProperty property, Range<Long> allowedRange)
+      throws MetadataDumperUsageException {
+    String stringValue = arguments.getDefinition(property);
+    if (StringUtils.isEmpty(stringValue)) {
+      return OptionalLong.empty();
+    }
+    long value;
+    try {
+      value = Long.parseLong(stringValue);
+    } catch (NumberFormatException ex) {
+      throw new MetadataDumperUsageException(
+          createErrorMessage(stringValue, property, allowedRange));
+    }
+    if (!allowedRange.contains(value)) {
+      throw new MetadataDumperUsageException(
+          createErrorMessage(stringValue, property, allowedRange));
+    }
+    return OptionalLong.of(value);
+  }
+
+  private static String createErrorMessage(
+      String stringValue, ConnectorProperty property, Range<Long> allowedRange) {
+    StringBuilder errorMessage = new StringBuilder();
+    errorMessage
+        .append("ERROR: Option '")
+        .append(property.getName())
+        .append("' accepts only integers");
+    if (!allowedRange.isEmpty()) {
+      errorMessage.append(" in range ").append(allowedRange);
+    }
+    errorMessage.append(". Actual: '").append(stringValue).append("'.");
+    return errorMessage.toString();
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/SplitTextColumnQueryGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/SplitTextColumnQueryGeneratorTest.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.formatQuery;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SplitTextColumnQueryGeneratorTest {
+
+  @Test
+  public void generate_success() {
+    SplitTextColumnQueryGenerator generator =
+        new SplitTextColumnQueryGenerator(
+            ImmutableList.of("SampleColumn"),
+            "Description",
+            "PartNo",
+            "Corpus",
+            /* whereCondition= */ Optional.empty(),
+            /* textColumnOriginalLength= */ 10,
+            /* splitTextColumnMaxLength= */ 5);
+
+    // Act
+    String query = generator.generate();
+
+    // Assert
+    assertEquals(
+        formatQuery(
+            "SELECT SampleColumn,\n"
+                + " CAST(SUBSTR(Description,1,5) AS VARCHAR(5)) AS Description,\n"
+                + " (PartNo - 1) * 2 + 1 AS PartNo FROM Corpus\n"
+                + " UNION ALL\n"
+                + " SELECT SampleColumn,\n"
+                + " CAST(SUBSTR(Description,6,5) AS VARCHAR(5)) AS Description,\n"
+                + " (PartNo - 1) * 2 + 2 AS PartNo FROM Corpus"),
+        query);
+  }
+
+  @Test
+  public void generate_splitLengthGreaterThanOriginalLength() {
+    SplitTextColumnQueryGenerator generator =
+        new SplitTextColumnQueryGenerator(
+            ImmutableList.of("SampleColumn"),
+            "Description",
+            "PartNo",
+            "Corpus",
+            /* whereCondition= */ Optional.empty(),
+            /* textColumnOriginalLength= */ 10,
+            /* splitTextColumnMaxLength= */ 11);
+
+    // Act
+    String query = generator.generate();
+
+    // Assert
+    assertEquals("SELECT SampleColumn, Description, PartNo FROM Corpus", query);
+  }
+
+  @Test
+  public void generate_splitLengthGreaterThanOriginalLengthWithWhereClause() {
+    SplitTextColumnQueryGenerator generator =
+        new SplitTextColumnQueryGenerator(
+            ImmutableList.of("SampleColumn"),
+            "Description",
+            "PartNo",
+            "Corpus",
+            /* whereCondition= */ Optional.of("Description LIKE '%ABC%'"),
+            /* textColumnOriginalLength= */ 10,
+            /* splitTextColumnMaxLength= */ 11);
+
+    // Act
+    String query = generator.generate();
+
+    // Assert
+    assertEquals(
+        "SELECT SampleColumn, Description, PartNo FROM Corpus WHERE Description LIKE '%ABC%'",
+        query);
+  }
+
+  @Test
+  public void generate_twoColumns() {
+    SplitTextColumnQueryGenerator generator =
+        new SplitTextColumnQueryGenerator(
+            ImmutableList.of("SampleColumn1", "SampleColumn2"),
+            "Description",
+            "PartNo",
+            "Corpus",
+            /* whereCondition= */ Optional.empty(),
+            /* textColumnOriginalLength= */ 10,
+            /* splitTextColumnMaxLength= */ 5);
+
+    // Act
+    String query = generator.generate();
+
+    // Assert
+    assertEquals(
+        formatQuery(
+            "SELECT SampleColumn1, SampleColumn2,\n"
+                + " CAST(SUBSTR(Description,1,5) AS VARCHAR(5)) AS Description,\n"
+                + " (PartNo - 1) * 2 + 1 AS PartNo FROM Corpus\n"
+                + " UNION ALL\n"
+                + " SELECT SampleColumn1, SampleColumn2,\n"
+                + " CAST(SUBSTR(Description,6,5) AS VARCHAR(5)) AS Description,\n"
+                + " (PartNo - 1) * 2 + 2 AS PartNo FROM Corpus"),
+        query);
+  }
+
+  @Test
+  public void generate_withWhereClause() {
+    SplitTextColumnQueryGenerator generator =
+        new SplitTextColumnQueryGenerator(
+            ImmutableList.of("SampleColumn"),
+            "Description",
+            "PartNo",
+            "Corpus",
+            /* whereCondition= */ Optional.of("Description LIKE '%DEF%'"),
+            /* textColumnOriginalLength= */ 10,
+            /* splitTextColumnMaxLength= */ 5);
+
+    // Act
+    String query = generator.generate();
+
+    // Assert
+    assertEquals(
+        formatQuery(
+            "SELECT SampleColumn, CAST(SUBSTR(Description,1,5) AS VARCHAR(5)) AS Description,\n"
+                + " (PartNo - 1) * 2 + 1 AS PartNo FROM Corpus WHERE Description LIKE '%DEF%'\n"
+                + " UNION ALL\n"
+                + " SELECT SampleColumn,\n"
+                + " CAST(SUBSTR(Description,6,5) AS VARCHAR(5)) AS Description,\n"
+                + " (PartNo - 1) * 2 + 2 AS PartNo FROM Corpus WHERE Description LIKE '%DEF%'"),
+        query);
+  }
+
+  @Test
+  public void generate_threeParts() {
+    SplitTextColumnQueryGenerator generator =
+        new SplitTextColumnQueryGenerator(
+            ImmutableList.of("SampleColumn"),
+            "Description",
+            "PartNo",
+            "Corpus",
+            /* whereCondition= */ Optional.empty(),
+            /* textColumnOriginalLength= */ 100,
+            /* splitTextColumnMaxLength= */ 40);
+
+    // Act
+    String query = generator.generate();
+
+    // Assert
+    assertEquals(
+        formatQuery(
+            "SELECT SampleColumn,\n"
+                + " CAST(SUBSTR(Description,1,40) AS VARCHAR(40)) AS Description,\n"
+                + " (PartNo - 1) * 3 + 1 AS PartNo FROM Corpus\n"
+                + " UNION ALL\n"
+                + " SELECT SampleColumn,\n"
+                + " CAST(SUBSTR(Description,41,40) AS VARCHAR(40)) AS Description,\n"
+                + " (PartNo - 1) * 3 + 2 AS PartNo FROM Corpus"
+                + " UNION ALL\n"
+                + " SELECT SampleColumn,\n"
+                + " CAST(SUBSTR(Description,81,40) AS VARCHAR(40)) AS Description,\n"
+                + " (PartNo - 1) * 3 + 3 AS PartNo FROM Corpus"),
+        query);
+  }
+
+  @Test
+  public void generate_originalLengthZero_fail() {
+    // Act
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new SplitTextColumnQueryGenerator(
+                    ImmutableList.of("SampleColumn"),
+                    "Description",
+                    "PartNo",
+                    "Corpus",
+                    /* whereCondition= */ Optional.empty(),
+                    /* textColumnOriginalLength= */ 0,
+                    /* splitTextColumnMaxLength= */ 5));
+
+    // Assert
+    assertEquals("textColumnOriginalLength must be greater than 0", e.getMessage());
+  }
+
+  @Test
+  public void generate_splitLengthZero_fail() {
+    // Act
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new SplitTextColumnQueryGenerator(
+                    ImmutableList.of("SampleColumn"),
+                    "Description",
+                    "PartNo",
+                    "Corpus",
+                    /* whereCondition= */ Optional.empty(),
+                    /* textColumnOriginalLength= */ 1,
+                    /* splitTextColumnMaxLength= */ 0));
+
+    // Assert
+    assertEquals("splitTextColumnMaxLength must be greater than 0", e.getMessage());
+  }
+
+  @Test
+  public void generate_tooManyParts_fail() {
+    // Act
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class,
+            () ->
+                new SplitTextColumnQueryGenerator(
+                    ImmutableList.of("SampleColumn"),
+                    "Description",
+                    "PartNo",
+                    "Corpus",
+                    /* whereCondition= */ Optional.empty(),
+                    /* textColumnOriginalLength= */ 11,
+                    /* splitTextColumnMaxLength= */ 1));
+
+    // Assert
+    assertEquals(
+        "Too many parts after splitting. Original length='11', splitTextColumnMaxLength='1',"
+            + " parts count='11', max parts count='10'.",
+        e.getMessage());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/util/PropertyParserTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/util/PropertyParserTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataMetadataConnector.TeradataMetadataConnectorProperties;
+import com.google.edwmigration.dumper.application.dumper.utils.PropertyParser;
+import java.io.IOException;
+import java.util.OptionalLong;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+@RunWith(Theories.class)
+public class PropertyParserTest {
+
+  @Test
+  public void parseNumber_success() throws IOException, MetadataDumperUsageException {
+    ConnectorArguments arguments =
+        new ConnectorArguments(
+            "--connector", "teradata", "-Dteradata.metadata.max-text-length=2000");
+
+    // Act
+    OptionalLong value =
+        PropertyParser.parseNumber(
+            arguments,
+            TeradataMetadataConnectorProperties.MAX_TEXT_LENGTH,
+            Range.closed(1000L, 3000L));
+
+    // Assert
+    assertEquals(OptionalLong.of(2000), value);
+  }
+
+  @Test
+  public void parseNumber_noValueSpecified() throws IOException, MetadataDumperUsageException {
+    ConnectorArguments arguments = new ConnectorArguments("--connector", "teradata");
+
+    // Act
+    OptionalLong value =
+        PropertyParser.parseNumber(
+            arguments,
+            TeradataMetadataConnectorProperties.MAX_TEXT_LENGTH,
+            Range.closed(1000L, 3000L));
+
+    // Assert
+    assertEquals(OptionalLong.empty(), value);
+  }
+
+  @DataPoints("failureTestCases")
+  public static final ImmutableList<TestCase> FAILURE_TEST_CASES =
+      ImmutableList.of(
+          TestCase.create(
+              0L,
+              Range.closed(3L, 4L),
+              "ERROR: Option 'teradata.metadata.max-text-length' accepts only integers in range [3..4]. Actual: '0'."),
+          TestCase.create(
+              1L,
+              Range.closed(3L, 4L),
+              "ERROR: Option 'teradata.metadata.max-text-length' accepts only integers in range [3..4]. Actual: '1'."),
+          TestCase.create(
+              5L,
+              Range.closed(3L, 4L),
+              "ERROR: Option 'teradata.metadata.max-text-length' accepts only integers in range [3..4]. Actual: '5'."),
+          TestCase.create(
+              1L,
+              Range.atLeast(2L),
+              "ERROR: Option 'teradata.metadata.max-text-length' accepts only integers in range [2..+∞). Actual: '1'."));
+
+  @Theory
+  public void parseNumber_fail(@FromDataPoints("failureTestCases") TestCase testCase)
+      throws IOException {
+    ConnectorArguments arguments =
+        new ConnectorArguments(
+            "--connector",
+            "teradata",
+            "-Dteradata.metadata.max-text-length=" + testCase.maxTextLength());
+
+    // Act
+    MetadataDumperUsageException e =
+        assertThrows(
+            MetadataDumperUsageException.class,
+            () ->
+                PropertyParser.parseNumber(
+                    arguments,
+                    TeradataMetadataConnectorProperties.MAX_TEXT_LENGTH,
+                    testCase.allowedValues()));
+
+    // Assert
+    assertEquals(testCase.expectedErrorMessage(), e.getMessage());
+  }
+
+  @AutoValue
+  abstract static class TestCase {
+    abstract long maxTextLength();
+
+    abstract Range<Long> allowedValues();
+
+    abstract String expectedErrorMessage();
+
+    static TestCase create(
+        long maxTextLength, Range<Long> allowedValues, String expectedErrorMessage) {
+      return new AutoValue_PropertyParserTest_TestCase(
+          maxTextLength, allowedValues, expectedErrorMessage);
+    }
+  }
+}


### PR DESCRIPTION
The `RequestText` column of the `dbc.TableTextV` table may need splitting due to 64kB row size limit on Teradata 15. This change introduces a new command-line option that allows for splitting this column into multiple rows if the length is longer than the specified max length.

By default, if the option is not used the column is extracted as is, which may reach 32000 characters. With the option, the column is split into multiple rows. The max length can be any integer between 5000 and 30000 characters.

Example usage:
```
-Dteradata.metadata.max-text-length=7000
```