### PR TITLE
Set Oracle useFetchSizeWithLongColumn argument to true

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -73,6 +73,10 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 })
 public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
 
+  /* This argument is required to improve performance of retrieving LONG columns */
+  private static final String USE_FETCH_SIZE_WITH_LONG_COLUMN_ARG =
+      "useFetchSizeWithLongColumn=true";
+
   public static final int OPT_PORT_DEFAULT = 1521;
 
   public AbstractOracleConnector(@Nonnull String name) {
@@ -106,7 +110,8 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
         url = "jdbc:oracle:thin:@//" + host + ":" + port + "/" + arguments.getOracleServicename();
       }
     }
-    // LOG.info("URL IS " + url);
+    url = String.format("%s?%s", USE_FETCH_SIZE_WITH_LONG_COLUMN_ARG);
+
     Driver driver = newDriver(arguments.getDriverPaths(), "oracle.jdbc.OracleDriver");
     DataSource dataSource =
         new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -26,7 +26,7 @@ import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArg
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInputs;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector;
-import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
+import com.google.edwmigration.dumper.application.dumper.connector.ConnectorPropertyWithDefault;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.utils.PropertyParser;
@@ -79,9 +79,9 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
 
   public static final int OPT_PORT_DEFAULT = 1521;
 
-  protected enum CommonOracleConnectorProperty implements ConnectorProperty {
+  protected enum CommonOracleConnectorProperty implements ConnectorPropertyWithDefault {
     USE_FETCH_SIZE_WITH_LONG_COLUMN(
-        "oracle.useFetchSizeWithLongColumn",
+        "oracle.use-fetch-size-with-long-column",
         "Enables prefetch of rows with a LONG or LONG RAW column. This parameter improves the query performance"
             + " but can result in higher memory consumption. Default value: \"true\", set to \"false\" to disable it.",
         "true");
@@ -111,11 +111,15 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
     public String getDescription() {
       return description;
     }
+
+    public String getDefaultValue() {
+      return defaultValue.orElse("");
+    }
   }
 
   @Nonnull
   @Override
-  public Class<? extends Enum<? extends ConnectorProperty>> getConnectorProperties() {
+  public Class<? extends Enum<? extends ConnectorPropertyWithDefault>> getConnectorProperties() {
     return CommonOracleConnectorProperty.class;
   }
 
@@ -151,7 +155,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
         PropertyParser.getString(
                 arguments, CommonOracleConnectorProperty.USE_FETCH_SIZE_WITH_LONG_COLUMN)
             .orElse(
-                CommonOracleConnectorProperty.USE_FETCH_SIZE_WITH_LONG_COLUMN.defaultValue.get()));
+                CommonOracleConnectorProperty.USE_FETCH_SIZE_WITH_LONG_COLUMN.getDefaultValue()));
 
     return properties;
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -110,7 +110,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
         url = "jdbc:oracle:thin:@//" + host + ":" + port + "/" + arguments.getOracleServicename();
       }
     }
-    url = String.format("%s?%s", USE_FETCH_SIZE_WITH_LONG_COLUMN_ARG);
+    url = String.format("%s?%s", url, USE_FETCH_SIZE_WITH_LONG_COLUMN_ARG);
 
     Driver driver = newDriver(arguments.getDriverPaths(), "oracle.jdbc.OracleDriver");
     DataSource dataSource =

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -59,7 +59,6 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 public class OracleMetadataConnector extends AbstractOracleConnector
     implements MetadataConnector, OracleMetadataDumpFormat {
 
-  @SuppressWarnings("UnusedVariable")
   private static final Logger LOG = LoggerFactory.getLogger(OracleMetadataConnector.class);
 
   public OracleMetadataConnector() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/PropertyParser.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/PropertyParser.java
@@ -20,6 +20,7 @@ import com.google.common.collect.Range;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
+import java.util.Optional;
 import java.util.OptionalLong;
 import org.apache.commons.lang3.StringUtils;
 
@@ -58,6 +59,23 @@ public class PropertyParser {
           createErrorMessage(stringValue, property, allowedRange));
     }
     return OptionalLong.of(value);
+  }
+
+  /**
+   * Gets the a string property passed as an argument to the command-line option.
+   *
+   * @param arguments all command-line options
+   * @param property command-line option
+   * @return the string value of the argument or an empty optional
+   */
+  public static Optional<String> getString(
+      ConnectorArguments arguments, ConnectorProperty property) {
+    String stringValue = arguments.getDefinition(property);
+    if (StringUtils.isEmpty(stringValue)) {
+      return Optional.empty();
+    }
+
+    return Optional.of(stringValue);
   }
 
   private static String createErrorMessage(


### PR DESCRIPTION
Oracle metadata extraction takes extremely lot of time for some tables. It processes 5-8 records per second resulting in many hours of extraction. This is caused by extracting columns with type LONG.

useFetchSizeWithLongColumn parameter enables prefetch of rows with a LONG or LONG RAW column. It significantly reduces extraction time. (for my test instance: 10h -> 5min).

This PR enables `useFetchSizeWithLongColumn` by default. User can disable it by setting `-Doracle.useFetchSizeWithLongColumn=false` command line argument or including this property in the connection URL. 
