### PR TITLE
337839892 Access CSV header creation logic without the need for an enum

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -278,12 +278,13 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
   }
 
   private static SQLException headerCountException(ImmutableList<?> items) {
-    Exception innerException = new MetadataDumperUsageException(
-      "Fatal Error. ResultSet does not have the expected column count: " + items.size(),
-      Arrays.asList(
-          "If a custom query has been specified please confirm the selected columns match"
-              + " the following: ",
-          StringUtils.join(items, ", ")));
+    Exception innerException =
+        new MetadataDumperUsageException(
+            "Fatal Error. ResultSet does not have the expected column count: " + items.size(),
+            Arrays.asList(
+                "If a custom query has been specified please confirm the selected columns match"
+                    + " the following: ",
+                StringUtils.join(items, ", ")));
     // Can we avoid nesting exceptions here?
     return new SQLException(innerException);
   }


### PR DESCRIPTION
The goal of this change is to add a different way of accessing existing `AbstractJdbcTask` logic. Existing behavior remains unchanged, existing code is changed slightly to avoid repetition.

Creating the CSV headers doesn't technically require:
- having an enum class: all we need is a list of names
- the caller being from an `AbstractJdbcTask` subclass:  neither the concept of a Dumper task nor JDBC is related to this functionality. It only deals with writing CSV.

This change adds a simpler way to access the functionality