### PR TITLE
New option for alternate query log tables

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -312,13 +312,20 @@ public class ConnectorArguments extends DefaultArguments {
       parser
           .acceptsAll(Arrays.asList("dry-run", "n"), "Show export actions without executing.")
           .forHelp();
+
+  public static final String OPT_QUERY_LOG_ALTERNATES_DEPRECATION_MESSAGE =
+      "The "
+          + OPT_QUERY_LOG_ALTERNATES
+          + " option is "
+          + "deprecated, please use -Dteradata-logs.query-log-table and -Dteradata-logs.sql-log-table instead";
   private final OptionSpec<String> optionQueryLogAlternates =
       parser
           .accepts(
               OPT_QUERY_LOG_ALTERNATES,
               "pair of alternate query log tables to export (teradata-logs only), by default "
                   + "logTable=dbc.DBQLogTbl and queryTable=dbc.DBQLSQLTbl, if --assessment flag"
-                  + " is enabled, then logTable=dbc.QryLogV and queryTable=dbc.DBQLSQLTbl.")
+                  + " is enabled, then logTable=dbc.QryLogV and queryTable=dbc.DBQLSQLTbl. "
+                  + OPT_QUERY_LOG_ALTERNATES_DEPRECATION_MESSAGE)
           .withRequiredArg()
           .ofType(String.class)
           .withValuesSeparatedBy(',')
