### PR TITLE
Add splitting of long SQL queries in DBQLSqlTbl

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
@@ -21,6 +21,7 @@ import static com.google.edwmigration.dumper.application.dumper.connector.terada
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.function.Predicate;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -162,8 +163,18 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
       List<String> conditions,
       ZonedInterval interval,
       @CheckForNull String logDateColumn,
+      OptionalLong maxSqlLength,
       List<String> orderBy) {
-    super(targetPath, state, logTable, queryTable, conditions, interval, logDateColumn, orderBy);
+    super(
+        targetPath,
+        state,
+        logTable,
+        queryTable,
+        conditions,
+        interval,
+        logDateColumn,
+        maxSqlLength,
+        orderBy);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.formatQuery;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.optionalIf;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
@@ -42,7 +43,6 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.TeradataMetadataDump
 import java.util.List;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 
 /** @author miguel */
@@ -70,7 +70,7 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
     MAX_TEXT_LENGTH(
         "max-text-length",
         "Max length of the text column when dumping TableTextV view."
-            + " Text that is longer than the defined limit will be split."
+            + " Text that is longer than the defined limit will be split into multiple rows."
             + " Example: 10000. Allowed range: "
             + MAX_TEXT_LENGTH_RANGE
             + ".");
@@ -261,10 +261,6 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
     }
     return new TeradataJdbcSelectTask(
         TableTextVFormat.ZIP_ENTRY_NAME, TaskCategory.REQUIRED, query);
-  }
-
-  private static <T> Optional<T> optionalIf(boolean condition, Supplier<T> supplier) {
-    return condition ? Optional.of(supplier.get()) : Optional.empty();
   }
 
   private static String escapeStringLiteral(String s) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtils.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtils.java
@@ -18,8 +18,13 @@ package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
 import com.google.common.base.Preconditions;
 import java.util.Optional;
+import java.util.function.Supplier;
 
 class TeradataUtils {
+
+  public static <T> Optional<T> optionalIf(boolean condition, Supplier<T> supplier) {
+    return condition ? Optional.of(supplier.get()) : Optional.empty();
+  }
 
   /**
    * Formats the query by:


### PR DESCRIPTION
The `SqlTextInfo` column of the `dbc.DBQLSqlTbl` table may need splitting due to 64kB row size limit on Teradata 15. This change introduces a new command-line option that allows for splitting this column into multiple rows if the length is longer than the specified max length.

By default, if the option is not used the column is extracted as is, which may reach 31000 characters. With the option, the column is split into multiple rows. The max length can be any integer between 5000 and 30000 characters.

Example usage:

```
-Dteradata-logs.max-sql-length=7000
```