### PR TITLE
Fix logging connector properties

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -23,6 +23,8 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
@@ -53,12 +55,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import joptsimple.ValueConversionException;
@@ -503,16 +505,15 @@ public class ConnectorArguments extends DefaultArguments {
     // if --connector <valid-connection> provided, print only that
     if (o.has(connectorNameOption)) {
       String helpOnConnector = o.valueOf(connectorNameOption);
-      for (Connector connector : ServiceLoader.load(Connector.class)) {
-        if (helpOnConnector.equals(connector.getName())) {
-          out.append("\nSelected connector:\n");
-          printConnectorHelp(out, connector);
-          return;
-        }
+      Connector connector = ConnectorRepository.getByName(helpOnConnector);
+      if (connector != null) {
+        out.append("\nSelected connector:\n");
+        printConnectorHelp(out, connector);
+        return;
       }
     }
     out.append("\nAvailable connectors:\n");
-    for (Connector connector : ServiceLoader.load(Connector.class)) {
+    for (Connector connector : ConnectorRepository.getAllConnectors()) {
       printConnectorHelp(out, connector);
     }
   }
@@ -847,26 +848,49 @@ public class ConnectorArguments extends DefaultArguments {
 
   @CheckForNull
   public String getDefinition(@Nonnull ConnectorProperty property) {
-    if (definitionMap == null) {
-      searchDefinitions();
-    }
-    String result = definitionMap.get(property.getName());
-    LOG.info(
-        "Retrieving {} from key {} - got: {}",
-        property.getName(),
-        property.getDescription(),
-        MoreObjects.firstNonNull(result, "[not found]"));
-    return result;
+    return getDefinitionMap().get(property.getName());
   }
 
-  public void searchDefinitions() {
-    definitionMap = new HashMap<>();
-    for (String definition : getOptions().valuesOf(definitionOption)) {
-      if (definition.contains("=")) {
-        int idx = definition.indexOf("=");
-        definitionMap.put(definition.substring(0, idx), definition.substring(idx + 1));
+  private Map<String, String> getDefinitionMap() {
+    if (definitionMap == null) {
+      definitionMap = new HashMap<>();
+      @Nullable String connector = getConnectorName();
+      ImmutableMultimap<String, String> propertyNamesByConnector = allPropertyNamesByConnector();
+      ImmutableSet<String> allPropertyNames =
+          ImmutableSet.copyOf(propertyNamesByConnector.values());
+      for (String definition : getOptions().valuesOf(definitionOption)) {
+        if (definition.contains("=")) {
+          int idx = definition.indexOf("=");
+          String name = definition.substring(0, idx);
+          String value = definition.substring(idx + 1);
+          definitionMap.put(name, value);
+          if (connector != null && propertyNamesByConnector.get(connector).contains(name)) {
+            LOG.info("Parsed property: name='{}', value='{}'", name, value);
+          } else if (allPropertyNames.contains(name)) {
+            LOG.warn(
+                "Property: name='{}', value='{}' is not compatible with connector '{}'",
+                name,
+                value,
+                MoreObjects.firstNonNull(connector, "[not specified]"));
+          } else {
+            LOG.warn("Skipping unknown property: name='{}', value='{}'", name, value);
+          }
+        }
       }
     }
+    return definitionMap;
+  }
+
+  private ImmutableMultimap<String, String> allPropertyNamesByConnector() {
+    ImmutableMultimap.Builder<String, String> connectorPropertyNames = ImmutableMultimap.builder();
+    for (Connector connector : ConnectorRepository.getAllConnectors()) {
+      String connectorName = connector.getName();
+      for (Enum<? extends ConnectorProperty> enumConstant :
+          connector.getConnectorProperties().getEnumConstants()) {
+        connectorPropertyNames.put(connectorName, ((ConnectorProperty) enumConstant).getName());
+      }
+    }
+    return connectorPropertyNames.build();
   }
 
   @Override
@@ -891,16 +915,7 @@ public class ConnectorArguments extends DefaultArguments {
             .add(OPT_QUERY_LOG_END, getQueryLogEnd())
             .add(OPT_QUERY_LOG_ALTERNATES, getQueryLogAlternates())
             .add(OPT_ASSESSMENT, isAssessment());
-    for (Connector connector : ServiceLoader.load(Connector.class)) {
-      if (connector.getName().equals("teradata-logs")) {
-        for (Enum<? extends ConnectorProperty> enumConstant :
-            connector.getConnectorProperties().getEnumConstants()) {
-          toStringHelper.add(
-              ((ConnectorProperty) enumConstant).getName(),
-              getDefinitionOrDefault((TeradataLogsConnectorProperty) enumConstant));
-        }
-      }
-    }
+    getDefinitionMap().forEach(toStringHelper::add);
     return toStringHelper.toString();
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -24,8 +24,8 @@ import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
@@ -863,7 +863,7 @@ public class ConnectorArguments extends DefaultArguments {
   private static ImmutableMap<String, String> buildDefinitionMap(
       @Nullable String connector, List<String> definitions) {
     ImmutableMap.Builder<String, String> resultMap = ImmutableMap.builder();
-    ImmutableMultimap<String, String> propertyNamesByConnector = allPropertyNamesByConnector();
+    ImmutableSetMultimap<String, String> propertyNamesByConnector = allPropertyNamesByConnector();
     ImmutableSet<String> allPropertyNames = ImmutableSet.copyOf(propertyNamesByConnector.values());
     for (String definition : definitions) {
       if (definition.contains("=")) {
@@ -887,8 +887,9 @@ public class ConnectorArguments extends DefaultArguments {
     return resultMap.buildKeepingLast();
   }
 
-  private static ImmutableMultimap<String, String> allPropertyNamesByConnector() {
-    ImmutableMultimap.Builder<String, String> connectorPropertyNames = ImmutableMultimap.builder();
+  private static ImmutableSetMultimap<String, String> allPropertyNamesByConnector() {
+    ImmutableSetMultimap.Builder<String, String> connectorPropertyNames =
+        ImmutableSetMultimap.builder();
     for (Connector connector : ConnectorRepository.getInstance().getAllConnectors()) {
       String connectorName = connector.getName();
       for (Enum<? extends ConnectorProperty> enumConstant :

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorRepository.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorRepository.java
@@ -26,26 +26,34 @@ import javax.annotation.Nullable;
 
 public class ConnectorRepository {
 
-  private static final ImmutableMap<String, Connector> CONNECTORS;
+  private static class Inner {
+    private static final ConnectorRepository INSTANCE = new ConnectorRepository();
+  }
 
-  static {
+  public static ConnectorRepository getInstance() {
+    return Inner.INSTANCE;
+  }
+
+  private final ImmutableMap<String, Connector> connectors;
+
+  private ConnectorRepository() {
     ImmutableMap.Builder<String, Connector> builder = ImmutableMap.builder();
     for (Connector connector : ServiceLoader.load(Connector.class)) {
       builder.put(connector.getName().toLowerCase(), connector);
     }
-    CONNECTORS = builder.build();
+    connectors = builder.build();
   }
 
-  static ImmutableSet<String> getAllNames() {
-    return CONNECTORS.keySet();
+  ImmutableSet<String> getAllNames() {
+    return connectors.keySet();
   }
 
-  static ImmutableCollection<Connector> getAllConnectors() {
-    return CONNECTORS.values();
+  ImmutableCollection<Connector> getAllConnectors() {
+    return connectors.values();
   }
 
   @Nullable
-  static Connector getByName(@Nonnull String connectorName) {
-    return CONNECTORS.get(connectorName.toLowerCase());
+  Connector getByName(@Nonnull String connectorName) {
+    return connectors.get(connectorName.toLowerCase());
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorRepository.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorRepository.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import java.util.ServiceLoader;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+public class ConnectorRepository {
+
+  private static final ImmutableMap<String, Connector> CONNECTORS;
+
+  static {
+    ImmutableMap.Builder<String, Connector> builder = ImmutableMap.builder();
+    for (Connector connector : ServiceLoader.load(Connector.class)) {
+      builder.put(connector.getName().toLowerCase(), connector);
+    }
+    CONNECTORS = builder.build();
+  }
+
+  static ImmutableSet<String> getAllNames() {
+    return CONNECTORS.keySet();
+  }
+
+  static ImmutableCollection<Connector> getAllConnectors() {
+    return CONNECTORS.values();
+  }
+
+  @Nullable
+  static Connector getByName(@Nonnull String connectorName) {
+    return CONNECTORS.get(connectorName.toLowerCase());
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/Main.java
@@ -20,6 +20,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import java.util.Objects;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,6 +48,7 @@ public class Main {
               ImmutableList<String> errorMessages =
                   Throwables.getCausalChain(e).stream()
                       .map(Throwable::getMessage)
+                      .filter(Objects::nonNull)
                       .collect(toImmutableList());
               for (int i = 0; i < errorMessages.size(); i++) {
                 String errorMessage = errorMessages.get(i);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -84,12 +84,12 @@ public class MetadataDumper {
       return false;
     }
 
-    Connector connector = ConnectorRepository.getByName(connectorName);
+    Connector connector = ConnectorRepository.getInstance().getByName(connectorName);
     if (connector == null) {
       LOG.error(
           "Target DBMS '{}' not supported; available are {}.",
           connectorName,
-          ConnectorRepository.getAllNames());
+          ConnectorRepository.getInstance().getAllNames());
       return false;
     }
     return run(connector, arguments);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -49,7 +49,6 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -63,16 +62,6 @@ import org.slf4j.LoggerFactory;
 public class MetadataDumper {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetadataDumper.class);
-
-  private static final ImmutableMap<String, Connector> CONNECTORS;
-
-  static {
-    ImmutableMap.Builder<String, Connector> builder = ImmutableMap.builder();
-    for (Connector connector : ServiceLoader.load(Connector.class)) {
-      builder.put(connector.getName().toUpperCase(), connector);
-    }
-    CONNECTORS = builder.build();
-  }
 
   private static final Pattern GCS_PATH_PATTERN =
       Pattern.compile("gs://(?<bucket>[^/]+)/(?<path>.*)");
@@ -95,14 +84,12 @@ public class MetadataDumper {
       return false;
     }
 
-    Connector connector = CONNECTORS.get(connectorName.toUpperCase());
+    Connector connector = ConnectorRepository.getByName(connectorName);
     if (connector == null) {
       LOG.error(
-          "Target DBMS "
-              + connectorName
-              + " not supported; available are "
-              + CONNECTORS.keySet()
-              + ".");
+          "Target DBMS '{}' not supported; available are {}.",
+          connectorName,
+          ConnectorRepository.getAllNames());
       return false;
     }
     return run(connector, arguments);


### PR DESCRIPTION
The `teradata-logs` connector properties were errorneously logged for all the connectors during the extraction. This logging is removed.

Additionally, a new logging is added at the beginning of processing with the detection of properties from another connector than the one currently specified and the detection of unknown properties.