### PR TITLE
Fix WHERE clause for non-assessment Teradata tasks

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
@@ -22,6 +22,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
 import java.util.List;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -160,7 +161,7 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
       SharedState state,
       String logTable,
       String queryTable,
-      List<String> conditions,
+      Set<String> conditions,
       ZonedInterval interval,
       @CheckForNull String logDateColumn,
       OptionalLong maxSqlLength,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractConnectorTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractConnectorTest {
   @SuppressWarnings("UnusedVariable")
   private static final Logger LOG = LoggerFactory.getLogger(AbstractConnectorTest.class);
 
-  protected static enum SpecialTaskType {
+  protected enum SpecialTaskType {
     Version,
     Arguments,
     Format

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
@@ -20,6 +20,7 @@ import static com.google.edwmigration.dumper.application.dumper.test.DumperTestU
 import static java.util.Collections.emptyList;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
 import java.time.ZoneId;
@@ -52,7 +53,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
             /* maxSqlLength= */ OptionalLong.empty(),
@@ -79,7 +80,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
             /* maxSqlLength= */ OptionalLong.of(20000),
@@ -114,7 +115,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
             /* maxSqlLength= */ OptionalLong.empty(),
@@ -141,7 +142,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             "SampleLogDate", /* orderBy */
             /* maxSqlLength= */ OptionalLong.empty(),
@@ -169,7 +170,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ ImmutableList.of("L.QueryID=7"),
+            /* conditions= */ ImmutableSet.of("L.QueryID=7"),
             interval,
             /* logDateColumn= */ null,
             /* maxSqlLength= */ OptionalLong.empty(),
@@ -196,7 +197,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
             /* maxSqlLength= */ OptionalLong.empty(),
@@ -224,7 +225,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             "SampleLogDate", /* orderBy */
             /* maxSqlLength= */ OptionalLong.empty(),
@@ -253,7 +254,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            /* conditions= */ emptyList(),
+            /* conditions= */ ImmutableSet.of(),
             interval,
             "SampleLogDate", /* orderBy */
             /* maxSqlLength= */ OptionalLong.of(20000),
@@ -292,7 +293,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             queryLogsState,
             "SampleQueryTable",
             "SampleSqlTable",
-            ImmutableList.of("QueryID=7", "QueryText LIKE '%abc%'"),
+            ImmutableSet.of("QueryID=7", "QueryText LIKE '%abc%'"),
             interval,
             "SampleLogDate",
             /* maxSqlLength= */ OptionalLong.empty(),

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
@@ -16,10 +16,15 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask.setParameterValues;
+import static com.google.edwmigration.dumper.application.dumper.test.DumperTestUtils.assertQueryEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -29,6 +34,8 @@ import com.google.edwmigration.dumper.application.dumper.connector.AbstractConne
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.io.FileSystemOutputHandleFactory;
 import com.google.edwmigration.dumper.application.dumper.io.OutputHandleFactory;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
+import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import com.google.edwmigration.dumper.application.dumper.test.DummyTaskRunContext;
@@ -133,12 +140,164 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
       List<Task<?>> tasks = new ArrayList<>();
       connector.addTasksTo(
           tasks,
-          new ConnectorArguments(
-              new String[] {"--connector", connector.getName(), "--query-log-days", "1"}));
+          new ConnectorArguments("--connector", connector.getName(), "--query-log-days", "1"));
       for (Task<?> task : tasks) {
         task.run(runContext);
       }
     }
+  }
+
+  @Test
+  public void addTasksTo_dumpMetadataTask() throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(tasks, new ConnectorArguments("--connector", connector.getName()));
+
+    // Assert
+    assertEquals(1, tasks.stream().filter(task -> task instanceof DumpMetadataTask).count());
+  }
+
+  @Test
+  public void addTasksTo_formatTask() throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(tasks, new ConnectorArguments("--connector", connector.getName()));
+
+    // Assert
+    assertEquals(1, tasks.stream().filter(task -> task instanceof FormatTask).count());
+  }
+
+  @Test
+  public void addTasksTo_noTeradataAssessmentLogsJdbcTaskWithoutAssessmentFlag() throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(tasks, new ConnectorArguments("--connector", connector.getName()));
+
+    // Assert
+    assertTrue(tasks.stream().noneMatch(task -> task instanceof TeradataAssessmentLogsJdbcTask));
+  }
+
+  @Test
+  public void
+      addTasksTo_allTeradataLogsJdbcTasksAreTeradataAssessmentLogsJdbcTasksWithAssessmentFlag()
+          throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(
+        tasks, new ConnectorArguments("--connector", connector.getName(), "--assessment"));
+
+    // Assert
+    assertTrue(
+        tasks.stream()
+            .filter(task -> task instanceof TeradataLogsJdbcTask)
+            .allMatch(task -> task instanceof TeradataAssessmentLogsJdbcTask));
+  }
+
+  @Test
+  public void addTasksTo_teradataLogsJdbcTaskForOneHour() throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(
+        tasks,
+        new ConnectorArguments(
+            "--connector",
+            connector.getName(),
+            "--query-log-start",
+            "2023-12-22 00:00:00",
+            "--query-log-end",
+            "2023-12-22 01:00:00"));
+
+    // Assert
+    List<String> queries =
+        tasks.stream()
+            .filter(task -> task instanceof TeradataLogsJdbcTask)
+            .map(
+                task ->
+                    ((TeradataLogsJdbcTask) task)
+                        .getSql(unused -> true, new String[] {"SampleColumn"}))
+            .collect(toImmutableList());
+    assertEquals(1, queries.size());
+    assertQueryEquals(
+        "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE L.ErrorCode=0 AND"
+            + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP) AND"
+            + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
+        getOnlyElement(queries));
+  }
+
+  @Test
+  public void addTasksTo_teradataLogsJdbcTasksForTwoHours() throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(
+        tasks,
+        new ConnectorArguments(
+            "--connector",
+            connector.getName(),
+            "--query-log-start",
+            "2023-12-22 00:00:00",
+            "--query-log-end",
+            "2023-12-22 02:00:00"));
+
+    // Assert
+    List<String> queries =
+        tasks.stream()
+            .filter(task -> task instanceof TeradataLogsJdbcTask)
+            .map(
+                task ->
+                    ((TeradataLogsJdbcTask) task)
+                        .getSql(unused -> true, new String[] {"SampleColumn"}))
+            .collect(toImmutableList());
+    assertEquals(
+        ImmutableList.of(
+            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE L.ErrorCode=0 AND"
+                + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP) AND"
+                + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
+            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE L.ErrorCode=0 AND"
+                + " L.StartTime >= CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
+                + " L.StartTime < CAST('2023-12-22T02:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'"),
+        queries);
+  }
+
+  @Test
+  public void addTasksTo_teradataAssessmentLogsJdbcTaskWithAssessmentFlag() throws Exception {
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(
+        tasks,
+        new ConnectorArguments(
+            "--connector",
+            connector.getName(),
+            "--query-log-start",
+            "2023-12-22 00:00:00",
+            "--query-log-end",
+            "2023-12-22 01:00:00",
+            "--assessment"));
+
+    // Assert
+    List<String> queries =
+        tasks.stream()
+            .filter(task -> task instanceof TeradataAssessmentLogsJdbcTask)
+            .map(
+                task ->
+                    ((TeradataAssessmentLogsJdbcTask) task)
+                        .getSql(unused -> true, new String[] {"ST.QueryID"}))
+            .collect(toImmutableList());
+    assertEquals(1, queries.size());
+    assertQueryEquals(
+        "SELECT ST.QueryID"
+            + " FROM dbc.QryLogV L LEFT OUTER JOIN dbc.DBQLSQLTbl ST ON (L.QueryID=ST.QueryID)"
+            + " WHERE L.ErrorCode=0"
+            + " AND L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP)"
+            + " AND L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP)"
+            + " ORDER BY ST.QueryID, ST.SQLRowNo",
+        getOnlyElement(queries));
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static com.google.edwmigration.dumper.application.dumper.test.DumperTestUtils.assertQueryEquals;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
+import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+
+public class TeradataLogsJdbcTaskTest {
+
+  private SharedState queryLogsState = new SharedState();
+
+  @Test
+  public void getSql_success() {
+    ZonedInterval interval =
+        new ZonedInterval(
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneId.systemDefault()),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneId.systemDefault()));
+    TeradataLogsJdbcTask jdbcTask =
+        new TeradataLogsJdbcTask(
+            "result.csv",
+            queryLogsState,
+            "SampleQueryTable",
+            "SampleSqlTable",
+            /* conditions= */ ImmutableSet.of(),
+            interval);
+
+    // Act
+    String query = jdbcTask.getSql(s -> true, new String[] {"L.QueryID", "ST.QueryID"});
+
+    // Assert
+    assertQueryEquals(
+        "SELECT L.QueryID, ST.QueryID"
+            + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
+            + " WHERE L.ErrorCode=0 AND"
+            + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+        query);
+  }
+
+  @Test
+  public void getSql_withCondition() {
+    ZonedInterval interval =
+        new ZonedInterval(
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneId.systemDefault()),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneId.systemDefault()));
+    TeradataLogsJdbcTask jdbcTask =
+        new TeradataLogsJdbcTask(
+            "result.csv",
+            queryLogsState,
+            "SampleQueryTable",
+            "SampleSqlTable",
+            /* conditions= */ ImmutableSet.of("L.UserName <> 'DBC'"),
+            interval);
+
+    // Act
+    String query = jdbcTask.getSql(s -> true, new String[] {"L.QueryID", "ST.QueryID"});
+
+    // Assert
+    assertQueryEquals(
+        "SELECT L.QueryID, ST.QueryID"
+            + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
+            + " WHERE L.ErrorCode=0 AND"
+            + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
+        query);
+  }
+}


### PR DESCRIPTION
The WHERE clause generated for Teradata logs tasks (in `teradata-logs` connector without specifying the `--assessment` flag) contained repeated conditions `L.UserName <> 'DBC'`:

```
L.UserName <> 'DBC' AND L.UserName <> 'DBC' AND L.UserName <> 'DBC' AND ...
```

The `conditions` list was mistakenly modified inside the loop, which caused additional redundant conditions to be added to the query, if there was more than one time interval extracted.

If there were too many such conditions, the query failed.