### PR TITLE
Return exit status 1 if extraction failed

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
@@ -35,8 +35,8 @@ public class Main {
     this.metadataDumper = metadataDumper;
   }
 
-  public void run(@Nonnull String... args) throws Exception {
-    metadataDumper.run(args);
+  public boolean run(@Nonnull String... args) throws Exception {
+    return metadataDumper.run(args);
   }
 
   private static void printErrorMessages(Throwable e) {
@@ -61,20 +61,22 @@ public class Main {
   public static void main(String... args) throws Exception {
     try {
       Main main = new Main(new MetadataDumper());
-      // LOG.debug("Arguments are: [" + String.join("] [", args) + "]");
-      // Without this, the dumper prints "Missing required arguments:[connector]"
       if (args.length == 0) {
         args = new String[] {"--help"};
       }
-      main.run(args);
+      if (!main.run(args)) {
+        System.exit(1);
+      }
     } catch (MetadataDumperUsageException e) {
       LOG.error(e.getMessage());
       for (String msg : e.getMessages()) {
         LOG.error(msg);
       }
+      System.exit(1);
     } catch (Exception e) {
       e.printStackTrace();
       printErrorMessages(e);
+      System.exit(1);
     }
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperTest.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper;
 
+import static org.junit.Assert.assertTrue;
+
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.bigquery.BigQueryLogsConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.hive.HiveMetadataConnector;
@@ -34,7 +36,7 @@ public class MetadataDumperTest {
 
   // TODO(ishmum): `testOverridesZipWithGivenName` with content check
   private File file;
-  private Main dumper = new Main(new MetadataDumper().withExitOnError(false));
+  private Main dumper = new Main(new MetadataDumper());
   private final Connector connector = new HiveMetadataConnector();
   private final String defaultFileName = "dwh-migration-hiveql-metadata.zip";
 
@@ -48,7 +50,8 @@ public class MetadataDumperTest {
   @Test
   public void testInstantiate() throws Exception {
     dumper = new Main(new MetadataDumper());
-    dumper.run("--connector", new BigQueryLogsConnector().getName(), "--dry-run");
+    boolean result = dumper.run("--connector", new BigQueryLogsConnector().getName(), "--dry-run");
+    assertTrue(result);
   }
 
   @Test
@@ -60,7 +63,7 @@ public class MetadataDumperTest {
     dumper.run("--connector", connector.getName());
 
     // Assert
-    Assert.assertTrue(file.exists());
+    assertTrue(file.exists());
   }
 
   @Test
@@ -73,7 +76,7 @@ public class MetadataDumperTest {
     dumper.run("--connector", connector.getName(), "--output", path);
 
     // Assert
-    Assert.assertTrue(file.exists());
+    assertTrue(file.exists());
   }
 
   @Test
@@ -86,7 +89,7 @@ public class MetadataDumperTest {
     dumper.run("--connector", connector.getName(), "--output", name);
 
     // Assert
-    Assert.assertTrue(file.exists());
+    assertTrue(file.exists());
   }
 
   @Test
@@ -101,7 +104,7 @@ public class MetadataDumperTest {
     dumper.run("--connector", connector.getName(), "--output", name);
 
     // Assert
-    Assert.assertTrue(expectedFile.exists());
+    assertTrue(expectedFile.exists());
   }
 
   @Test
@@ -116,7 +119,7 @@ public class MetadataDumperTest {
     dumper.run("--connector", connector.getName(), "--output", name);
 
     // Assert
-    Assert.assertTrue(expectedFile.exists());
+    assertTrue(expectedFile.exists());
   }
 
   @Test
@@ -134,6 +137,6 @@ public class MetadataDumperTest {
             () -> dumper.run("--connector", connector.getName(), "--output", name));
 
     // Assert
-    Assert.assertTrue(exception.getMessage().startsWith("A file already exists at test"));
+    assertTrue(exception.getMessage().startsWith("A file already exists at test"));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnectorTest.java
@@ -274,7 +274,7 @@ public class TeradataMetadataConnectorTest extends AbstractConnectorExecutionTes
             // "--database", "db_0"
             );
 
-    MetadataDumper dumper = new MetadataDumper().withExitOnError(false);
+    MetadataDumper dumper = new MetadataDumper();
 
     dumper.run(new ConnectorArguments(args.toArray(ArrayUtils.EMPTY_STRING_ARRAY)));
 


### PR DESCRIPTION
If any exception was not caught in the main thread before reaching the `main` method, it is now caught there and processed, returning exit status 1. The `System.exit(1)` invocation is moved from `MetadataDumper` class to `Main` class.

The original behavior in terms of exit status for required/optional tasks is preserved:
If any of the required tasks fail, the process returns exit status 1. Otherwise, if no required task fails, then the process returns exit status 0 (no matter if any of the optional tasks failed or not).