### PR TITLE
Speed up unit tests

### DIFF
--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.bigquery.BigQueryLogsConnector;
-import com.google.edwmigration.dumper.application.dumper.connector.hive.HiveMetadataConnector;
+import com.google.edwmigration.dumper.application.dumper.connector.test.TestConnector;
 import java.io.File;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
@@ -37,8 +37,8 @@ public class MetadataDumperTest {
   // TODO(ishmum): `testOverridesZipWithGivenName` with content check
   private File file;
   private Main dumper = new Main(new MetadataDumper());
-  private final Connector connector = new HiveMetadataConnector();
-  private final String defaultFileName = "dwh-migration-hiveql-metadata.zip";
+  private final Connector connector = new TestConnector();
+  private final String defaultFileName = "dwh-migration-test-metadata.zip";
 
   @After
   public void tearDown() throws IOException {
@@ -49,7 +49,6 @@ public class MetadataDumperTest {
 
   @Test
   public void testInstantiate() throws Exception {
-    dumper = new Main(new MetadataDumper());
     boolean result = dumper.run("--connector", new BigQueryLogsConnector().getName(), "--dry-run");
     assertTrue(result);
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.test;
+
+import com.google.auto.service.AutoService;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnector;
+import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
+import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
+import com.google.edwmigration.dumper.application.dumper.handle.Handle;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+@AutoService({Connector.class, MetadataConnector.class})
+public class TestConnector extends AbstractConnector implements MetadataConnector {
+  private static final Handle DUMMY_HANDLE = new AbstractHandle() {};
+
+  public TestConnector() {
+    super("test");
+  }
+
+  @Nonnull
+  @Override
+  public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
+      throws Exception {
+    // do nothing in tests
+  }
+
+  @Nonnull
+  @Override
+  public Handle open(@Nonnull ConnectorArguments arguments) {
+    return DUMMY_HANDLE;
+  }
+}


### PR DESCRIPTION
The diagnostic query generation takes a long time, while it is not necessary for unit tests. The query was executed only because of failed connections to the non-existent database, which were attempted from the real connector. Replacing the real connector with the test connector eliminates the need to connect to the real database, so the tasks are no longer failing.

The execution time decreased from 31s to 7s.

Command used for time measurement:
```
time ./gradlew cleanTest :dumper:app:test --no-build-cache
```