### PR TITLE
Add Hive QOS allowed values to help message

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/DefaultArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/DefaultArguments.java
@@ -16,9 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper;
 
-import static com.google.edwmigration.dumper.application.dumper.utils.OptionalUtils.optionallyIfNotEmpty;
-import static java.util.Arrays.stream;
-
 import com.google.common.base.Joiner;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
@@ -27,7 +24,6 @@ import java.io.PrintStream;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
@@ -86,43 +82,6 @@ public class DefaultArguments {
       buf.append('/');
       joiner.appendTo(buf, V_FALSE);
       return buf.toString();
-    }
-  }
-
-  public enum HadoopRpcProtection {
-    AUTHENTICATION("auth"),
-    INTEGRITY("auth-int"),
-    PRIVACY("auth-conf");
-
-    private final String qopValue;
-
-    HadoopRpcProtection(String qopValue) {
-      this.qopValue = qopValue;
-    }
-  }
-
-  public interface Converter<V> {
-
-    Optional<V> convert(String value);
-  }
-
-  public static class HadoopSaslQopConverter implements Converter<String> {
-
-    public static HadoopSaslQopConverter INSTANCE = new HadoopSaslQopConverter();
-
-    private HadoopSaslQopConverter() {}
-
-    @Override
-    public Optional<String> convert(String value) throws MetadataDumperUsageException {
-      return optionallyIfNotEmpty(value).map(this::convertInternal);
-    }
-
-    private String convertInternal(String value) {
-      return stream(HadoopRpcProtection.values())
-          .filter(qop -> qop.name().equalsIgnoreCase(value))
-          .findFirst()
-          .map(qop -> qop.qopValue)
-          .orElseThrow(() -> new MetadataDumperUsageException("Not a valid QOP: " + value));
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/AbstractHiveConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/AbstractHiveConnector.java
@@ -20,12 +20,11 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSink;
 import com.google.common.util.concurrent.MoreExecutors;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.DefaultArguments.HadoopRpcProtection;
-import com.google.edwmigration.dumper.application.dumper.DefaultArguments.HadoopSaslQopConverter;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorPropertyWithDefault;
+import com.google.edwmigration.dumper.application.dumper.connector.hive.HadoopSaslQopConverter.HadoopRpcProtection;
 import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractTask;
@@ -251,7 +250,9 @@ public abstract class AbstractHiveConnector extends AbstractConnector {
     RPC_PROTECTION(
         "rpc.protection",
         "The 'hadoop.rpc.protection' configuration of your cluster. This determines the QOP of the"
-            + " SASL connection between hadoop and the dumper.",
+            + " SASL connection between hadoop and the dumper. Allowed values: '"
+            + HadoopRpcProtection.ALLOWED_VALUES
+            + "'.",
         HadoopRpcProtection.PRIVACY.name());
 
     private final String name;
@@ -303,8 +304,8 @@ public abstract class AbstractHiveConnector extends AbstractConnector {
                 HiveMetastoreThriftClient.Builder.UnavailableClientVersionBehavior.FALLBACK)
             .withKerberosUrl(arguments.getHiveKerberosUrl());
 
-    HadoopSaslQopConverter.INSTANCE
-        .convert(arguments.getDefinitionOrDefault(HiveConnectorProperty.RPC_PROTECTION))
+    HadoopSaslQopConverter.convert(
+            arguments.getDefinitionOrDefault(HiveConnectorProperty.RPC_PROTECTION))
         .ifPresent(thriftClientBuilder::withSaslQop);
 
     return new ThriftClientHandle(thriftClientBuilder, arguments.getThreadPoolSize());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HadoopSaslQopConverter.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HadoopSaslQopConverter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.hive;
+
+import static com.google.edwmigration.dumper.application.dumper.utils.OptionalUtils.optionallyIfNotEmpty;
+import static java.util.Arrays.stream;
+import static java.util.stream.Collectors.joining;
+
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.edwmigration.dumper.application.dumper.connector.hive.AbstractHiveConnector.HiveConnectorProperty;
+import java.util.Optional;
+
+public class HadoopSaslQopConverter {
+
+  enum HadoopRpcProtection {
+    AUTHENTICATION("auth"),
+    INTEGRITY("auth-int"),
+    PRIVACY("auth-conf");
+
+    static final String ALLOWED_VALUES =
+        stream(HadoopRpcProtection.values())
+            .map(protection -> protection.name().toLowerCase())
+            .collect(joining(", "));
+
+    private final String qopValue;
+
+    HadoopRpcProtection(String qopValue) {
+      this.qopValue = qopValue;
+    }
+  }
+
+  static Optional<String> convert(String value) throws MetadataDumperUsageException {
+    return optionallyIfNotEmpty(value).map(HadoopSaslQopConverter::convertInternal);
+  }
+
+  private static String convertInternal(String value) {
+    return stream(HadoopRpcProtection.values())
+        .filter(qop -> qop.name().equalsIgnoreCase(value))
+        .findFirst()
+        .map(qop -> qop.qopValue)
+        .orElseThrow(
+            () ->
+                new MetadataDumperUsageException(
+                    String.format(
+                        "Invalid value '%s' for property '%s'. Allowed values are: '%s'.",
+                        value,
+                        HiveConnectorProperty.RPC_PROTECTION.getName(),
+                        HadoopRpcProtection.ALLOWED_VALUES)));
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HadoopSaslQopConverterTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HadoopSaslQopConverterTest.java
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.google.edwmigration.dumper.application.dumper;
+package com.google.edwmigration.dumper.application.dumper.connector.hive;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import com.google.edwmigration.dumper.application.dumper.DefaultArguments.HadoopSaslQopConverter;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
@@ -31,14 +31,14 @@ public class HadoopSaslQopConverterTest {
 
   @Test
   public void convert_success() {
-    String qop = HadoopSaslQopConverter.INSTANCE.convert("integrity").get();
+    String qop = HadoopSaslQopConverter.convert("integrity").get();
 
     assertEquals("auth-int", qop);
   }
 
   @Test
   public void convert_emptyString() {
-    assertFalse(HadoopSaslQopConverter.INSTANCE.convert("").isPresent());
+    assertFalse(HadoopSaslQopConverter.convert("").isPresent());
   }
 
   @Test
@@ -47,9 +47,12 @@ public class HadoopSaslQopConverterTest {
         Assert.assertThrows(
             MetadataDumperUsageException.class,
             () -> {
-              Optional<String> ignored = HadoopSaslQopConverter.INSTANCE.convert("invalid-value");
+              Optional<String> ignored = HadoopSaslQopConverter.convert("auth");
             });
 
-    assertEquals("Not a valid QOP: invalid-value", exception.getMessage());
+    assertEquals(
+        "Invalid value 'auth' for property 'hiveql.rpc.protection'."
+            + " Allowed values are: 'authentication, integrity, privacy'.",
+        exception.getMessage());
   }
 }


### PR DESCRIPTION
Additionally, move `HadoopSaslQopConverter` from `DefaultArguments` to the hive-specific package.