### PR TITLE
[b/323519703] Fix Oracle XML tasks

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -34,7 +34,6 @@ public interface Connector {
   @Nonnull
   public String getDefaultFileName(boolean isAssessment);
 
-  @Nonnull
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception;
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -139,7 +139,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
 
   @Nonnull
   @Override
-  public Handle open(ConnectorArguments arguments) throws Exception {
+  public Handle open(@Nonnull ConnectorArguments arguments) throws Exception {
     Driver driver = newDriver(arguments.getDriverPaths(), "oracle.jdbc.OracleDriver");
     DataSource dataSource =
         new SimpleDriverDataSource(driver, buildUrl(arguments), buildProperties(arguments));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -33,6 +33,8 @@ import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleMetadataDumpFormat;
+import com.google.j2objc.annotations.LoopTranslation.LoopStyle;
+
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -148,7 +150,7 @@ public class OracleMetadataConnector extends AbstractOracleConnector
     return new SelectTask(
         file,
         String.format(
-            "SELECT %s, %s, DBMS_METADATA.GET_XML('%s', %s, %s) FROM %s u %s",
+            "SELECT %s, %s, DBMS_METADATA.GET_XML('%s', %s, %s) FROM %s %s",
             ownerColumn, nameColumn, objectType, nameColumn, ownerColumn, table, where));
   }
 
@@ -195,10 +197,10 @@ public class OracleMetadataConnector extends AbstractOracleConnector
     String whereCondFunctionOwner =
         " WHERE OBJECT_NAME = 'FUNCTION'"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
-    // Since version 11g Oracle has introduced deferred segment creation.
-    // This filter removes iot overflow segments and tables with no segment created.
+    // This filter removes iot overflow segments and nested tables.
+    // XML data does not exist for them what causes `not found` exception.
     String whereCondTableSegmentCreated =
-        " WHERE SEGMENT_CREATED='YES' AND (IOT_TYPE is null or IOT_TYPE='IOT')"
+        " WHERE NESTED='NO' AND (IOT_TYPE IS NULL OR IOT_TYPE='IOT')"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
 
     buildSelectStarTask(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -196,9 +196,9 @@ public class OracleMetadataConnector extends AbstractOracleConnector
         " WHERE OBJECT_NAME = 'FUNCTION'"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
     // Since version 11g Oracle has introduced deferred segment creation.
-    // This results in DBMS_METADATA.GET_XML not found error for tables with no segment created.
+    // This filter removes iot overflow segments and tables with no segment created.
     String whereCondTableSegmentCreated =
-        " WHERE SEGMENT_CREATED='YES'"
+        " WHERE SEGMENT_CREATED='YES' AND (IOT_TYPE is null or IOT_TYPE='IOT')"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
 
     buildSelectStarTask(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -94,11 +94,10 @@ public class OracleMetadataConnector extends AbstractOracleConnector
       LOG.error("All the select tasks failed:");
       for (int i = 1; i <= tasks.length; i++) {
         LOG.error(
-            String.format(
-                "(%s): %s : %s",
-                i,
-                tasks[i].getName(),
-                ExceptionUtils.getRootCauseMessage(tasks[i].getException())));
+            "({}): {} : {}",
+            i,
+            tasks[i].getName(),
+            ExceptionUtils.getRootCauseMessage(tasks[i].getException()));
       }
       return null;
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -33,8 +33,6 @@ import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleMetadataDumpFormat;
-import com.google.j2objc.annotations.LoopTranslation.LoopStyle;
-
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -198,10 +196,13 @@ public class OracleMetadataConnector extends AbstractOracleConnector
         " WHERE OBJECT_NAME = 'FUNCTION'"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
     // This filter removes iot overflow segments and nested tables.
-    // XML data does not exist for them what causes `not found` exception.
-    String whereCondTableSegmentCreated =
+    // XML metadata does not exist for them what causes `not found` exception.
+    String whereCondTableXmlMetadata =
         " WHERE NESTED='NO' AND (IOT_TYPE IS NULL OR IOT_TYPE='IOT')"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
+    // XML metadata does not exist for predefined oracel types what result in not found exception.
+    String whereCondTypesNoPredefined =
+        " WHERE PREDEFINED='NO'" + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
 
     buildSelectStarTask(
         out,
@@ -322,7 +323,7 @@ public class OracleMetadataConnector extends AbstractOracleConnector
         "TABLE",
         "OWNER",
         "TABLE_NAME",
-        whereCondTableSegmentCreated);
+        whereCondTableXmlMetadata);
 
     buildSelectXmlTask(
         out,
@@ -366,7 +367,7 @@ public class OracleMetadataConnector extends AbstractOracleConnector
         "TYPE",
         "OWNER",
         "TYPE_NAME",
-        whereCondOwner);
+        whereCondTypesNoPredefined);
 
     buildSelectXmlTask(
         out,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -195,7 +195,8 @@ public class OracleMetadataConnector extends AbstractOracleConnector
     String whereCondFunctionOwner =
         " WHERE OBJECT_NAME = 'FUNCTION'"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
-    // XML metadata does not exist for iot overflow and nested tables what causes `not found` exception.
+    // XML metadata does not exist for iot overflow and nested tables what causes `not found`
+    // exception.
     String whereCondTableXmlMetadata =
         " WHERE NESTED='NO' AND (IOT_TYPE IS NULL OR IOT_TYPE='IOT')"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -92,12 +92,13 @@ public class OracleMetadataConnector extends AbstractOracleConnector
     protected Void doRun(TaskRunContext context, @Nonnull ByteSink sink, @Nonnull Handle handle)
         throws Exception {
       LOG.error("All the select tasks failed:");
-      for (int i = 1; i <= tasks.length; i++) {
+      int i = 1;
+      for (GroupTask<?> task : tasks) {
         LOG.error(
             "({}): {} : {}",
-            i,
-            tasks[i].getName(),
-            ExceptionUtils.getRootCauseMessage(tasks[i].getException()));
+            i++,
+            task.getName(),
+            ExceptionUtils.getRootCauseMessage(task.getException()));
       }
       return null;
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -195,12 +195,11 @@ public class OracleMetadataConnector extends AbstractOracleConnector
     String whereCondFunctionOwner =
         " WHERE OBJECT_NAME = 'FUNCTION'"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
-    // This filter removes iot overflow segments and nested tables.
-    // XML metadata does not exist for them what causes `not found` exception.
+    // XML metadata does not exist for iot overflow and nested tables what causes `not found` exception.
     String whereCondTableXmlMetadata =
         " WHERE NESTED='NO' AND (IOT_TYPE IS NULL OR IOT_TYPE='IOT')"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
-    // XML metadata does not exist for predefined oracel types what result in not found exception.
+    // XML metadata does not exist for predefined oracle types what result in `not found` exception.
     String whereCondTypesNoPredefined =
         " WHERE PREDEFINED='NO'" + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -349,8 +349,11 @@ public class OracleMetadataConnector extends AbstractOracleConnector
     String whereCondFunctionOwner =
         " WHERE OBJECT_NAME = 'FUNCTION'"
             + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
+    // Since version 11g Oracle has introduced deferred segment creation.
+    // This results in DBMS_METADATA.GET_XML not found error for tables with no segment created.
     String whereCondTableSegmentCreated =
-        " WHERE SEGMENT_CREATED='Y'" + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
+        " WHERE SEGMENT_CREATED='YES'"
+            + (ownerInList == null ? "" : " AND OWNER IN " + ownerInList);
 
     /*
         buildSelectStarTask(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -99,7 +99,6 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
     return jdbcHandle;
   }
 
-  @Nonnull
   private void setCurrentDatabase(@Nonnull String databaseName, @Nonnull JdbcTemplate jdbcTemplate)
       throws MetadataDumperUsageException {
     String currentDatabase =

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/OracleMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/OracleMetadataDumpFormat.java
@@ -672,7 +672,8 @@ public interface OracleMetadataDumpFormat {
 
   interface XmlFunctions {
 
-    final String ZIP_ENTRY_NAME = "Functions-XML.csv";
+    final String ZIP_ENTRY_NAME_DBA = "DBA.Functions-XML.csv";
+    final String ZIP_ENTRY_NAME_ALL = "ALL.Functions-XML.csv";
 
     enum Header {
       OWNER,


### PR DESCRIPTION
b/323519703
Existing Oracle XML tasks fail due to the missing argument placeholders in XML SQL query. What's more the XML metadata is retrieved sequentially for each object what makes it extremely slow. This PR fixes XML related issues and reduces extraction time:

- Replace custom XML task with regular SQL query to improve the performance. 
- Add filters for *_TABLES and *_TASKS to exclude objects not existing in DBMS_METADATA.

Extraction time was reduced from over 10h to ~25 minutes.
XML Metadata is correctly extracted for all objects.

![image](https://github.com/google/dwh-migration-tools/assets/14976096/0537ae80-ceba-4072-812e-7c2cbd0c4da6)