@@ -849,6 +856,11 @@ public class ConnectorArguments extends DefaultArguments {
   @CheckForNull
   public String getDefinition(@Nonnull ConnectorProperty property) {
     return getDefinitionMap().get(property.getName());
+  }
+
+  /** Checks if the property was specified on the command-line. */
+  public boolean isDefinitionSpecified(@Nonnull ConnectorProperty property) {
+    return StringUtils.isNotEmpty(getDefinitionMap().get(property.getName()));
   }
 
   private Map<String, String> getDefinitionMap() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
@@ -91,7 +91,7 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
   protected static final DateTimeFormatter SQL_FORMAT =
       DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
   @VisibleForTesting /* pp */ static final String DEF_LOG_TABLE = "dbc.DBQLogTbl";
-  @VisibleForTesting /* pp */ static final String DEF_QUERY_TABLE = "dbc.DBQLSQLTbl";
+  @VisibleForTesting /* pp */ static final String DEF_SQL_TABLE = "dbc.DBQLSQLTbl";
 
   protected enum CommonTeradataConnectorProperty implements ConnectorProperty {
     TMODE(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/QueryLogTableNames.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/QueryLogTableNames.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+
+/**
+ * Table names to extract the query logs from. See the description in {@link
+ * QueryLogTableNamesResolver}.
+ */
+@AutoValue
+abstract class QueryLogTableNames {
+
+  /** @return query logs table name */
+  abstract String queryLogsTableName();
+
+  /** @return SQL logs table name */
+  abstract String sqlLogsTableName();
+
+  /** @return whether at least one alternate table is being used */
+  abstract boolean usingAtLeastOneAlternate();
+
+  static QueryLogTableNames create(
+      String queryLogsTableName, String sqlLogsTableName, boolean usingAtLeastOneAlternate) {
+    Preconditions.checkArgument(
+        !queryLogsTableName.isEmpty(), "Query log table name cannot be empty.");
+    Preconditions.checkArgument(!sqlLogsTableName.isEmpty(), "SQL log table name cannot be empty.");
+    return new AutoValue_QueryLogTableNames(
+        queryLogsTableName, sqlLogsTableName, usingAtLeastOneAlternate);
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/QueryLogTableNamesResolver.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/QueryLogTableNamesResolver.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_QUERY_LOG_ALTERNATES;
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_QUERY_LOG_ALTERNATES_DEPRECATION_MESSAGE;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.DEF_LOG_TABLE;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataLogsConnector.ASSESSMENT_DEF_LOG_TABLE;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataLogsConnector.TeradataLogsConnectorProperty.QUERY_LOGS_TABLE;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataLogsConnector.TeradataLogsConnectorProperty.SQL_LOGS_TABLE;
+import static com.google.edwmigration.dumper.application.dumper.connector.teradata.TeradataUtils.nonEmpty;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Resolver that retrieves the names of query log tables from the command-line options.
+ *
+ * <p>Teradata saves query logs in two tables: {@code DBC.DBQLogTbl} and {@code DBC.DBQLSqlTbl}.
+ * These two tables are called query log table and SQL log table for the purposes of the query logs
+ * extraction.
+ *
+ * <p>Depending on the flags provided on the command-line, the {@code teradata-logs} connector uses
+ * different pair of source tables for extraction:
+ *
+ * <ul>
+ *   <li>If the {@code --assessment} flag is not used, then the logs are extracted from tables
+ *       {@code DBC.DBQLogTbl} and {@code DBC.DBQLSqlTbl}
+ *   <li>If the {@code --assessment} flag is used, then the logs are extracted from tables {@code
+ *       DBC.QryLogV} (a view that selects the logs from {@code DBC.DBQLogTbl} table) and {@code
+ *       DBC.DBQLSqlTbl}
+ * </ul>
+ *
+ * <p>Additionally, the user can specify an alternative table for each of the two tables:
+ *
+ * <ul>
+ *   <li>For the query log table, the command-line flag is: {@code -Dteradata-logs.query-log-table}
+ *   <li>For the SQL log table, the command-line flag is: {@code -Dteradata-logs.sql-log-table}
+ * </ul>
+ *
+ * <p>Deprecated: There is also a second way of specifying both alternative tables by using the
+ * {@code --query-log-alternates} command-line flag that accepts these two log tables as a parameter
+ * (separated by a comma).
+ */
+class QueryLogTableNamesResolver {
+  private static final Logger LOG = LoggerFactory.getLogger(QueryLogTableNamesResolver.class);
+
+  private static final String TERADATA_LOGS_CONNECTOR_NAME = "teradata-logs";
+
+  static QueryLogTableNames resolve(ConnectorArguments arguments) {
+    Preconditions.checkArgument(
+        arguments.getConnectorName().equalsIgnoreCase(TERADATA_LOGS_CONNECTOR_NAME),
+        "Resolver requires the connector to be '%s'.",
+        TERADATA_LOGS_CONNECTOR_NAME);
+    if (arguments.getQueryLogAlternates().isEmpty()) {
+      return resolveFromDefinitionOptions(arguments);
+    }
+    return resolveFromLegacyOption(arguments);
+  }
+
+  private static QueryLogTableNames resolveFromDefinitionOptions(ConnectorArguments arguments) {
+    boolean alternateQueryLogTableSpecified = arguments.isDefinitionSpecified(QUERY_LOGS_TABLE);
+    boolean alternateSqlLogTableSpecified = arguments.isDefinitionSpecified(SQL_LOGS_TABLE);
+    String queryLogTable =
+        nonEmpty(arguments.getDefinition(QUERY_LOGS_TABLE))
+            .orElse(arguments.isAssessment() ? ASSESSMENT_DEF_LOG_TABLE : DEF_LOG_TABLE);
+    String sqlLogTable = arguments.getDefinitionOrDefault(SQL_LOGS_TABLE);
+    if (alternateQueryLogTableSpecified && !alternateSqlLogTableSpecified) {
+      LOG.warn(
+          "The alternate query log table was provided using the '-D{}' flag, but no"
+              + " alternate SQL table was provided using the '-D{}' flag. The following tables"
+              + " will be joined to extract the query logs: '{}' and '{}'.",
+          QUERY_LOGS_TABLE.getName(),
+          SQL_LOGS_TABLE.getName(),
+          queryLogTable,
+          sqlLogTable);
+    } else if (!alternateQueryLogTableSpecified && alternateSqlLogTableSpecified) {
+      LOG.warn(
+          "The alternate SQL log table was provided using the '-D{}' flag, but no alternate"
+              + " query table was provided using the '-D{}' flag. The following tables will be"
+              + " joined to extract the query logs: '{}' and '{}'.",
+          SQL_LOGS_TABLE.getName(),
+          QUERY_LOGS_TABLE.getName(),
+          queryLogTable,
+          sqlLogTable);
+    }
+    return QueryLogTableNames.create(
+        queryLogTable,
+        sqlLogTable,
+        alternateQueryLogTableSpecified || alternateSqlLogTableSpecified);
+  }
+
+  private static final QueryLogTableNames resolveFromLegacyOption(ConnectorArguments arguments) {
+    List<String> legacyAlternates = arguments.getQueryLogAlternates();
+    boolean alternateQueryLogTableSpecified = arguments.isDefinitionSpecified(QUERY_LOGS_TABLE);
+    boolean alternateSqlLogTableSpecified = arguments.isDefinitionSpecified(SQL_LOGS_TABLE);
+    if (alternateQueryLogTableSpecified || alternateSqlLogTableSpecified) {
+      ImmutableList.Builder<String> flagsUsed = ImmutableList.builder();
+      flagsUsed.add(OPT_QUERY_LOG_ALTERNATES);
+      if (alternateQueryLogTableSpecified) {
+        flagsUsed.add(QUERY_LOGS_TABLE.getName());
+      }
+      if (alternateSqlLogTableSpecified) {
+        flagsUsed.add(SQL_LOGS_TABLE.getName());
+      }
+      throw new MetadataDumperUsageException(
+          String.format(
+                  "Mixed alternate query log table configuration detected in flags '%s'. (",
+                  flagsUsed.build())
+              + OPT_QUERY_LOG_ALTERNATES_DEPRECATION_MESSAGE
+              + ")");
+    }
+    if (legacyAlternates.size() != 2) {
+      throw new MetadataDumperUsageException(
+          "Alternate query log tables must be given as a pair separated by a comma;"
+              + " you specified: '"
+              + legacyAlternates
+              + "'. ("
+              + OPT_QUERY_LOG_ALTERNATES_DEPRECATION_MESSAGE
+              + ")");
+    }
+    return QueryLogTableNames.create(
+        /* queryLogsTableName= */ legacyAlternates.get(0),
+        /* sqlLogsTableName= */ legacyAlternates.get(1),
+        /* usingAtLeastOneAlternate= */ true);
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
@@ -272,14 +272,14 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
     out.add(new FormatTask(FORMAT_NAME));
 
     String logTable = DEF_LOG_TABLE;
-    String queryTable = DEF_QUERY_TABLE;
+    String sqlTable = DEF_SQL_TABLE;
     List<String> alternates = arguments.getQueryLogAlternates();
     if (!alternates.isEmpty()) {
       if (alternates.size() != 2)
         throw new MetadataDumperUsageException(
             "Alternate query log tables must be given as a pair; you specified: " + alternates);
       logTable = alternates.get(0);
-      queryTable = alternates.get(1);
+      sqlTable = alternates.get(1);
     }
 
     // if the user specifies an earliest start time there will be extraneous empty dump files
@@ -306,7 +306,7 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
               + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(interval.getStartUTC())
               + ".csv";
       out.add(
-          new LSqlQueryFactory(LSqlfile, state, logTable, queryTable, lSqlConditions, interval)
+          new LSqlQueryFactory(LSqlfile, state, logTable, sqlTable, lSqlConditions, interval)
               .withHeaderClass(TeradataLogsDumpFormat.HeaderLSql.class));
 
       String LOGfile =
@@ -314,7 +314,7 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
               + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(interval.getStartUTC())
               + ".csv";
       out.add(
-          new LogQueryFactory(LOGfile, state, logTable, queryTable, logConditions, interval)
+          new LogQueryFactory(LOGfile, state, logTable, sqlTable, logConditions, interval)
               .withHeaderClass(TeradataLogsDumpFormat.HeaderLog.class));
     }
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
@@ -159,23 +159,14 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
   public TeradataAssessmentLogsJdbcTask(
       @Nonnull String targetPath,
       SharedState state,
-      String logTable,
-      String queryTable,
+      QueryLogTableNames tableNames,
       Set<String> conditions,
       ZonedInterval interval,
       @CheckForNull String logDateColumn,
       OptionalLong maxSqlLength,
       List<String> orderBy) {
     super(
-        targetPath,
-        state,
-        logTable,
-        queryTable,
-        conditions,
-        interval,
-        logDateColumn,
-        maxSqlLength,
-        orderBy);
+        targetPath, state, tableNames, conditions, interval, logDateColumn, maxSqlLength, orderBy);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtils.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtils.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import java.util.Optional;
@@ -28,6 +29,10 @@ public class TeradataUtils {
 
   public static <T> Optional<T> optionalIf(boolean condition, Supplier<T> supplier) {
     return condition ? Optional.of(supplier.get()) : Optional.empty();
+  }
+
+  public static Optional<String> nonEmpty(String value) {
+    return Optional.ofNullable(Strings.emptyToNull(value));
   }
 
   /**

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/QueryLogTableNamesResolverTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/QueryLogTableNamesResolverTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.io.IOException;
+import joptsimple.OptionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class QueryLogTableNamesResolverTest {
+
+  @Test
+  public void resolve_success() throws IOException {
+    ConnectorArguments args = new ConnectorArguments("--connector", "teradata-logs");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("dbc.DBQLogTbl", tableNames.queryLogsTableName());
+    assertEquals("dbc.DBQLSQLTbl", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_withAssessmentFlag_success() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments("--connector", "teradata-logs", "--assessment");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("dbc.QryLogV", tableNames.queryLogsTableName());
+    assertEquals("dbc.DBQLSQLTbl", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_legacyAlternateTables_success() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector",
+            "teradata-logs",
+            "--query-log-alternates",
+            "SampleLogTable,SampleSqlTable");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("SampleLogTable", tableNames.queryLogsTableName());
+    assertEquals("SampleSqlTable", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_alternateQueryLogsTable_success() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector", "teradata-logs", "-Dteradata-logs.query-logs-table=SampleTable");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("SampleTable", tableNames.queryLogsTableName());
+    assertEquals("dbc.DBQLSQLTbl", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_alternateSqlLogsTable_success() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector", "teradata-logs", "-Dteradata-logs.sql-logs-table=SampleTable");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("dbc.DBQLogTbl", tableNames.queryLogsTableName());
+    assertEquals("SampleTable", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_alternateSqlLogsTableForAssessment_success() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector",
+            "teradata-logs",
+            "--assessment",
+            "-Dteradata-logs.sql-logs-table=SampleTable");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("dbc.QryLogV", tableNames.queryLogsTableName());
+    assertEquals("SampleTable", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_alternateQueryLogsTables_success() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector",
+            "teradata-logs",
+            "-Dteradata-logs.query-logs-table=SampleLogTable",
+            "-Dteradata-logs.sql-logs-table=SampleSqlTable");
+
+    // Act
+    QueryLogTableNames tableNames = QueryLogTableNamesResolver.resolve(args);
+
+    // Assert
+    assertEquals("SampleLogTable", tableNames.queryLogsTableName());
+    assertEquals("SampleSqlTable", tableNames.sqlLogsTableName());
+  }
+
+  @Test
+  public void resolve_legacyAlternateTablesNoArgument_throwsException() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments("--connector", "teradata-logs", "--query-log-alternates");
+
+    // Act
+    OptionException e =
+        assertThrows(OptionException.class, () -> QueryLogTableNamesResolver.resolve(args));
+
+    // Assert
+    assertEquals("Option query-log-alternates requires an argument", e.getMessage());
+  }
+
+  @Test
+  public void resolve_legacyAlternateTablesOnlyOneTableInsteadOfPair_throwsException()
+      throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector", "teradata-logs", "--query-log-alternates", "SampleTable");
+
+    // Act
+    MetadataDumperUsageException e =
+        assertThrows(
+            MetadataDumperUsageException.class, () -> QueryLogTableNamesResolver.resolve(args));
+
+    // Assert
+    assertEquals(
+        "Alternate query log tables must be given as a pair separated by a comma; you"
+            + " specified: '[SampleTable]'. (The query-log-alternates option is deprecated, please use"
+            + " -Dteradata-logs.query-log-table and -Dteradata-logs.sql-log-table instead)",
+        e.getMessage());
+  }
+
+  @Test
+  public void resolve_mixedLegacyAlternateTablesAndNewFlag_throwsException() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector",
+            "teradata-logs",
+            "--query-log-alternates",
+            "SampleTable",
+            "-Dteradata-logs.query-logs-table=SampleTable");
+
+    // Act
+    MetadataDumperUsageException e =
+        assertThrows(
+            MetadataDumperUsageException.class, () -> QueryLogTableNamesResolver.resolve(args));
+
+    // Assert
+    assertEquals(
+        "Mixed alternate query log table configuration detected in flags"
+            + " '[query-log-alternates, teradata-logs.query-logs-table]'. (The query-log-alternates"
+            + " option is deprecated, please use -Dteradata-logs.query-log-table and"
+            + " -Dteradata-logs.sql-log-table instead)",
+        e.getMessage());
+  }
+
+  @Test
+  public void resolve_mixedLegacyAlternateTablesAndNewFlags_throwsException() throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector",
+            "teradata-logs",
+            "--query-log-alternates",
+            "SampleTable",
+            "-Dteradata-logs.query-logs-table=SampleTable",
+            "-Dteradata-logs.sql-logs-table=SampleTable");
+
+    // Act
+    MetadataDumperUsageException e =
+        assertThrows(
+            MetadataDumperUsageException.class, () -> QueryLogTableNamesResolver.resolve(args));
+
+    // Assert
+    assertEquals(
+        "Mixed alternate query log table configuration detected in flags"
+            + " '[query-log-alternates, teradata-logs.query-logs-table, teradata-logs.sql-logs-table]'."
+            + " (The query-log-alternates option is deprecated, please use"
+            + " -Dteradata-logs.query-log-table and -Dteradata-logs.sql-log-table instead)",
+        e.getMessage());
+  }
+
+  @Test
+  public void resolve_unsupportedConnector_throwsException() throws IOException {
+    ConnectorArguments args = new ConnectorArguments("--connector", "test-connector");
+
+    // Act
+    IllegalArgumentException e =
+        assertThrows(
+            IllegalArgumentException.class, () -> QueryLogTableNamesResolver.resolve(args));
+
+    // Assert
+    assertEquals("Resolver requires the connector to be 'teradata-logs'.", e.getMessage());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
@@ -51,8 +51,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
@@ -78,8 +77,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
@@ -113,8 +111,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
@@ -140,8 +137,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             "SampleLogDate", /* orderBy */
@@ -168,8 +164,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of("L.QueryID=7"),
             interval,
             /* logDateColumn= */ null,
@@ -195,8 +190,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             /* logDateColumn= */ null,
@@ -223,8 +217,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             "SampleLogDate", /* orderBy */
@@ -252,8 +245,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             /* conditions= */ ImmutableSet.of(),
             interval,
             "SampleLogDate", /* orderBy */
@@ -291,8 +283,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         new TeradataAssessmentLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            createTableName("SampleQueryTable", "SampleSqlTable"),
             ImmutableSet.of("QueryID=7", "QueryText LIKE '%abc%'"),
             interval,
             "SampleLogDate",
@@ -315,5 +306,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " QueryID=7 AND QueryText LIKE '%abc%'"
             + " ORDER BY ST.QueryID, ST.RowNo",
         query);
+  }
+
+  private QueryLogTableNames createTableName(String logTable, String sqlTable) {
+    return QueryLogTableNames.create(logTable, sqlTable, /* usingAtLeastOneAlternate */ true);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -39,8 +39,8 @@ public class TeradataLogsJdbcTaskTest {
         new TeradataLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            QueryLogTableNames.create(
+                "SampleQueryTable", "SampleSqlTable", /* usingAtLeastOneAlternate */ true),
             /* conditions= */ ImmutableSet.of(),
             interval);
 
@@ -67,8 +67,8 @@ public class TeradataLogsJdbcTaskTest {
         new TeradataLogsJdbcTask(
             "result.csv",
             queryLogsState,
-            "SampleQueryTable",
-            "SampleSqlTable",
+            QueryLogTableNames.create(
+                "SampleQueryTable", "SampleSqlTable", /* usingAtLeastOneAlternate */ true),
             /* conditions= */ ImmutableSet.of("L.UserName <> 'DBC'"),
             interval);
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilsTest.java
@@ -145,4 +145,24 @@ public class TeradataUtilsTest {
 
     assertEquals(Optional.of("ANSI"), transactionMode);
   }
+
+  @Test
+  public void nonEmpty_null() {
+    assertEquals(Optional.empty(), TeradataUtils.nonEmpty(null));
+  }
+
+  @Test
+  public void nonEmpty_emptyString() {
+    assertEquals(Optional.empty(), TeradataUtils.nonEmpty(""));
+  }
+
+  @Test
+  public void nonEmpty_success() {
+    assertEquals(Optional.of("abc"), TeradataUtils.nonEmpty("abc"));
+  }
+
+  @Test
+  public void nonEmpty_space() {
+    assertEquals(Optional.of(" "), TeradataUtils.nonEmpty(" "));
+  }
 }


### PR DESCRIPTION
I'm splitting the `--query-log-alternates` option of the `teradata-logs` connector into two separate options to simplify the documentation.

Before:
```
--query-log-alternates HistoricLogTable,HistoricSqlTable
```

After:
```
-Dteradata-logs.query-logs-table=HistoricLogTable
-Dteradata-logs.sql-logs-table=HistoricSqlTable
```

This change will also align the naming of the new options with the existing options for other tables:
```
-Dteradata-logs.utility-logs-table
-Dteradata-logs.res-usage-scpu-table
-Dteradata-logs.res-usage-spma-table
```

The old option is kept for backwards compatibility.