### PR TITLE
Make Snowflake QUERY_ACCELERATION_HISTORY optional

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
@@ -121,17 +121,10 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
   protected static class TeradataJdbcSelectTask extends JdbcSelectTask {
 
     private final String sqlCount;
-    private final TaskCategory category;
 
     public TeradataJdbcSelectTask(String targetPath, TaskCategory category, String sqlTemplate) {
-      super(targetPath, String.format(sqlTemplate, "*"));
+      super(targetPath, String.format(sqlTemplate, "*"), Preconditions.checkNotNull(category));
       this.sqlCount = sqlTemplate.contains("%s") ? String.format(sqlTemplate, "count(*)") : null;
-      this.category = Preconditions.checkNotNull(category);
-    }
-
-    @Override
-    public TaskCategory getCategory() {
-      return category;
     }
 
     // This works to execute the count SQL on the same connection as the data SQL,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectTask.java
@@ -33,9 +33,23 @@ public class JdbcSelectTask extends AbstractJdbcTask<Summary> {
 
   @Nonnull private final String sql;
 
+  @Nonnull private final TaskCategory taskCategory;
+
   public JdbcSelectTask(@Nonnull String targetPath, @Nonnull String sql) {
+    this(targetPath, sql, TaskCategory.REQUIRED);
+  }
+
+  public JdbcSelectTask(
+      @Nonnull String targetPath, @Nonnull String sql, TaskCategory taskCategory) {
     super(targetPath);
     this.sql = sql;
+    this.taskCategory = taskCategory;
+  }
+
+  @Override
+  @Nonnull
+  public TaskCategory getCategory() {
+    return taskCategory;
   }
 
   @Nonnull


### PR DESCRIPTION
The extraction of Snowflake `QUERY_ACCELERATION_HISTORY` table is sometimes not possible, therefore I'm changing the TaskCategory from `REQUIRED` to `OPTIONAL`, so that the extraction doesn't fail in case this table is not available.

Additionally, cleanup the `TeradataJdbcSelectTask` class, because otherwise the `TeradataJdbcSelectTask` class would contain a duplicated code between it and the `JdbcSelectTask` class.