### PR TITLE
[329832604] Fix password-related NPEs in Oracle, provide more descriptive errors

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -676,8 +676,8 @@ public class ConnectorArguments extends DefaultArguments {
   /**
    * Get a password depending on the --password flag.
    *
-   * @return null if the --password flag is not provided otherwise, the result of
-   *     getPasswordOrPrompt()
+   * @return An empty optional if the --password flag is not provided. Otherwise, an optional
+   *     containing the result of getPasswordOrPrompt()
    */
   @Nonnull
   public Optional<String> getPasswordIfFlagProvided() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -665,22 +665,26 @@ public class ConnectorArguments extends DefaultArguments {
   public String getUserOrFail() {
     String user = getOptions().valueOf(optionUser);
     if (user == null) {
-      throw new MetadataDumperUsageException("Required username was not provided.");
+      throw new MetadataDumperUsageException(
+        "Required username was not provided. Please use the " + OPT_USER +
+        " flag to provide the username");
     }
     return user;
   }
 
-  @CheckForNull
-  public String getPasswordIfProvided() {
-    if (getOptions().has(optionPass)) {
-      return getPassword();
-    } else {
-      return null;
-    }
+  /**
+   * Get a password depending on the --password flag.
+   *
+   * @return null if the --password flag is not provided
+   * otherwise, the result of getPasswordOrPrompt()
+   */
+  @Nonnull
+  public Optional<String> getPasswordIfFlagProvided() {
+    return optionallyWhen(getOptions().has(optionPass), this::getPasswordOrPrompt);
   }
 
   @Nonnull
-  public String getPassword() {
+  public String getPasswordOrPrompt() {
     String password = getOptions().valueOf(optionPass);
     if (password != null) {
       return password;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -666,8 +666,9 @@ public class ConnectorArguments extends DefaultArguments {
     String user = getOptions().valueOf(optionUser);
     if (user == null) {
       throw new MetadataDumperUsageException(
-        "Required username was not provided. Please use the " + OPT_USER +
-        " flag to provide the username");
+          "Required username was not provided. Please use the "
+              + OPT_USER
+              + " flag to provide the username");
     }
     return user;
   }
@@ -675,8 +676,8 @@ public class ConnectorArguments extends DefaultArguments {
   /**
    * Get a password depending on the --password flag.
    *
-   * @return null if the --password flag is not provided
-   * otherwise, the result of getPasswordOrPrompt()
+   * @return null if the --password flag is not provided otherwise, the result of
+   *     getPasswordOrPrompt()
    */
   @Nonnull
   public Optional<String> getPasswordIfFlagProvided() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -666,9 +666,9 @@ public class ConnectorArguments extends DefaultArguments {
     String user = getOptions().valueOf(optionUser);
     if (user == null) {
       throw new MetadataDumperUsageException(
-          "Required username was not provided. Please use the "
+          "Required username was not provided. Please use the '--"
               + OPT_USER
-              + " flag to provide the username");
+              + "' flag to provide the username.");
     }
     return user;
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
@@ -170,7 +170,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
     if (!driver.acceptsURL(url))
       throw new MetadataDumperUsageException(
           "JDBC driver " + driver + " does not accept URL " + url);
-    String password = arguments.getPasswordIfProvided();
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
     return new JdbcDataSource(driver, url, arguments.getUser(), password);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
@@ -170,6 +170,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
     if (!driver.acceptsURL(url))
       throw new MetadataDumperUsageException(
           "JDBC driver " + driver + " does not accept URL " + url);
-    return new JdbcDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    return new JdbcDataSource(driver, url, arguments.getUser(), password);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/mysql/AbstractMysqlConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/mysql/AbstractMysqlConnector.java
@@ -66,8 +66,8 @@ public abstract class AbstractMysqlConnector extends AbstractJdbcConnector {
 
     Driver driver =
         newDriver(arguments.getDriverPaths(), "com.mysql.jdbc.Driver", "org.mariadb.jdbc.Driver");
-    DataSource dataSource =
-        new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/mysql/AbstractMysqlConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/mysql/AbstractMysqlConnector.java
@@ -66,7 +66,7 @@ public abstract class AbstractMysqlConnector extends AbstractJdbcConnector {
 
     Driver driver =
         newDriver(arguments.getDriverPaths(), "com.mysql.jdbc.Driver", "org.mariadb.jdbc.Driver");
-    String password = arguments.getPasswordIfProvided();
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
     DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
@@ -317,8 +317,8 @@ public class NetezzaMetadataConnector extends AbstractJdbcConnector
     }
 
     Driver driver = newDriver(arguments.getDriverPaths(), "org.netezza.Driver");
-    DataSource dataSource =
-        new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
@@ -317,7 +317,7 @@ public class NetezzaMetadataConnector extends AbstractJdbcConnector
     }
 
     Driver driver = newDriver(arguments.getDriverPaths(), "org.netezza.Driver");
-    String password = arguments.getPasswordIfProvided();
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
     DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -139,16 +139,17 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
 
   @Nonnull
   @Override
-  public Handle open(ConnectorArguments arguments) throws Exception {
+  public Handle open(@Nonnull ConnectorArguments arguments) throws Exception {
     Driver driver = newDriver(arguments.getDriverPaths(), "oracle.jdbc.OracleDriver");
     DataSource dataSource =
         new SimpleDriverDataSource(driver, buildUrl(arguments), buildProperties(arguments));
     return new JdbcHandle(dataSource);
   }
 
-  private Properties buildProperties(ConnectorArguments arguments) {
+  @Nonnull
+  Properties buildProperties(@Nonnull ConnectorArguments arguments) {
     Properties properties = new Properties();
-    properties.setProperty("user", arguments.getUser());
+    properties.setProperty("user", arguments.getUserOrFail());
     properties.setProperty("password", arguments.getPassword());
     properties.setProperty(
         "useFetchSizeWithLongColumn",

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -150,7 +150,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
   Properties buildProperties(@Nonnull ConnectorArguments arguments) {
     Properties properties = new Properties();
     properties.setProperty("user", arguments.getUserOrFail());
-    properties.setProperty("password", arguments.getPassword());
+    properties.setProperty("password", arguments.getPasswordOrPrompt());
     properties.setProperty(
         "useFetchSizeWithLongColumn",
         PropertyParser.getString(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -147,7 +147,8 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
         + Iterables.getFirst(arguments.getDatabases(), "") //
         + new JdbcPropBuilder("?=&")
             .propOrWarn("user", arguments.getUser(), "--user must be specified")
-            .propOrWarn("password", arguments.getPassword(), "--password must be specified")
+            .propOrWarn(
+                "password", arguments.getPasswordIfProvided(), "--password must be specified")
             .prop("ssl", "true")
             .toJdbcPart();
   }
@@ -163,7 +164,8 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
         + Iterables.getFirst(arguments.getDatabases(), "") //
         + new JdbcPropBuilder("?=&")
             .propOrWarn("UID", arguments.getUser(), "--user must be specified")
-            .propOrWarn("PWD", arguments.getPassword(), "--password must be specified")
+            .propOrWarn(
+                "PWD", arguments.getPasswordIfProvided(), "--password must be specified")
             .toJdbcPart();
   }
 
@@ -214,7 +216,7 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
       boolean isDriverRedshift = driver.acceptsURL("jdbc:redshift:iam://host/db");
       // there may be no --iam options, in which case default ~/.aws/credentials to be used.
       // so this is the only reliable check
-      boolean isAuthenticationPassword = arguments.getPassword() != null;
+      boolean isAuthenticationPassword = arguments.getPasswordIfProvided() != null;
 
       if (!isDriverRedshift) {
         if (!isAuthenticationPassword)
@@ -234,8 +236,8 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
     //   DSILogLevel=0..6;LogPath=C:\temp
     //   LogLevel 0/1
     LOG.trace("URI is " + url);
-    DataSource dataSource =
-        new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
 
     return JdbcHandle.newPooledJdbcHandle(dataSource, arguments.getThreadPoolSize());
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -238,7 +238,8 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
     //   DSILogLevel=0..6;LogPath=C:\temp
     //   LogLevel 0/1
     LOG.trace("URI is " + url);
-    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password.orElse(null));
+    DataSource dataSource =
+        new SimpleDriverDataSource(driver, url, arguments.getUser(), password.orElse(null));
 
     return JdbcHandle.newPooledJdbcHandle(dataSource, arguments.getThreadPoolSize());
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -96,7 +96,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
 
     Driver driver =
         newDriver(arguments.getDriverPaths(), "net.snowflake.client.jdbc.SnowflakeDriver");
-    String password = arguments.getPasswordIfProvided();
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
     DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     JdbcHandle jdbcHandle = new JdbcHandle(dataSource);
     setCurrentDatabase(databaseName, jdbcHandle.getJdbcTemplate());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -96,8 +96,8 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
 
     Driver driver =
         newDriver(arguments.getDriverPaths(), "net.snowflake.client.jdbc.SnowflakeDriver");
-    DataSource dataSource =
-        new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     JdbcHandle jdbcHandle = new JdbcHandle(dataSource);
     setCurrentDatabase(databaseName, jdbcHandle.getJdbcTemplate());
     return jdbcHandle;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/sqlserver/SqlServerMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/sqlserver/SqlServerMetadataConnector.java
@@ -117,7 +117,7 @@ public class SqlServerMetadataConnector extends AbstractJdbcConnector
     // LOG.info("Connecting to URL {}", url);
     Driver driver =
         newDriver(arguments.getDriverPaths(), "com.microsoft.sqlserver.jdbc.SQLServerDriver");
-    String password = arguments.getPasswordIfProvided();
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
     DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/sqlserver/SqlServerMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/sqlserver/SqlServerMetadataConnector.java
@@ -117,8 +117,8 @@ public class SqlServerMetadataConnector extends AbstractJdbcConnector
     // LOG.info("Connecting to URL {}", url);
     Driver driver =
         newDriver(arguments.getDriverPaths(), "com.microsoft.sqlserver.jdbc.SQLServerDriver");
-    DataSource dataSource =
-        new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/AbstractVerticaConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/AbstractVerticaConnector.java
@@ -68,8 +68,8 @@ public abstract class AbstractVerticaConnector extends AbstractJdbcConnector {
     }
 
     Driver driver = newDriver(arguments.getDriverPaths(), "com.vertica.jdbc.Driver");
-    DataSource dataSource =
-        new SimpleDriverDataSource(driver, url, arguments.getUser(), arguments.getPassword());
+    String password = arguments.getPasswordIfProvided();
+    DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/AbstractVerticaConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/AbstractVerticaConnector.java
@@ -68,7 +68,7 @@ public abstract class AbstractVerticaConnector extends AbstractJdbcConnector {
     }
 
     Driver driver = newDriver(arguments.getDriverPaths(), "com.vertica.jdbc.Driver");
-    String password = arguments.getPasswordIfProvided();
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
     DataSource dataSource = new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
     return new JdbcHandle(dataSource);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
@@ -16,18 +16,16 @@
  */
 package com.google.edwmigration.dumper.application.dumper.io;
 
-import java.io.Console;
-
-import javax.annotation.Nonnull;
-
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.io.Console;
+import javax.annotation.Nonnull;
 
 /**
  * Provides the functionality of reading a password from prompt.
  *
- * Needed, because users may not want to provide the password on the command line.
- * This might be for security reasons or due to issues caused by special characters.
-*/
+ * <p>Needed, because users may not want to provide the password on the command line. This might be
+ * for security reasons or due to issues caused by special characters.
+ */
 public class PasswordReader {
 
   private boolean hasCachedValue = false;
@@ -42,7 +40,7 @@ public class PasswordReader {
     if (console == null) {
       // user requested a prompt, but we can't even get a console, so let's just fail
       throw new MetadataDumperUsageException(
-        "A password prompt was requested, but there is no console available.");
+          "A password prompt was requested, but there is no console available.");
     }
     console.printf("Password: ");
     cachedValue = new String(console.readPassword());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
@@ -6,24 +6,25 @@ import javax.annotation.Nonnull;
 
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 
-// Provides the functionality of reading a password from prompt.
-//
-// Needed, because users may not want to provide the password on the command line.
-// This might be for security reasons or due to issues caused by special characters.
+/**
+ * Provides the functionality of reading a password from prompt.
+ *
+ * Needed, because users may not want to provide the password on the command line.
+ * This might be for security reasons or due to issues caused by special characters.
+*/
 public class PasswordReader {
 
   private boolean hasCachedValue = false;
   @Nonnull private String cachedValue = "";
 
   @Nonnull
-  public String getOrPrompt() {
+  public synchronized String getOrPrompt() {
     if (hasCachedValue) {
       return cachedValue;
     }
     Console console = System.console();
     if (console == null) {
       // user requested a prompt, but we can't even get a console, so let's just fail
-      // - continuing with a null password is almost certainly not what the user wants here
       throw new MetadataDumperUsageException(
         "A password prompt was requested, but there is no console available.");
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.edwmigration.dumper.application.dumper.io;
 
 import java.io.Console;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/io/PasswordReader.java
@@ -1,0 +1,35 @@
+package com.google.edwmigration.dumper.application.dumper.io;
+
+import java.io.Console;
+
+import javax.annotation.Nonnull;
+
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+
+// Provides the functionality of reading a password from prompt.
+//
+// Needed, because users may not want to provide the password on the command line.
+// This might be for security reasons or due to issues caused by special characters.
+public class PasswordReader {
+
+  private boolean hasCachedValue = false;
+  @Nonnull private String cachedValue = "";
+
+  @Nonnull
+  public String getOrPrompt() {
+    if (hasCachedValue) {
+      return cachedValue;
+    }
+    Console console = System.console();
+    if (console == null) {
+      // user requested a prompt, but we can't even get a console, so let's just fail
+      // - continuing with a null password is almost certainly not what the user wants here
+      throw new MetadataDumperUsageException(
+        "A password prompt was requested, but there is no console available.");
+    }
+    console.printf("Password: ");
+    cachedValue = new String(console.readPassword());
+    hasCachedValue = true;
+    return cachedValue;
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
@@ -70,19 +70,19 @@ public class ConnectorArgumentsTest {
   }
 
   @Test
-  public void testNoUserFlag() throws IOException {
+  public void getUserOrFail_noUserFlag_throwsException() throws IOException {
     ConnectorArguments arguments = new ConnectorArguments("--connector", "abcABC123");
-    Runnable action = () -> arguments.getUserOrFail();
-    String expectedMessage =
-        "Required username was not provided. Please use the '--user' flag to provide the username.";
 
-    Exception exception = assertThrows(MetadataDumperUsageException.class, action::run);
+    Exception exception =
+        assertThrows(MetadataDumperUsageException.class, arguments::getUserOrFail);
 
-    assertEquals(expectedMessage, exception.getMessage());
+    assertEquals(
+        "Required username was not provided. Please use the '--user' flag to provide the username.",
+        exception.getMessage());
   }
 
   @Test
-  public void testValidUserFlag() throws IOException {
+  public void getUserOrFail_success() throws IOException {
     String expectedName = "admin456";
     ConnectorArguments arguments =
         new ConnectorArguments("--connector", "abcABC123", "--user", expectedName);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
@@ -73,8 +73,12 @@ public class ConnectorArgumentsTest {
   public void testNoUserFlag() throws IOException {
     ConnectorArguments arguments = new ConnectorArguments("--connector", "abcABC123");
     Runnable action = () -> arguments.getUserOrFail();
+    String expectedMessage =
+      "Required username was not provided. Please use the '--user' flag to provide the username.";
 
-    assertThrows(MetadataDumperUsageException.class, action::run);
+    Exception exception = assertThrows(MetadataDumperUsageException.class, action::run);
+
+    assertEquals(expectedMessage, exception.getMessage());
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
@@ -32,7 +33,7 @@ public class ConnectorArgumentsTest {
   @Test
   public void getDatabases_success() throws IOException {
     ConnectorArguments arguments =
-        new ConnectorArguments(new String[] {"--connector", "teradata", "--database", "sample-db"});
+        new ConnectorArguments("--connector", "teradata", "--database", "sample-db");
 
     List<String> databaseNames = arguments.getDatabases();
 
@@ -41,7 +42,7 @@ public class ConnectorArgumentsTest {
 
   @Test
   public void getDatabases_databaseOptionNotSpecified_success() throws IOException {
-    ConnectorArguments arguments = new ConnectorArguments(new String[] {"--connector", "teradata"});
+    ConnectorArguments arguments = new ConnectorArguments("--connector", "teradata");
 
     List<String> databaseNames = arguments.getDatabases();
 
@@ -51,7 +52,7 @@ public class ConnectorArgumentsTest {
   @Test
   public void getDatabases_trimDatabaseNames() throws IOException {
     ConnectorArguments arguments =
-        new ConnectorArguments(new String[] {"--connector", "teradata", "--database", "db1, db2 "});
+        new ConnectorArguments("--connector", "teradata", "--database", "db1, db2 ");
 
     List<String> databaseNames = arguments.getDatabases();
 
@@ -61,11 +62,29 @@ public class ConnectorArgumentsTest {
   @Test
   public void getDatabases_trimDatabaseNamesFilteringOutBlankStrings() throws IOException {
     ConnectorArguments arguments =
-        new ConnectorArguments(
-            new String[] {"--connector", "teradata", "--database", "db1, ,,, db2 "});
+        new ConnectorArguments("--connector", "teradata", "--database", "db1, ,,, db2 ");
 
     List<String> databaseNames = arguments.getDatabases();
 
     assertEquals(ImmutableList.of("db1", "db2"), databaseNames);
+  }
+
+  @Test
+  public void testNoUserFlag() throws IOException {
+    ConnectorArguments arguments = new ConnectorArguments("--connector", "abcABC123");
+    Runnable action = () -> arguments.getUserOrFail();
+
+    assertThrows(MetadataDumperUsageException.class, action::run);
+  }
+
+  @Test
+  public void testValidUserFlag() throws IOException {
+    String expectedName = "admin456";
+    ConnectorArguments arguments =
+        new ConnectorArguments("--connector", "abcABC123", "--user", expectedName);
+
+    String actualName = arguments.getUserOrFail();
+
+    assertEquals(expectedName, actualName);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
@@ -74,7 +74,7 @@ public class ConnectorArgumentsTest {
     ConnectorArguments arguments = new ConnectorArguments("--connector", "abcABC123");
     Runnable action = () -> arguments.getUserOrFail();
     String expectedMessage =
-      "Required username was not provided. Please use the '--user' flag to provide the username.";
+        "Required username was not provided. Please use the '--user' flag to provide the username.";
 
     Exception exception = assertThrows(MetadataDumperUsageException.class, action::run);
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static org.junit.Assert.assertEquals;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -35,7 +35,7 @@ public class AbstractOracleConnectorTest {
   private final AbstractOracleConnector connector = new OracleMetadataConnector();
 
   @Test
-  public void testValid() {
+  public void buildProperties_success() {
     when(arguments.getPasswordOrPrompt()).thenReturn(EXAMPLE_PASSWORD);
     when(arguments.getUserOrFail()).thenReturn(EXAMPLE_USER);
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -12,22 +12,20 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class AbstractOracleConnectorTest {
-  // provide mocks only with a username and a password
-  // ignore the useFetchSize... property, because it has a default
-  private static final String EXPECTED_PASSWORD = "p4ssw0rd";
-  private static final String EXPECTED_USER = "user123";
+  private static final String EXAMPLE_PASSWORD = "p4ssw0rd";
+  private static final String EXAMPLE_USER = "user123";
 
   private final ConnectorArguments arguments = mock(ConnectorArguments.class);
   private final AbstractOracleConnector connector = new OracleMetadataConnector();
 
   @Test
   public void testValid() {
-    when(arguments.getPassword()).thenReturn(EXPECTED_PASSWORD);
-    when(arguments.getUserOrFail()).thenReturn(EXPECTED_USER);
+    when(arguments.getPasswordOrPrompt()).thenReturn(EXAMPLE_PASSWORD);
+    when(arguments.getUserOrFail()).thenReturn(EXAMPLE_USER);
 
     Properties actual = connector.buildProperties(arguments);
 
-    assertEquals(EXPECTED_PASSWORD, actual.getProperty("password"));
-    assertEquals(EXPECTED_USER, actual.getProperty("user"));
+    assertEquals(EXAMPLE_PASSWORD, actual.getProperty("password"));
+    assertEquals(EXAMPLE_USER, actual.getProperty("user"));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -1,0 +1,33 @@
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import java.util.Properties;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class AbstractOracleConnectorTest {
+  // provide mocks only with a username and a password
+  // ignore the useFetchSize... property, because it has a default
+  private static final String EXPECTED_PASSWORD = "p4ssw0rd";
+  private static final String EXPECTED_USER = "user123";
+
+  private final ConnectorArguments arguments = mock(ConnectorArguments.class);
+  private final AbstractOracleConnector connector = new OracleMetadataConnector();
+
+  @Test
+  public void testValid() {
+    when(arguments.getPassword()).thenReturn(EXPECTED_PASSWORD);
+    when(arguments.getUserOrFail()).thenReturn(EXPECTED_USER);
+
+    Properties actual = connector.buildProperties(arguments);
+
+    assertEquals(EXPECTED_PASSWORD, actual.getProperty("password"));
+    assertEquals(EXPECTED_USER, actual.getProperty("user"));
+  }
+}


### PR DESCRIPTION
### Introduce changes to how password prompts are handled by Dumper:

1. If the user requested a prompt (i.e. there's an empty `--password` flag), but Dumper can't display the prompt due to having no access to a console, then Dumper will fail. Previously, Dumper would continue with a null password.
2. `getPassword()` is now a method that never returns a null password. If no password is provided or cached, it will always prompt. The method `getPasswordIfProvided()` provides the old functionality where it may be needed.
3. Handling the prompts was separated from `ConnectorArguments` since the two aren't very closely related and to prevent `ConnectorArguments` from getting too large.

### Handle cases where incomplete authorization is provided to Oracle connectors:

4. If a password is required, but there is no `--password` flag, then Dumper will prompt for a password. Previously, Dumper would use null as the password and continue.
5. The NullPointerException resulting from providing no password is now prevented - Oracle connectors will use the new `getPassword()`, so the password will never be null.
6. For both Oracle connectors, providing no username will cause an usage-exception with a message. Previously, Dumper would emit a NullPointerException.