### PR TITLE
Add new flag to change Teradata Transaction mode

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperUsageException.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumperUsageException.java
@@ -27,7 +27,7 @@ import javax.annotation.Nonnull;
  *
  * @author matt
  */
-public class MetadataDumperUsageException extends Exception {
+public class MetadataDumperUsageException extends RuntimeException {
 
   private final List<String> msgs;
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -98,7 +98,8 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
             + " Example: 10000. Allowed range: "
             + MAX_SQL_LENGTH_RANGE
             + ".",
-        /* defaultValue= */ null);
+        /* defaultValue= */ null),
+    TMODE(CommonTeradataConnectorProperty.TMODE);
 
     private final String name;
     private final String description;
@@ -108,6 +109,12 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
       this.name = "teradata-logs." + name;
       this.description = description;
       this.defaultValue = defaultValue;
+    }
+
+    TeradataLogsConnectorProperty(CommonTeradataConnectorProperty connectorProperty) {
+      this.name = connectorProperty.getName();
+      this.description = connectorProperty.getDescription();
+      this.defaultValue = null;
     }
 
     @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataMetadataConnector.java
@@ -79,7 +79,8 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
             + " Text that is longer than the defined limit will be split into multiple rows."
             + " Example: 10000. Allowed range: "
             + MAX_TEXT_LENGTH_RANGE
-            + ".");
+            + "."),
+    TMODE(CommonTeradataConnectorProperty.TMODE);
 
     private final String name;
     private final String description;
@@ -87,6 +88,11 @@ public class TeradataMetadataConnector extends AbstractTeradataConnector
     TeradataMetadataConnectorProperties(String name, String description) {
       this.name = "teradata.metadata." + name;
       this.description = description;
+    }
+
+    TeradataMetadataConnectorProperties(CommonTeradataConnectorProperty connectorProperty) {
+      this.name = connectorProperty.getName();
+      this.description = connectorProperty.getDescription();
     }
 
     @Nonnull

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilsTest.java
@@ -19,6 +19,8 @@ package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -94,5 +96,53 @@ public class TeradataUtilsTest {
         TeradataUtils.formatQuery("  SELECT  ( 2 + N + ( 3 + N + ( N +    N )  )  )    ");
 
     assertEquals("SELECT (2 + N + (3 + N + (N + N)))", formattedQuery);
+  }
+
+  @Test
+  public void determineTransactionMode_tera() {
+    Optional<String> transactionMode = TeradataUtils.determineTransactionMode(Optional.of("TERA"));
+
+    assertEquals(Optional.of("TERA"), transactionMode);
+  }
+
+  @Test
+  public void determineTransactionMode_ansi() {
+    Optional<String> transactionMode = TeradataUtils.determineTransactionMode(Optional.of("ANSI"));
+
+    assertEquals(Optional.of("ANSI"), transactionMode);
+  }
+
+  @Test
+  public void determineTransactionMode_default() {
+    Optional<String> transactionMode =
+        TeradataUtils.determineTransactionMode(Optional.of("DEFAULT"));
+
+    assertEquals(Optional.of("DEFAULT"), transactionMode);
+  }
+
+  @Test
+  public void determineTransactionMode_unsupportedMode_throwsException() {
+    MetadataDumperUsageException e =
+        assertThrows(
+            MetadataDumperUsageException.class,
+            () -> TeradataUtils.determineTransactionMode(Optional.of("fast")));
+
+    assertEquals(
+        "Unsupported transaction mode='fast', supported modes='[ANSI, TERA, DEFAULT, NONE]'.",
+        e.getMessage());
+  }
+
+  @Test
+  public void determineTransactionMode_none() {
+    Optional<String> transactionMode = TeradataUtils.determineTransactionMode(Optional.of("NONE"));
+
+    assertEquals(Optional.empty(), transactionMode);
+  }
+
+  @Test
+  public void determineTransactionMode_commandLineOptionNotSpecified() {
+    Optional<String> transactionMode = TeradataUtils.determineTransactionMode(Optional.empty());
+
+    assertEquals(Optional.of("ANSI"), transactionMode);
   }
 }


### PR DESCRIPTION
The default transaction mode in the dumper is ANSI.

The new command-line flag `-Dteradata.tmode` allows setting this mode to one of ANSI, TERA, DEFAULT or NONE for the `teradata` and `teradata-logs` connectors.