### PR TITLE
Use query builder for DatabasesV query

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/MetadataQueryGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/MetadataQueryGenerator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.and;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.eq;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.identifier;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.selectAll;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.star;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.stringLiteral;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.subquery;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.select;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.selectTop;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.union;
+
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Expression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.OrderBySpec;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.OrderBySpec.Direction;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.FromClauseStepBuilder;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/** Generator of queries used during dumping metadata from Teradata. */
+class MetadataQueryGenerator {
+
+  static final String DBC_INFO_QUERY =
+      select(
+              stringLiteral("teradata").as("dialect"),
+              identifier("InfoData").as("version"),
+              identifier("CURRENT_TIMESTAMP").as("export_time"))
+          .from("dbc.dbcinfo")
+          .where(eq(identifier("InfoKey"), stringLiteral("VERSION")))
+          .serialize();
+
+  static String createSelectForDatabasesV(
+      OptionalLong userRows, OptionalLong dbRows, Optional<Expression> condition) {
+    String tableName = "DBC.DatabasesV";
+    if (!userRows.isPresent() && !dbRows.isPresent()) {
+      FromClauseStepBuilder partialQuery = select("%s").from(tableName);
+      return condition.map(partialQuery::where).orElse(partialQuery).serialize();
+    }
+    SelectExpression usersSelect = createSingleDbKindSelectFromDatabasesV("U", userRows, condition);
+    SelectExpression dbsSelect = createSingleDbKindSelectFromDatabasesV("D", dbRows, condition);
+    return select("%s")
+        .from(
+            subquery(
+                union(
+                    selectAll().from(subquery(usersSelect)).as("users").build(),
+                    selectAll().from(subquery(dbsSelect)).as("dbs").build())))
+        .as("t")
+        .serialize();
+  }
+
+  private static SelectExpression createSingleDbKindSelectFromDatabasesV(
+      String dbKind, OptionalLong rowCount, Optional<Expression> condition) {
+    String tableName = "DBC.DatabasesV";
+    Expression dbKindCondition = eq(identifier("DBKind"), stringLiteral(dbKind));
+    Expression processedCondition =
+        condition
+            .<Expression>map(innerCondition -> and(innerCondition, dbKindCondition))
+            .orElse(dbKindCondition);
+    if (rowCount.isPresent()) {
+      return selectTop(rowCount.getAsLong(), projection(star()))
+          .from(tableName)
+          .where(processedCondition)
+          .orderBy(OrderBySpec.create(identifier("PermSpace"), Direction.DESC));
+    } else {
+      return selectAll().from(tableName).where(processedCondition).build();
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtils.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtils.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import java.util.Optional;
 import java.util.function.Supplier;
 
-class TeradataUtils {
+public class TeradataUtils {
 
   public static <T> Optional<T> optionalIf(boolean condition, Supplier<T> supplier) {
     return condition ? Optional.of(supplier.get()) : Optional.empty();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/ExpressionSerializer.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/ExpressionSerializer.java
@@ -16,15 +16,26 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.formatQuery;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.OrderBySpec.Direction.DESC;
+
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.BinaryExpression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Expression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Identifier;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.InExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.NaryExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.OrderBySpec;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Projection;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectSubqueryExpression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SourceSpec;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.StringLiteral;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SubqueryExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SubquerySourceSpec;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.TableSourceSpec;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.UnionExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.UnionSubqueryExpression;
 import java.util.Optional;
 import java.util.function.Consumer;
 
@@ -44,10 +55,11 @@ public class ExpressionSerializer {
   String serialize() {
     serializedQuery = new StringBuilder();
     append(expression);
-    return serializedQuery.toString();
+    return formatQuery(serializedQuery.toString());
   }
 
   private void append(Expression expr) {
+    serializedQuery.append(' ');
     if (expr instanceof SelectExpression) {
       append((SelectExpression) expression);
     } else if (expr instanceof StringLiteral) {
@@ -56,13 +68,31 @@ public class ExpressionSerializer {
       serializedQuery.append(((Identifier) expr).name());
     } else if (expr instanceof BinaryExpression) {
       append(((BinaryExpression) expr));
+    } else if (expr instanceof UnionExpression) {
+      append(((UnionExpression) expr));
+    } else if (expr instanceof SubqueryExpression) {
+      append(((SubqueryExpression) expr));
+    } else if (expr instanceof NaryExpression) {
+      append(((NaryExpression) expr));
+    } else if (expr instanceof InExpression) {
+      append(((InExpression) expr));
     } else {
       throw new IllegalArgumentException(String.format("Unsupported expression type: '%s'.", expr));
     }
   }
 
+  private void append(InExpression expr) {
+    append(expr.lhs());
+    serializedQuery.append(" IN (");
+    appendCommaSeparated(expr.items(), this::append);
+    serializedQuery.append(')');
+  }
+
+  private void append(NaryExpression expr) {
+    appendWithSeparators(expr.subexpressions(), expr.operator().name(), this::append);
+  }
+
   private void append(BinaryExpression expr) {
-    appendSpaceIfNecessary();
     append(expr.lhs());
     serializedQuery.append(' ');
     serializedQuery.append(expr.operator());
@@ -70,8 +100,27 @@ public class ExpressionSerializer {
     append(expr.rhs());
   }
 
+  private void append(SubqueryExpression expr) {
+    serializedQuery.append('(');
+    if (expr instanceof SelectSubqueryExpression) {
+      append(((SelectSubqueryExpression) expr).selectExpression());
+    } else if (expr instanceof UnionSubqueryExpression) {
+      append(((UnionSubqueryExpression) expr).unionExpression());
+    } else {
+      throw new IllegalStateException(String.format("Unsupported subquery expression '%s'", expr));
+    }
+    serializedQuery.append(')');
+  }
+
+  private void append(UnionExpression expr) {
+    appendWithSeparators(expr.selectExpressions(), "UNION ALL", this::append);
+  }
+
   private void append(SelectExpression selectExpression) {
     serializedQuery.append("SELECT");
+    selectExpression
+        .topRowCount()
+        .ifPresent(rowCount -> serializedQuery.append(" TOP ").append(rowCount));
     appendCommaSeparated(selectExpression.projections(), this::append);
     selectExpression
         .sourceSpec()
@@ -87,18 +136,36 @@ public class ExpressionSerializer {
               serializedQuery.append(" WHERE");
               append(condition);
             });
+    if (!selectExpression.orderBySpecs().isEmpty()) {
+      serializedQuery.append(" ORDER BY");
+      appendCommaSeparated(selectExpression.orderBySpecs(), this::append);
+    }
+  }
+
+  private void append(OrderBySpec orderBySpec) {
+    append(orderBySpec.expression());
+    if (orderBySpec.direction() == DESC) {
+      serializedQuery.append(" DESC");
+    }
   }
 
   private void append(SourceSpec sourceSpec) {
+    serializedQuery.append(' ');
     if (sourceSpec instanceof TableSourceSpec) {
       append((TableSourceSpec) sourceSpec);
+    } else if (sourceSpec instanceof SubquerySourceSpec) {
+      append((SubquerySourceSpec) sourceSpec);
     } else {
       throw new IllegalStateException(String.format("Unsupported source spec='%s'.", sourceSpec));
     }
   }
 
+  private void append(SubquerySourceSpec sourceSpec) {
+    append(sourceSpec.subqueryExpression());
+    append(sourceSpec.alias());
+  }
+
   private void append(TableSourceSpec tableSourceSpec) {
-    serializedQuery.append(' ');
     append(tableSourceSpec.tableName());
     append(tableSourceSpec.alias());
   }
@@ -112,19 +179,21 @@ public class ExpressionSerializer {
     aliasMaybe.ifPresent(alias -> serializedQuery.append(" AS ").append(alias));
   }
 
-  private void appendSpaceIfNecessary() {
-    if (serializedQuery.length() > 0) {
-      serializedQuery.append(' ');
-    }
+  private <T> void appendCommaSeparated(ImmutableList<T> list, Consumer<T> appender) {
+    appendWithSeparators(list, ",", appender);
   }
 
-  private <T> void appendCommaSeparated(ImmutableList<T> list, Consumer<T> appender) {
+  private <T> void appendWithSeparators(
+      ImmutableList<T> list, String separator, Consumer<T> appender) {
     boolean first = true;
     for (T element : list) {
       if (first) {
         first = false;
       } else {
-        serializedQuery.append(',');
+        if (!separator.equals(",")) {
+          serializedQuery.append(' ');
+        }
+        serializedQuery.append(separator);
       }
       serializedQuery.append(' ');
       appender.accept(element);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/TeradataSelectBuilder.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/TeradataSelectBuilder.java
@@ -16,13 +16,29 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.NaryExpression.NaryOperator.AND;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.select;
+
+import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.BinaryExpression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Expression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Identifier;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.InExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.NaryExpression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.Projection;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.SelectBuilder;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectSubqueryExpression;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.StringLiteral;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SubqueryExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SubquerySourceSpec;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.UnionExpression;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.UnionSubqueryExpression;
+import java.util.List;
 import java.util.Optional;
 
+/** Shortcuts for building the Teradata query. */
 public class TeradataSelectBuilder {
 
   public static Identifier identifier(String name) {
@@ -41,7 +57,43 @@ public class TeradataSelectBuilder {
     return BinaryExpression.create(lhs, "=", rhs);
   }
 
+  public static Expression in(Expression lhs, List<String> literals) {
+    return InExpression.create(
+        lhs,
+        literals.stream().map(TeradataSelectBuilder::stringLiteral).collect(toImmutableList()));
+  }
+
   public static StringLiteral stringLiteral(String value) {
     return StringLiteral.create(value);
+  }
+
+  public static SubquerySourceSpec subquerySource(SelectExpression selectExpression) {
+    return SubquerySourceSpec.create(
+        SelectSubqueryExpression.create(selectExpression), /* alias= */ Optional.empty());
+  }
+
+  public static SubquerySourceSpec subquerySource(UnionExpression unionExpression) {
+    return SubquerySourceSpec.create(
+        UnionSubqueryExpression.create(unionExpression), /* alias= */ Optional.empty());
+  }
+
+  public static SubqueryExpression subquery(UnionExpression unionExpression) {
+    return UnionSubqueryExpression.create(unionExpression);
+  }
+
+  public static SubqueryExpression subquery(SelectExpression selectExpression) {
+    return SelectSubqueryExpression.create(selectExpression);
+  }
+
+  public static NaryExpression and(Expression... subexpressions) {
+    return NaryExpression.create(AND, ImmutableList.copyOf(subexpressions));
+  }
+
+  public static Identifier star() {
+    return identifier("*");
+  }
+
+  public static SelectBuilder selectAll() {
+    return select(projection(star()));
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/InExpression.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/InExpression.java
@@ -16,11 +16,16 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
-public interface Expression {
+@AutoValue
+public abstract class InExpression implements Expression {
+  public abstract Expression lhs();
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public abstract ImmutableList<Expression> items();
+
+  public static InExpression create(Expression lhs, ImmutableList<Expression> items) {
+    return new AutoValue_InExpression(lhs, items);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/NaryExpression.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/NaryExpression.java
@@ -16,11 +16,22 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
-public interface Expression {
+@AutoValue
+public abstract class NaryExpression implements Expression {
+  public abstract NaryOperator operator();
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public abstract ImmutableList<Expression> subexpressions();
+
+  public static NaryExpression create(
+      NaryOperator operator, ImmutableList<Expression> subexpressions) {
+    return new AutoValue_NaryExpression(operator, subexpressions);
+  }
+
+  public enum NaryOperator {
+    AND,
+    OR
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/OrderBySpec.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/OrderBySpec.java
@@ -16,11 +16,25 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
 
-public interface Expression {
+@AutoValue
+public abstract class OrderBySpec {
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public abstract Expression expression();
+
+  public abstract Direction direction();
+
+  public static OrderBySpec create(Expression expression) {
+    return create(expression, Direction.ASC);
+  }
+
+  public static OrderBySpec create(Expression expression, Direction direction) {
+    return new AutoValue_OrderBySpec(expression, direction);
+  }
+
+  public enum Direction {
+    DESC,
+    ASC
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SelectSubqueryExpression.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SelectSubqueryExpression.java
@@ -16,11 +16,13 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
 
-public interface Expression {
+@AutoValue
+public abstract class SelectSubqueryExpression implements SubqueryExpression {
+  public abstract SelectExpression selectExpression();
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public static SelectSubqueryExpression create(SelectExpression selectExpression) {
+    return new AutoValue_SelectSubqueryExpression(selectExpression);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SubqueryExpression.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SubqueryExpression.java
@@ -16,11 +16,4 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
-
-public interface Expression {
-
-  default Projection as(String alias) {
-    return projection(this, alias);
-  }
-}
+public interface SubqueryExpression extends Expression {}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SubquerySourceSpec.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SubquerySourceSpec.java
@@ -16,11 +16,21 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
+import java.util.Optional;
 
-public interface Expression {
+@AutoValue
+public abstract class SubquerySourceSpec implements SourceSpec {
+  public abstract SubqueryExpression subqueryExpression();
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public abstract Optional<String> alias();
+
+  public static SubquerySourceSpec create(
+      SubqueryExpression subqueryExpression, Optional<String> alias) {
+    return new AutoValue_SubquerySourceSpec(subqueryExpression, alias);
+  }
+
+  public SubquerySourceSpec as(String alias) {
+    return create(subqueryExpression(), Optional.of(alias));
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/UnionExpression.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/UnionExpression.java
@@ -16,11 +16,14 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 
-public interface Expression {
+@AutoValue
+public abstract class UnionExpression implements Expression {
+  public abstract ImmutableList<SelectExpression> selectExpressions();
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public static UnionExpression create(ImmutableList<SelectExpression> selectExpressions) {
+    return new AutoValue_UnionExpression(selectExpressions);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/UnionSubqueryExpression.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/UnionSubqueryExpression.java
@@ -16,11 +16,13 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.projection;
+import com.google.auto.value.AutoValue;
 
-public interface Expression {
+@AutoValue
+public abstract class UnionSubqueryExpression implements SubqueryExpression {
+  public abstract UnionExpression unionExpression();
 
-  default Projection as(String alias) {
-    return projection(this, alias);
+  public static UnionSubqueryExpression create(UnionExpression unionExpression) {
+    return new AutoValue_UnionSubqueryExpression(unionExpression);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/MetadataQueryGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/MetadataQueryGeneratorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.MetadataQueryGenerator.DBC_INFO_QUERY;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.eq;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.identifier;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.in;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.TeradataSelectBuilder.stringLiteral;
+import static com.google.edwmigration.dumper.application.dumper.test.DumperTestUtils.assertQueryEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import java.util.OptionalLong;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MetadataQueryGeneratorTest {
+
+  @Test
+  public void createSelectForDatabasesV_noLimits() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.empty(),
+            /* dbRows= */ OptionalLong.empty(),
+            /* condition= */ Optional.empty());
+
+    assertQueryEquals("SELECT %s FROM DBC.DatabasesV", query);
+  }
+
+  @Test
+  public void createSelectForDatabasesV_condition() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.empty(),
+            /* dbRows= */ OptionalLong.empty(),
+            /* condition= */ Optional.of(eq(identifier("DatabaseName"), stringLiteral("abc"))));
+
+    assertQueryEquals("SELECT %s FROM DBC.DatabasesV WHERE DatabaseName = 'abc'", query);
+  }
+
+  @Test
+  public void createSelectForDatabasesV_usersLimit() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.of(13),
+            /* dbRows= */ OptionalLong.empty(),
+            /* condition= */ Optional.empty());
+
+    assertQueryEquals(
+        "SELECT %s FROM ("
+            + " SELECT * FROM (SELECT TOP 13 * FROM DBC.DatabasesV"
+            + "   WHERE DBKind = 'U' ORDER BY PermSpace DESC) AS users"
+            + " UNION ALL "
+            + " SELECT * FROM (SELECT * FROM DBC.DatabasesV WHERE DBKind = 'D') AS dbs"
+            + ") AS t",
+        query);
+  }
+
+  @Test
+  public void createSelectForDatabasesV_usersLimitAndCondition() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.of(13),
+            /* dbRows= */ OptionalLong.empty(),
+            /* condition= */ Optional.of(eq(identifier("DatabaseName"), stringLiteral("abc"))));
+
+    assertQueryEquals(
+        "SELECT %s FROM ("
+            + " SELECT * FROM (SELECT TOP 13 * FROM DBC.DatabasesV"
+            + "   WHERE DatabaseName = 'abc' AND DBKind = 'U' ORDER BY PermSpace DESC) AS users"
+            + " UNION ALL "
+            + " SELECT * FROM (SELECT * FROM DBC.DatabasesV"
+            + "   WHERE DatabaseName = 'abc' AND DBKind = 'D') AS dbs"
+            + ") AS t",
+        query);
+  }
+
+  @Test
+  public void createSelectForDatabasesV_dbsLimit() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.empty(),
+            /* dbRows= */ OptionalLong.of(18),
+            /* condition= */ Optional.empty());
+
+    assertQueryEquals(
+        "SELECT %s FROM ("
+            + " SELECT * FROM (SELECT * FROM DBC.DatabasesV WHERE DBKind = 'U') AS users"
+            + " UNION ALL "
+            + " SELECT * FROM (SELECT TOP 18 * FROM DBC.DatabasesV"
+            + "   WHERE DBKind = 'D' ORDER BY PermSpace DESC) AS dbs"
+            + ") AS t",
+        query);
+  }
+
+  @Test
+  public void createSelectForDatabasesV_usersAndDbsLimit() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.of(15),
+            /* dbRows= */ OptionalLong.of(18),
+            /* condition= */ Optional.empty());
+
+    assertQueryEquals(
+        "SELECT %s FROM ("
+            + " SELECT * FROM (SELECT TOP 15 * FROM DBC.DatabasesV"
+            + "   WHERE DBKind = 'U' ORDER BY PermSpace DESC) AS users"
+            + " UNION ALL "
+            + " SELECT * FROM (SELECT TOP 18 * FROM DBC.DatabasesV"
+            + "   WHERE DBKind = 'D' ORDER BY PermSpace DESC) AS dbs"
+            + ") AS t",
+        query);
+  }
+
+  @Test
+  public void createSelectForDatabasesV_usersAndDbsLimitAndCondition() {
+    String query =
+        MetadataQueryGenerator.createSelectForDatabasesV(
+            /* userRows= */ OptionalLong.of(15),
+            /* dbRows= */ OptionalLong.of(18),
+            /* condition= */ Optional.of(
+                in(identifier("DatabaseName"), ImmutableList.of("db1", "db2"))));
+
+    assertQueryEquals(
+        "SELECT %s FROM ("
+            + " SELECT * FROM (SELECT TOP 15 * FROM DBC.DatabasesV"
+            + "   WHERE DatabaseName IN ('db1', 'db2') AND DBKind = 'U'"
+            + "   ORDER BY PermSpace DESC) AS users"
+            + " UNION ALL "
+            + " SELECT * FROM (SELECT TOP 18 * FROM DBC.DatabasesV"
+            + "   WHERE DatabaseName IN ('db1', 'db2') AND DBKind = 'D'"
+            + "   ORDER BY PermSpace DESC) AS dbs"
+            + ") AS t",
+        query);
+  }
+
+  @Test
+  public void dbcInfoQuery() {
+    assertQueryEquals(
+        "SELECT 'teradata' AS dialect, InfoData AS version, CURRENT_TIMESTAMP AS export_time"
+            + " FROM dbc.dbcinfo WHERE InfoKey = 'VERSION'",
+        DBC_INFO_QUERY);
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SelectExpressionTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/query/model/SelectExpressionTest.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.select;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.query.model.SelectExpression.selectTop;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -33,5 +34,12 @@ public class SelectExpressionTest {
         assertThrows(IllegalStateException.class, () -> select(new String[0]).build());
 
     assertEquals("SELECT requires at least one projection.", e.getMessage());
+  }
+
+  @Test
+  public void select_topZero_fail() {
+    IllegalStateException e = assertThrows(IllegalStateException.class, () -> selectTop(0).build());
+
+    assertEquals("SELECT TOP must use positive integer.", e.getMessage());
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/test/DumperTestUtils.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/test/DumperTestUtils.java
@@ -16,6 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.test;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.formatQuery;
+import static org.junit.Assert.assertEquals;
+
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.test.TestUtils;
 import java.io.File;
@@ -71,5 +74,9 @@ public class DumperTestUtils {
         }
       }
     };
+  }
+
+  public static void assertQueryEquals(String expectedQuery, String actualQuery) {
+    assertEquals(formatQuery(expectedQuery), formatQuery(actualQuery));
   }
 }


### PR DESCRIPTION
Refactoring that replaces DatabasesV query generation from StringBuilder to query builder.

The change also fixes the issue with the missing `AND` operator in the `WHERE` clause.