### PR TITLE
Extract ExpandedViewText as ViewText from the Hive metastore.

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -190,7 +190,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
               outTable.createTime = table.getCreateTime();
               outTable.lastAccessTime = table.getLastAccessTime();
               outTable.owner = table.getOwner();
-              outTable.viewText = table.getOriginalViewText();
+              outTable.viewText = table.getExpandedViewText();
               outTable.location = table.getLocation();
               outTable.lastDdlTime = table.getLastDdlTime();
               outTable.totalSize = table.getTotalSize();


### PR DESCRIPTION
When the view text contains a quoted string; `Table.getOriginalViewText` returns the unquoted strings. 

For example, for following view created in Hive:
```
use test;
create view `order` as select `from`, `to` from s;
```

We get following output in `tables.jsonl`.
```
{"schemaName":"test","name":"order","type":"VIRTUAL_VIEW","createTime":1709638155,"lastAccessTime":0,"owner":"root","viewText":"select from, to from s","lastDdlTime":1709638155,"retention":0,"bucketsCount":-1,"isCompressed":false,"fields":[{"name":"from","type":"string"},{"name":"to","type":"string"}],"partitionKeys":[],"partitions":[]}
```
This causes issue in view compilation, since reserved words are not quoted. Also tables are not qualified with required session schema.

Using `Table.getExpandedViewText` fixes both of these problems.

We get following output in `tables.jsonl` after using `ExpandedViewText`:
```
{"schemaName":"test","name":"order","type":"VIRTUAL_VIEW","createTime":1709638155,"lastAccessTime":0,"owner":"root","viewText":"select `s`.`from`, `s`.`to` from `test`.`s`","lastDdlTime":1709638155,"retention":0,"bucketsCount":-1,"isCompressed":false,"fields":[{"name":"from","type":"string"},{"name":"to","type":"string"}],"partitionKeys":[
```