### PR TITLE
[Dumper] [Hive] Extract hive table SerDe details

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -201,6 +201,10 @@ public class HiveMetadataConnector extends AbstractHiveConnector
               outTable.bucketsCount = table.getBucketsCount();
               outTable.isCompressed = table.isCompressed();
 
+              outTable.serializationLib = table.getSerializationLib();
+              outTable.inputFormat = table.getInputFormat();
+              outTable.outputFormat = table.getOutputFormat();
+
               outTable.fields = new ArrayList<>();
               for (Field field : table.getFields()) {
                 TableMetadata.FieldMetadata fieldMetadata = new TableMetadata.FieldMetadata();

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/HiveMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/HiveMetadataDumpFormat.java
@@ -122,6 +122,10 @@ public interface HiveMetadataDumpFormat {
       @CheckForNull public Integer bucketsCount;
       @CheckForNull public Boolean isCompressed;
 
+      @CheckForNull public String serializationLib;
+      @CheckForNull public String inputFormat;
+      @CheckForNull public String outputFormat;
+
       @CheckForNull public List<FieldMetadata> fields;
       @CheckForNull public List<PartitionKeyMetadata> partitionKeys;
       @CheckForNull public List<PartitionMetadata> partitions;

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -179,7 +179,6 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
       @CheckForNull
       @Override
       public String getLocation() {
-        table.getSd().getSerdeInfo().getName();
         return (table.isSetSd() && table.getSd().isSetLocation()
             ? table.getSd().getLocation()
             : null);

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -179,6 +179,7 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
       @CheckForNull
       @Override
       public String getLocation() {
+        table.getSd().getSerdeInfo().getName();
         return (table.isSetSd() && table.getSd().isSetLocation()
             ? table.getSd().getLocation()
             : null);
@@ -236,6 +237,30 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
       @Override
       public Boolean isCompressed() {
         return table.isSetSd() && table.getSd().isCompressed();
+      }
+
+      @CheckForNull
+      @Override
+      public String getSerializationLib(){
+        return (table.isSetSd() && table.getSd().isSetSerdeInfo() && table.getSd().getSerdeInfo().isSetSerializationLib()
+            ? table.getSd().getSerdeInfo().getSerializationLib()
+            : null);
+      }
+
+      @CheckForNull
+      @Override
+      public String getInputFormat(){
+        return (table.isSetSd() && table.getSd().isSetInputFormat()
+            ? table.getSd().getInputFormat()
+            : null);
+      }
+
+      @CheckForNull
+      @Override
+      public String getOutputFormat(){
+        return (table.isSetSd() && table.getSd().isSetOutputFormat()
+            ? table.getSd().getOutputFormat()
+            : null);
       }
 
       @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -237,6 +237,31 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
         return table.isSetSd() && table.getSd().isCompressed();
       }
 
+      @CheckForNull
+      @Override
+      public String getSerializationLib(){
+        return (table.isSetSd() && table.getSd().isSetSerdeInfo() && table.getSd().getSerdeInfo().isSetSerializationLib()
+            ? table.getSd().getSerdeInfo().getSerializationLib()
+            : null);
+      }
+
+      @CheckForNull
+      @Override
+      public String getInputFormat(){
+        return (table.isSetSd() && table.getSd().isSetInputFormat()
+            ? table.getSd().getInputFormat()
+            : null);
+      }
+
+      @CheckForNull
+      @Override
+      public String getOutputFormat(){
+        return (table.isSetSd() && table.getSd().isSetOutputFormat()
+            ? table.getSd().getOutputFormat()
+            : null);
+      }
+
+
       @Nonnull
       @Override
       public List<? extends Field> getFields() throws Exception {

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
@@ -73,6 +73,15 @@ public interface Table {
   @CheckForNull
   public Boolean isCompressed();
 
+  @CheckForNull
+  public String getSerializationLib();
+
+  @CheckForNull
+  public String getInputFormat();
+
+  @CheckForNull
+  public String getOutputFormat();
+
   @Nonnull
   public List<? extends Field> getFields() throws Exception;
 


### PR DESCRIPTION
Update Hive connector to extract Hive table StorageDescriptor details for SerDe and Input/Output formats. This will help in importing hive table metadata into DPMS.

