### PR TITLE
Use UTC timezone instead of systemDefault in Teradata tests

### DIFF
--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.OptionalLong;
 import org.junit.Before;
@@ -37,8 +37,8 @@ public class TeradataAssessmentLogsJdbcTaskTest {
   private SharedState queryLogsState = new SharedState();
   private ZonedInterval interval =
       new ZonedInterval(
-          ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneId.systemDefault()),
-          ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneId.systemDefault()));
+          ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneOffset.UTC),
+          ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneOffset.UTC));
 
   @Before
   public void setUp() {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -23,7 +23,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.SharedState;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import org.junit.Test;
 
@@ -35,8 +35,8 @@ public class TeradataLogsJdbcTaskTest {
   public void getOrCreateSql_success() {
     ZonedInterval interval =
         new ZonedInterval(
-            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneId.systemDefault()),
-            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneId.systemDefault()));
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneOffset.UTC),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneOffset.UTC));
     TeradataLogsJdbcTask jdbcTask =
         new TeradataLogsJdbcTask(
             "result.csv",
@@ -63,8 +63,8 @@ public class TeradataLogsJdbcTaskTest {
   public void toString_success() {
     ZonedInterval interval =
         new ZonedInterval(
-            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneId.systemDefault()),
-            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneId.systemDefault()));
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneOffset.UTC),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneOffset.UTC));
     TeradataLogsJdbcTask jdbcTask =
         new TeradataLogsJdbcTask(
             "result.csv",
@@ -92,8 +92,8 @@ public class TeradataLogsJdbcTaskTest {
   public void getOrCreateSql_withCondition() {
     ZonedInterval interval =
         new ZonedInterval(
-            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneId.systemDefault()),
-            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneId.systemDefault()));
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneOffset.UTC),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneOffset.UTC));
     TeradataLogsJdbcTask jdbcTask =
         new TeradataLogsJdbcTask(
             "result.csv",

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -115,4 +115,33 @@ public class TeradataLogsJdbcTaskTest {
             + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
         query);
   }
+
+  @Test
+  public void toString_withZoneOffset_success() {
+    ZonedInterval interval =
+        new ZonedInterval(
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneOffset.ofHours(3)),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneOffset.ofHours(3)));
+    TeradataLogsJdbcTask jdbcTask =
+        new TeradataLogsJdbcTask(
+            "result.csv",
+            queryLogsState,
+            QueryLogTableNames.create(
+                "SampleQueryTable", "SampleSqlTable", /* usingAtLeastOneAlternate */ true),
+            /* conditions= */ ImmutableSet.of(),
+            interval);
+    String unused = jdbcTask.getOrCreateSql(s -> true, ImmutableList.of("L.QueryID", "ST.QueryID"));
+
+    // Act
+    String taskDescription = jdbcTask.toString();
+
+    // Assert
+    assertEquals(
+        "Write result.csv from\n        SELECT L.QueryID, ST.QueryID"
+            + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
+            + " WHERE L.ErrorCode=0 AND"
+            + " L.StartTime >= CAST('2023-03-04T13:00:00Z' AS TIMESTAMP) AND"
+            + " L.StartTime < CAST('2023-03-04T14:00:00Z' AS TIMESTAMP)",
+        taskDescription);
+  }
 }


### PR DESCRIPTION
This change fixes failing Teradata tests due to the system default timezone used in tests.