### PR TITLE
[b/337839892] Create an empty oracle-stats connector

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -28,9 +28,9 @@ public interface LogsConnector extends Connector {
   default String getDefaultFileName(boolean isAssessment) {
     if (isAssessment) {
       Clock clock = Clock.systemDefaultZone();
-      return ArchiveNameUtil.getFileNameWithTimestamp(getName() + "-logs", clock);
+      return ArchiveNameUtil.getFileNameWithTimestamp(getName(), "logs", clock);
     } else {
-      return ArchiveNameUtil.getFileName(getName() + "-logs");
+      return ArchiveNameUtil.getFileName(getName(), "logs");
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -28,9 +28,9 @@ public interface LogsConnector extends Connector {
   default String getDefaultFileName(boolean isAssessment) {
     if (isAssessment) {
       Clock clock = Clock.systemDefaultZone();
-      return ArchiveNameUtil.getFileNameWithTime(getName(), "logs", clock);
+      return ArchiveNameUtil.getFileNameWithTimestamp(getName(), "logs", clock);
     } else {
-      return ArchiveNameUtil.getBasicFileName(getName(), "logs");
+      return ArchiveNameUtil.getFileName(getName(), "logs");
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -19,16 +19,20 @@ package com.google.edwmigration.dumper.application.dumper.connector;
 import java.text.Format;
 import java.text.SimpleDateFormat;
 import javax.annotation.Nonnull;
-import org.apache.commons.lang3.StringUtils;
 
 /** @author shevek */
 public interface LogsConnector extends Connector {
 
   @Nonnull
+  @Override
   default String getDefaultFileName(boolean isAssessment) {
+    String timeSuffix = isAssessment ? getTimeSuffix() : "";
+    return String.format("dwh-migration-%s-logs%s.zip", getName(), timeSuffix);
+  }
+
+  @Nonnull
+  static String getTimeSuffix() {
     Format format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
-    String timeSuffix = "-" + format.format(System.currentTimeMillis());
-    return String.format(
-        "dwh-migration-%s-logs%s.zip", getName(), isAssessment ? timeSuffix : StringUtils.EMPTY);
+    return "-" + format.format(System.currentTimeMillis());
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -28,9 +28,9 @@ public interface LogsConnector extends Connector {
   default String getDefaultFileName(boolean isAssessment) {
     if (isAssessment) {
       Clock clock = Clock.systemDefaultZone();
-      return ArchiveNameUtil.getFileNameWithTimestamp(getName(), "logs", clock);
+      return ArchiveNameUtil.getFileNameWithTimestamp(getName() + "-logs", clock);
     } else {
-      return ArchiveNameUtil.getFileName(getName(), "logs");
+      return ArchiveNameUtil.getFileName(getName() + "-logs");
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -16,8 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector;
 
-import java.text.Format;
-import java.text.SimpleDateFormat;
+import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
+import java.time.Clock;
 import javax.annotation.Nonnull;
 
 /** @author shevek */
@@ -26,13 +26,11 @@ public interface LogsConnector extends Connector {
   @Nonnull
   @Override
   default String getDefaultFileName(boolean isAssessment) {
-    String timeSuffix = isAssessment ? getTimeSuffix() : "";
-    return String.format("dwh-migration-%s-logs%s.zip", getName(), timeSuffix);
-  }
-
-  @Nonnull
-  static String getTimeSuffix() {
-    Format format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
-    return "-" + format.format(System.currentTimeMillis());
+    if (isAssessment) {
+      Clock clock = Clock.systemDefaultZone();
+      return ArchiveNameUtil.getFileNameWithTime(getName(), "logs", clock);
+    } else {
+      return ArchiveNameUtil.getBasicFileName(getName(), "logs");
+    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -25,6 +25,6 @@ public interface MetadataConnector extends Connector {
   @Nonnull
   @Override
   default String getDefaultFileName(boolean unused) {
-    return ArchiveNameUtil.getFileName(getName() + "-metadata");
+    return ArchiveNameUtil.getFileName(getName(), "metadata");
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -16,11 +16,15 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector;
 
+import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
+import javax.annotation.Nonnull;
+
 /** @author shevek */
 public interface MetadataConnector extends Connector {
 
+  @Nonnull
   @Override
-  default String getDefaultFileName(boolean isAssessment) {
-    return "dwh-migration-" + getName() + "-metadata.zip";
+  default String getDefaultFileName(boolean unused) {
+    return ArchiveNameUtil.getBasicFileName(getName(), "metadata");
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -25,6 +25,6 @@ public interface MetadataConnector extends Connector {
   @Nonnull
   @Override
   default String getDefaultFileName(boolean unused) {
-    return ArchiveNameUtil.getFileName(getName(), "metadata");
+    return ArchiveNameUtil.getFileName(getName() + "-metadata");
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -25,6 +25,6 @@ public interface MetadataConnector extends Connector {
   @Nonnull
   @Override
   default String getDefaultFileName(boolean unused) {
-    return ArchiveNameUtil.getBasicFileName(getName(), "metadata");
+    return ArchiveNameUtil.getFileName(getName(), "metadata");
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -79,6 +79,8 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
 
   public static final int OPT_PORT_DEFAULT = 1521;
 
+  private final OracleConnectorScope connectorScope;
+
   protected enum CommonOracleConnectorProperty implements ConnectorPropertyWithDefault {
     USE_FETCH_SIZE_WITH_LONG_COLUMN(
         "oracle.use-fetch-size-with-long-column",
@@ -123,8 +125,20 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
     return CommonOracleConnectorProperty.class;
   }
 
-  public AbstractOracleConnector(@Nonnull String name) {
-    super(name);
+  public AbstractOracleConnector(@Nonnull OracleConnectorScope connectorScope) {
+    super(connectorScope.toDisplayName());
+    this.connectorScope = connectorScope;
+  }
+
+  @Override
+  @Nonnull
+  public String getDefaultFileName(boolean isAssessment) {
+    return connectorScope.toFileName(isAssessment);
+  }
+
+  @Nonnull
+  String getFormatName() {
+    return connectorScope.toFormat();
   }
 
   private boolean isOracleSid(ConnectorArguments arguments) throws MetadataDumperUsageException {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -31,6 +31,7 @@ import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.utils.PropertyParser;
 import java.sql.Driver;
+import java.time.Clock;
 import java.util.Optional;
 import java.util.Properties;
 import javax.annotation.Nonnull;
@@ -133,7 +134,8 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
   @Override
   @Nonnull
   public String getDefaultFileName(boolean isAssessment) {
-    return connectorScope.toFileName(isAssessment);
+    Clock systemClock = Clock.systemDefaultZone();
+    return connectorScope.toFileName(isAssessment, systemClock);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -126,7 +126,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
   }
 
   public AbstractOracleConnector(@Nonnull OracleConnectorScope connectorScope) {
-    super(connectorScope.toDisplayName());
+    super(connectorScope.displayName());
     this.connectorScope = connectorScope;
   }
 
@@ -138,7 +138,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
 
   @Nonnull
   String getFormatName() {
-    return connectorScope.toFormat();
+    return connectorScope.formatName();
   }
 
   private boolean isOracleSid(ConnectorArguments arguments) throws MetadataDumperUsageException {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -126,7 +126,7 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
   }
 
   public AbstractOracleConnector(@Nonnull OracleConnectorScope connectorScope) {
-    super(connectorScope.displayName());
+    super(connectorScope.connectorName());
     this.connectorScope = connectorScope;
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -161,6 +161,11 @@ public abstract class AbstractOracleConnector extends AbstractJdbcConnector {
   }
 
   @Nonnull
+  OracleConnectorScope getConnectorScope() {
+    return connectorScope;
+  }
+
+  @Nonnull
   Properties buildProperties(@Nonnull ConnectorArguments arguments) {
     Properties properties = new Properties();
     properties.setProperty("user", arguments.getUserOrFail());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -27,12 +27,12 @@ enum OracleConnectorScope {
   STATS("oracle-stats", "oracle.stats.zip", "stats");
 
   private final String connectorName;
-  private final String format;
+  private final String formatName;
   private final String resultType;
 
-  OracleConnectorScope(String displayName, String format, String resultType) {
+  OracleConnectorScope(String displayName, String formatName, String resultType) {
     this.connectorName = displayName;
-    this.format = format;
+    this.formatName = formatName;
     this.resultType = resultType;
   }
 
@@ -53,6 +53,6 @@ enum OracleConnectorScope {
   }
 
   String formatName() {
-    return format;
+    return formatName;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -26,18 +26,18 @@ enum OracleConnectorScope {
   METADATA("oracle", OracleMetadataDumpFormat.FORMAT_NAME, "metadata"),
   STATS("oracle-stats", "oracle.stats.zip", "stats");
 
-  private final String displayName;
+  private final String connectorName;
   private final String format;
   private final String resultType;
 
   OracleConnectorScope(String displayName, String format, String resultType) {
-    this.displayName = displayName;
+    this.connectorName = displayName;
     this.format = format;
     this.resultType = resultType;
   }
 
-  String displayName() {
-    return displayName;
+  String connectorName() {
+    return connectorName;
   }
 
   String toFileName(boolean isAssessment) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -43,13 +43,13 @@ enum OracleConnectorScope {
   String toFileName(boolean isAssessment, Clock clock) {
     if (this == LOGS) {
       // add "-logs" twice for consistency with previous versions
-      String name = String.format("oracle-%s-%s", resultType, resultType);
+      String suffix = String.format("%s-%s", resultType, resultType);
       if (isAssessment) {
-        return ArchiveNameUtil.getFileNameWithTimestamp(name, clock);
+        return ArchiveNameUtil.getFileNameWithTimestamp("oracle", suffix, clock);
       }
-      return ArchiveNameUtil.getFileName(name);
+      return ArchiveNameUtil.getFileName("oracle", suffix);
     }
-    return ArchiveNameUtil.getFileName("oracle-" + resultType);
+    return ArchiveNameUtil.getFileName("oracle", resultType);
   }
 
   String formatName() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -43,9 +43,9 @@ enum OracleConnectorScope {
   String toFileName(boolean isAssessment) {
     if (this == LOGS && isAssessment) {
       Clock systemClock = Clock.systemDefaultZone();
-      return ArchiveNameUtil.getFileNameWithTimestamp("oracle", resultType, systemClock);
+      return ArchiveNameUtil.getFileNameWithTimestamp("oracle-" + resultType, systemClock);
     } else {
-      return ArchiveNameUtil.getFileName("oracle", resultType);
+      return ArchiveNameUtil.getFileName("oracle-" + resultType);
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -26,20 +26,16 @@ enum OracleConnectorScope {
   STATS;
 
   String toDisplayName() {
-    switch (this) {
-      case LOGS:
-        return "oracle-logs";
-      case METADATA:
-        return "oracle";
-      case STATS:
-        return "oracle-stats";
+    if (this == METADATA) {
+      return "oracle";
+    } else {
+      return "oracle-" + getResultType();
     }
-    throw new AssertionError();
   }
 
   String toFileName(boolean isAssessment) {
     String timeSuffix = getTimeSuffix(isAssessment);
-    return String.format("dwh-migration-%s%s.zip", toDisplayName(), timeSuffix);
+    return String.format("dwh-migration-oracle-%s%s.zip", getResultType(), timeSuffix);
   }
 
   String toFormat() {
@@ -50,6 +46,18 @@ enum OracleConnectorScope {
         return OracleMetadataDumpFormat.FORMAT_NAME;
       case STATS:
         return "oracle.stats.zip";
+    }
+    throw new AssertionError();
+  }
+
+  private String getResultType() {
+    switch (this) {
+      case LOGS:
+        return "logs";
+      case METADATA:
+        return "metadata";
+      case STATS:
+        return "stats";
     }
     throw new AssertionError();
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -40,10 +40,14 @@ enum OracleConnectorScope {
     return connectorName;
   }
 
-  String toFileName(boolean isAssessment) {
-    if (this == LOGS && isAssessment) {
-      Clock systemClock = Clock.systemDefaultZone();
-      return ArchiveNameUtil.getFileNameWithTimestamp("oracle-" + resultType, systemClock);
+  String toFileName(boolean isAssessment, Clock clock) {
+    if (this == LOGS) {
+      // add "-logs" twice for consistency with previous versions
+      String name = String.format("oracle-%s-%s", resultType, resultType);
+      if (isAssessment) {
+        return ArchiveNameUtil.getFileNameWithTimestamp(name, clock);
+      }
+      return ArchiveNameUtil.getFileName(name);
     }
     return ArchiveNameUtil.getFileName("oracle-" + resultType);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -16,9 +16,10 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
+import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleLogsDumpFormat;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleMetadataDumpFormat;
+import java.time.Clock;
 
 enum OracleConnectorScope {
   LOGS("oracle-logs", OracleLogsDumpFormat.FORMAT_NAME, "logs"),
@@ -40,13 +41,12 @@ enum OracleConnectorScope {
   }
 
   String toFileName(boolean isAssessment) {
-    String timeSuffix;
     if (this == LOGS && isAssessment) {
-      timeSuffix = LogsConnector.getTimeSuffix();
+      Clock systemClock = Clock.systemDefaultZone();
+      return ArchiveNameUtil.getFileNameWithTime("oracle", resultType, systemClock);
     } else {
-      timeSuffix = "";
+      return ArchiveNameUtil.getBasicFileName("oracle", resultType);
     }
-    return String.format("dwh-migration-oracle-%s%s.zip", resultType, timeSuffix);
   }
 
   String toFormat() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleLogsDumpFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleMetadataDumpFormat;
+
+enum OracleConnectorScope {
+  LOGS,
+  METADATA,
+  STATS;
+
+  String toDisplayName() {
+    switch (this) {
+      case LOGS:
+        return "oracle-logs";
+      case METADATA:
+        return "oracle";
+      case STATS:
+        return "oracle-stats";
+    }
+    throw new AssertionError();
+  }
+
+  String toFileName(boolean isAssessment) {
+    String timeSuffix = getTimeSuffix(isAssessment);
+    return String.format("dwh-migration-%s%s.zip", toDisplayName(), timeSuffix);
+  }
+
+  String toFormat() {
+    switch (this) {
+      case LOGS:
+        return OracleLogsDumpFormat.FORMAT_NAME;
+      case METADATA:
+        return OracleMetadataDumpFormat.FORMAT_NAME;
+      case STATS:
+        return "oracle.stats.zip";
+    }
+    throw new AssertionError();
+  }
+
+  private String getTimeSuffix(boolean isAssessment) {
+    if (this == LOGS && isAssessment) {
+      return LogsConnector.getTimeSuffix();
+    } else {
+      return "";
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -21,16 +21,22 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleLogsDumpFormat
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.OracleMetadataDumpFormat;
 
 enum OracleConnectorScope {
-  LOGS,
-  METADATA,
-  STATS;
+  LOGS("oracle-logs", OracleLogsDumpFormat.FORMAT_NAME, "logs"),
+  METADATA("oracle", OracleMetadataDumpFormat.FORMAT_NAME, "metadata"),
+  STATS("oracle-stats", "oracle.stats.zip", "stats");
+
+  private final String displayName;
+  private final String format;
+  private final String resultType;
+
+  OracleConnectorScope(String displayName, String format, String resultType) {
+    this.displayName = displayName;
+    this.format = format;
+    this.resultType = resultType;
+  }
 
   String toDisplayName() {
-    if (this == METADATA) {
-      return "oracle";
-    } else {
-      return "oracle-" + getResultType();
-    }
+    return displayName;
   }
 
   String toFileName(boolean isAssessment) {
@@ -40,30 +46,10 @@ enum OracleConnectorScope {
     } else {
       timeSuffix = "";
     }
-    return String.format("dwh-migration-oracle-%s%s.zip", getResultType(), timeSuffix);
+    return String.format("dwh-migration-oracle-%s%s.zip", resultType, timeSuffix);
   }
 
   String toFormat() {
-    switch (this) {
-      case LOGS:
-        return OracleLogsDumpFormat.FORMAT_NAME;
-      case METADATA:
-        return OracleMetadataDumpFormat.FORMAT_NAME;
-      case STATS:
-        return "oracle.stats.zip";
-    }
-    throw new AssertionError();
-  }
-
-  private String getResultType() {
-    switch (this) {
-      case LOGS:
-        return "logs";
-      case METADATA:
-        return "metadata";
-      case STATS:
-        return "stats";
-    }
-    throw new AssertionError();
+    return format;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -36,20 +36,20 @@ enum OracleConnectorScope {
     this.resultType = resultType;
   }
 
-  String toDisplayName() {
+  String displayName() {
     return displayName;
   }
 
   String toFileName(boolean isAssessment) {
     if (this == LOGS && isAssessment) {
       Clock systemClock = Clock.systemDefaultZone();
-      return ArchiveNameUtil.getFileNameWithTime("oracle", resultType, systemClock);
+      return ArchiveNameUtil.getFileNameWithTimestamp("oracle", resultType, systemClock);
     } else {
-      return ArchiveNameUtil.getBasicFileName("oracle", resultType);
+      return ArchiveNameUtil.getFileName("oracle", resultType);
     }
   }
 
-  String toFormat() {
+  String formatName() {
     return format;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -44,9 +44,8 @@ enum OracleConnectorScope {
     if (this == LOGS && isAssessment) {
       Clock systemClock = Clock.systemDefaultZone();
       return ArchiveNameUtil.getFileNameWithTimestamp("oracle-" + resultType, systemClock);
-    } else {
-      return ArchiveNameUtil.getFileName("oracle-" + resultType);
     }
+    return ArchiveNameUtil.getFileName("oracle-" + resultType);
   }
 
   String formatName() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -34,7 +34,12 @@ enum OracleConnectorScope {
   }
 
   String toFileName(boolean isAssessment) {
-    String timeSuffix = getTimeSuffix(isAssessment);
+    String timeSuffix;
+    if (this == LOGS && isAssessment) {
+      timeSuffix = LogsConnector.getTimeSuffix();
+    } else {
+      timeSuffix = "";
+    }
     return String.format("dwh-migration-oracle-%s%s.zip", getResultType(), timeSuffix);
   }
 
@@ -60,13 +65,5 @@ enum OracleConnectorScope {
         return "stats";
     }
     throw new AssertionError();
-  }
-
-  private String getTimeSuffix(boolean isAssessment) {
-    if (this == LOGS && isAssessment) {
-      return LogsConnector.getTimeSuffix();
-    } else {
-      return "";
-    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnector.java
@@ -34,7 +34,7 @@ public class OracleLogsConnector extends AbstractOracleConnector
     implements LogsConnector, OracleLogsDumpFormat {
 
   public OracleLogsConnector() {
-    super("oracle-logs");
+    super(OracleConnectorScope.LOGS);
   }
 
   /** Exists so we can extract query text CLOBs to Strings before they reach the CSVPrinter. */
@@ -48,7 +48,7 @@ public class OracleLogsConnector extends AbstractOracleConnector
   @Override
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(new DumpMetadataTask(arguments, getFormatName()));
     // It's not clear to me whether we should be using v$sqlarea instead here.
     String query =
         "SELECT sql_fulltext, cpu_time, elapsed_time, disk_reads, runtime_mem FROM v$sql";

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -180,7 +180,7 @@ public class OracleMetadataConnector extends AbstractOracleConnector
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception {
     out.add(new DumpMetadataTask(arguments, getFormatName()));
-    out.add(new FormatTask(OracleMetadataDumpFormat.FORMAT_NAME));
+    out.add(new FormatTask(getFormatName()));
 
     out.add(new JdbcSelectTask(V_Version.ZIP_ENTRY_NAME, "SELECT * from V$VERSION"));
     out.add(new JdbcSelectTask(V_Parameter2.ZIP_ENTRY_NAME, "SELECT * from V$PARAMETER2"));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -49,7 +49,7 @@ public class OracleMetadataConnector extends AbstractOracleConnector
   private static final Logger LOG = LoggerFactory.getLogger(OracleMetadataConnector.class);
 
   public OracleMetadataConnector() {
-    super("oracle");
+    super(OracleConnectorScope.METADATA);
   }
 
   private static interface GroupTask<T> extends Task<T> {
@@ -179,7 +179,7 @@ public class OracleMetadataConnector extends AbstractOracleConnector
   @Override
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(new DumpMetadataTask(arguments, getFormatName()));
     out.add(new FormatTask(OracleMetadataDumpFormat.FORMAT_NAME));
 
     out.add(new JdbcSelectTask(V_Version.ZIP_ENTRY_NAME, "SELECT * from V$VERSION"));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -28,14 +28,13 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class OracleStatsConnector extends AbstractOracleConnector {
 
-  private final StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
-
   public OracleStatsConnector() {
     super(OracleConnectorScope.STATS);
   }
 
   @Override
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) throws Exception {
+    StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
     out.add(new DumpMetadataTask(arguments, getFormatName()));
     out.addAll(taskListGenerator.createTasks(arguments));
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
+import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
+import java.util.List;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+// TODO: add @AutoService when implementation is completed
+@Description("Dumps aggregated statistics from Oracle")
+@ParametersAreNonnullByDefault
+public class OracleStatsConnector extends AbstractOracleConnector {
+
+  private final StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
+
+  public OracleStatsConnector() {
+    super(OracleConnectorScope.STATS);
+  }
+
+  @Override
+  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) throws Exception {
+    out.add(new DumpMetadataTask(arguments, getFormatName()));
+    out.addAll(taskListGenerator.createTasks(arguments));
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+class StatsTaskListGenerator {
+
+  @Nonnull
+  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -33,7 +33,7 @@ public class ArchiveNameUtil {
   public static String getFileNameWithTimestamp(String name, String suffix, Clock clock) {
     SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
     String timeSuffix = format.format(clock.millis());
-    return formatFileName(name, suffix + timeSuffix);
+    return formatFileName(name, suffix + "-" + timeSuffix);
   }
 
   /**

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.utils;
+
+import java.text.SimpleDateFormat;
+import java.time.Clock;
+
+public class ArchiveNameUtil {
+
+  /**
+   * Generate the archive file name that includes creation time. Typically this is used with a logs
+   * connector when dumping for Assessment.
+   *
+   * @param dwhType The type of the input data source, e.g. "teradata" or "snowflake".
+   * @param resultType The type of the resulting dump, e.g. "logs", "account-usage-logs" or
+   *     "raw-logs".
+   * @param clock The Clock instance to provide the date.
+   * @return Full name for the .zip archive.
+   */
+  public static String getFileNameWithTime(String dwhType, String resultType, Clock clock) {
+    SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
+    String timeSuffix = format.format(clock.millis());
+    return getFileName(dwhType, resultType + timeSuffix);
+  }
+
+  /**
+   * Generate the archive file name, but do not include creation time. This is the most common case,
+   * dumping logs for assessment being a known exception.
+   *
+   * @param dwhType The type of the input data source, e.g. "teradata" or "oracle".
+   * @param resultType The type of the resulting dump, e.g. "metadata" or "stats".
+   * @return Full name for the .zip archive.
+   */
+  public static String getBasicFileName(String dwhType, String resultType) {
+    return getFileName(dwhType, resultType);
+  }
+
+  private static String getFileName(String dwhType, String details) {
+    return String.format("dwh-migration-%s-%s.zip", dwhType, details);
+  }
+
+  private ArchiveNameUtil() {}
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -31,10 +31,10 @@ public class ArchiveNameUtil {
    * @param clock The Clock instance to provide the date.
    * @return Full name for the .zip archive.
    */
-  public static String getFileNameWithTime(String dwhType, String resultType, Clock clock) {
+  public static String getFileNameWithTimestamp(String dwhType, String resultType, Clock clock) {
     SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
     String timeSuffix = format.format(clock.millis());
-    return getFileName(dwhType, resultType + timeSuffix);
+    return formatFileName(dwhType, resultType + timeSuffix);
   }
 
   /**
@@ -45,11 +45,11 @@ public class ArchiveNameUtil {
    * @param resultType The type of the resulting dump, e.g. "metadata" or "stats".
    * @return Full name for the .zip archive.
    */
-  public static String getBasicFileName(String dwhType, String resultType) {
-    return getFileName(dwhType, resultType);
+  public static String getFileName(String dwhType, String resultType) {
+    return formatFileName(dwhType, resultType);
   }
 
-  private static String getFileName(String dwhType, String details) {
+  private static String formatFileName(String dwhType, String details) {
     return String.format("dwh-migration-%s-%s.zip", dwhType, details);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -25,7 +25,8 @@ public class ArchiveNameUtil {
    * Generate the archive file name that includes creation time. Typically this is used with a logs
    * connector when dumping for Assessment.
    *
-   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as "-metadata" or "-logs".
+   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as
+   *     "-metadata" or "-logs".
    * @param clock The Clock instance to provide the date.
    * @return Full name for the .zip archive.
    */
@@ -39,7 +40,8 @@ public class ArchiveNameUtil {
    * Generate the archive file name, but do not include creation time. This is the most common case,
    * dumping logs for assessment being a known exception.
    *
-   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as "-metadata" or "-logs"
+   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as
+   *     "-metadata" or "-logs"
    * @return Full name for the .zip archive.
    */
   public static String getFileName(String nameWithOptionalSuffix) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -25,30 +25,31 @@ public class ArchiveNameUtil {
    * Generate the archive file name that includes creation time. Typically this is used with a logs
    * connector when dumping for Assessment.
    *
-   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as
-   *     "-metadata" or "-logs".
+   * @param name The name of the connector.
+   * @param suffix Connector-specific suffix such as "metadata" or "logs".
    * @param clock The Clock instance to provide the date.
    * @return Full name for the .zip archive.
    */
-  public static String getFileNameWithTimestamp(String nameWithOptionalSuffix, Clock clock) {
+  public static String getFileNameWithTimestamp(String name, String suffix, Clock clock) {
     SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
     String timeSuffix = format.format(clock.millis());
-    return formatFileName(nameWithOptionalSuffix + timeSuffix);
+    return formatFileName(name, suffix + timeSuffix);
   }
 
   /**
    * Generate the archive file name, but do not include creation time. This is the most common case,
    * dumping logs for assessment being a known exception.
    *
-   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as
-   *     "-metadata" or "-logs"
+   * @param name The name of the connector.
+   * @param suffix Connector-specific suffix such as "metadata" or "logs".
    * @return Full name for the .zip archive.
    */
-  public static String getFileName(String nameWithOptionalSuffix) {
-    return formatFileName(nameWithOptionalSuffix);
+  public static String getFileName(String name, String suffix) {
+    return formatFileName(name, suffix);
   }
 
-  private static String formatFileName(String nameWithOptionalSuffix) {
+  private static String formatFileName(String name, String suffix) {
+    String nameWithOptionalSuffix = name + (suffix.isEmpty() ? "" : "-" + suffix);
     return String.format("dwh-migration-%s.zip", nameWithOptionalSuffix);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -25,32 +25,29 @@ public class ArchiveNameUtil {
    * Generate the archive file name that includes creation time. Typically this is used with a logs
    * connector when dumping for Assessment.
    *
-   * @param dwhType The type of the input data source, e.g. "teradata" or "snowflake".
-   * @param resultType The type of the resulting dump, e.g. "logs", "account-usage-logs" or
-   *     "raw-logs".
+   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as "-metadata" or "-logs".
    * @param clock The Clock instance to provide the date.
    * @return Full name for the .zip archive.
    */
-  public static String getFileNameWithTimestamp(String dwhType, String resultType, Clock clock) {
+  public static String getFileNameWithTimestamp(String nameWithOptionalSuffix, Clock clock) {
     SimpleDateFormat format = new SimpleDateFormat("yyyyMMdd'T'HHmmss");
     String timeSuffix = format.format(clock.millis());
-    return formatFileName(dwhType, resultType + timeSuffix);
+    return formatFileName(nameWithOptionalSuffix + timeSuffix);
   }
 
   /**
    * Generate the archive file name, but do not include creation time. This is the most common case,
    * dumping logs for assessment being a known exception.
    *
-   * @param dwhType The type of the input data source, e.g. "teradata" or "oracle".
-   * @param resultType The type of the resulting dump, e.g. "metadata" or "stats".
+   * @param nameWithOptionalSuffix The name of the connector, can be followed by a suffix such as "-metadata" or "-logs"
    * @return Full name for the .zip archive.
    */
-  public static String getFileName(String dwhType, String resultType) {
-    return formatFileName(dwhType, resultType);
+  public static String getFileName(String nameWithOptionalSuffix) {
+    return formatFileName(nameWithOptionalSuffix);
   }
 
-  private static String formatFileName(String dwhType, String details) {
-    return String.format("dwh-migration-%s-%s.zip", dwhType, details);
+  private static String formatFileName(String nameWithOptionalSuffix) {
+    return String.format("dwh-migration-%s.zip", nameWithOptionalSuffix);
   }
 
   private ArchiveNameUtil() {}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -35,7 +35,7 @@ public class AbstractOracleConnectorTest {
   private final AbstractOracleConnector connector = new OracleMetadataConnector();
 
   @Test
-  public void getDefaultFileName_notForAssessment() {
+  public void getDefaultFileName_notForAssessment_success() {
     OracleLogsConnector logs = new OracleLogsConnector();
     OracleMetadataConnector metadata = new OracleMetadataConnector();
     OracleStatsConnector stats = new OracleStatsConnector();
@@ -46,7 +46,7 @@ public class AbstractOracleConnectorTest {
   }
 
   @Test
-  public void getFormatName() {
+  public void getFormatName_success() {
     OracleLogsConnector logs = new OracleLogsConnector();
     OracleMetadataConnector metadata = new OracleMetadataConnector();
     OracleStatsConnector stats = new OracleStatsConnector();
@@ -57,7 +57,7 @@ public class AbstractOracleConnectorTest {
   }
 
   @Test
-  public void getName() {
+  public void getName_success() {
     OracleLogsConnector logs = new OracleLogsConnector();
     OracleMetadataConnector metadata = new OracleMetadataConnector();
     OracleStatsConnector stats = new OracleStatsConnector();

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -35,43 +35,6 @@ public class AbstractOracleConnectorTest {
   private final AbstractOracleConnector connector = new OracleMetadataConnector();
 
   @Test
-  public void getDefaultFileName_notForAssessment_success() {
-    OracleLogsConnector logs = new OracleLogsConnector();
-    OracleMetadataConnector metadata = new OracleMetadataConnector();
-    OracleStatsConnector stats = new OracleStatsConnector();
-
-    assertEquals(
-        "dwh-migration-oracle-logs.zip", logs.getDefaultFileName(/* isAssessment= */ false));
-    assertEquals(
-        "dwh-migration-oracle-metadata.zip",
-        metadata.getDefaultFileName(/* isAssessment= */ false));
-    assertEquals(
-        "dwh-migration-oracle-stats.zip", stats.getDefaultFileName(/* isAssessment= */ false));
-  }
-
-  @Test
-  public void getFormatName_success() {
-    OracleLogsConnector logs = new OracleLogsConnector();
-    OracleMetadataConnector metadata = new OracleMetadataConnector();
-    OracleStatsConnector stats = new OracleStatsConnector();
-
-    assertEquals("oracle.logs.zip", logs.getFormatName());
-    assertEquals("oracle.dump.zip", metadata.getFormatName());
-    assertEquals("oracle.stats.zip", stats.getFormatName());
-  }
-
-  @Test
-  public void getName_success() {
-    OracleLogsConnector logs = new OracleLogsConnector();
-    OracleMetadataConnector metadata = new OracleMetadataConnector();
-    OracleStatsConnector stats = new OracleStatsConnector();
-
-    assertEquals("oracle-logs", logs.getName());
-    assertEquals("oracle", metadata.getName());
-    assertEquals("oracle-stats", stats.getName());
-  }
-
-  @Test
   public void buildProperties_success() {
     when(arguments.getPasswordOrPrompt()).thenReturn(EXAMPLE_PASSWORD);
     when(arguments.getUserOrFail()).thenReturn(EXAMPLE_USER);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -40,9 +40,13 @@ public class AbstractOracleConnectorTest {
     OracleMetadataConnector metadata = new OracleMetadataConnector();
     OracleStatsConnector stats = new OracleStatsConnector();
 
-    assertEquals("dwh-migration-oracle-logs.zip", logs.getDefaultFileName(false));
-    assertEquals("dwh-migration-oracle-metadata.zip", metadata.getDefaultFileName(false));
-    assertEquals("dwh-migration-oracle-stats.zip", stats.getDefaultFileName(false));
+    assertEquals(
+        "dwh-migration-oracle-logs.zip", logs.getDefaultFileName(/* isAssessment= */ false));
+    assertEquals(
+        "dwh-migration-oracle-metadata.zip",
+        metadata.getDefaultFileName(/* isAssessment= */ false));
+    assertEquals(
+        "dwh-migration-oracle-stats.zip", stats.getDefaultFileName(/* isAssessment= */ false));
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -41,7 +41,7 @@ public class AbstractOracleConnectorTest {
     OracleStatsConnector stats = new OracleStatsConnector();
 
     assertEquals("dwh-migration-oracle-logs.zip", logs.getDefaultFileName(false));
-    assertEquals("dwh-migration-oracle.zip", metadata.getDefaultFileName(false));
+    assertEquals("dwh-migration-oracle-metadata.zip", metadata.getDefaultFileName(false));
     assertEquals("dwh-migration-oracle-stats.zip", stats.getDefaultFileName(false));
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnectorTest.java
@@ -35,6 +35,39 @@ public class AbstractOracleConnectorTest {
   private final AbstractOracleConnector connector = new OracleMetadataConnector();
 
   @Test
+  public void getDefaultFileName_notForAssessment() {
+    OracleLogsConnector logs = new OracleLogsConnector();
+    OracleMetadataConnector metadata = new OracleMetadataConnector();
+    OracleStatsConnector stats = new OracleStatsConnector();
+
+    assertEquals("dwh-migration-oracle-logs.zip", logs.getDefaultFileName(false));
+    assertEquals("dwh-migration-oracle.zip", metadata.getDefaultFileName(false));
+    assertEquals("dwh-migration-oracle-stats.zip", stats.getDefaultFileName(false));
+  }
+
+  @Test
+  public void getFormatName() {
+    OracleLogsConnector logs = new OracleLogsConnector();
+    OracleMetadataConnector metadata = new OracleMetadataConnector();
+    OracleStatsConnector stats = new OracleStatsConnector();
+
+    assertEquals("oracle.logs.zip", logs.getFormatName());
+    assertEquals("oracle.dump.zip", metadata.getFormatName());
+    assertEquals("oracle.stats.zip", stats.getFormatName());
+  }
+
+  @Test
+  public void getName() {
+    OracleLogsConnector logs = new OracleLogsConnector();
+    OracleMetadataConnector metadata = new OracleMetadataConnector();
+    OracleStatsConnector stats = new OracleStatsConnector();
+
+    assertEquals("oracle-logs", logs.getName());
+    assertEquals("oracle", metadata.getName());
+    assertEquals("oracle-stats", stats.getName());
+  }
+
+  @Test
   public void buildProperties_success() {
     when(arguments.getPasswordOrPrompt()).thenReturn(EXAMPLE_PASSWORD);
     when(arguments.getUserOrFail()).thenReturn(EXAMPLE_USER);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -48,7 +48,8 @@ public class OracleConnectorScopeTest {
     Instant instant = Instant.ofEpochMilli(1715346130945L);
     Clock clock = Clock.fixed(instant, ZoneId.systemDefault());
 
-    assertEquals("dwh-migration-oracle-logs-logs20240510T130210.zip", LOGS.toFileName(true, clock));
+    assertEquals(
+        "dwh-migration-oracle-logs-logs-20240510T130210.zip", LOGS.toFileName(true, clock));
     assertEquals("dwh-migration-oracle-metadata.zip", METADATA.toFileName(true, clock));
     assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(true, clock));
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -28,9 +28,9 @@ public class OracleConnectorScopeTest {
 
   @Test
   public void toDisplayName_success() {
-    assertEquals("oracle-logs", LOGS.displayName());
-    assertEquals("oracle", METADATA.displayName());
-    assertEquals("oracle-stats", STATS.displayName());
+    assertEquals("oracle-logs", LOGS.connectorName());
+    assertEquals("oracle", METADATA.connectorName());
+    assertEquals("oracle-stats", STATS.connectorName());
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -17,7 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleConnectorScope.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -34,14 +34,6 @@ public class OracleConnectorScopeTest {
   }
 
   @Test
-  public void toFileName_notForAssessment_success() {
-    assertEquals("dwh-migration-oracle-logs.zip", LOGS.toFileName(/* isAssessment= */ false));
-    assertEquals(
-        "dwh-migration-oracle-metadata.zip", METADATA.toFileName(/* isAssessment= */ false));
-    assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(/* isAssessment= */ false));
-  }
-
-  @Test
   public void toFormat_success() {
     assertEquals("oracle.logs.zip", LOGS.toFormat());
     assertEquals("oracle.dump.zip", METADATA.toFormat());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleConnectorScope.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OracleConnectorScopeTest {
+
+  @Test
+  public void toDisplayName_success() {
+    assertEquals("oracle-logs", LOGS.toDisplayName());
+    assertEquals("oracle", METADATA.toDisplayName());
+    assertEquals("oracle-stats", STATS.toDisplayName());
+  }
+
+  @Test
+  public void toFileName_notForAssessment_success() {
+    assertEquals("dwh-migration-oracle-logs.zip", LOGS.toFileName(/* isAssessment= */ false));
+    assertEquals(
+        "dwh-migration-oracle-metadata.zip", METADATA.toFileName(/* isAssessment= */ false));
+    assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(/* isAssessment= */ false));
+  }
+
+  @Test
+  public void toFormat_success() {
+    assertEquals("oracle.logs.zip", LOGS.toFormat());
+    assertEquals("oracle.dump.zip", METADATA.toFormat());
+    assertEquals("oracle.stats.zip", STATS.toFormat());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -19,6 +19,9 @@ package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleConnectorScope.*;
 import static org.junit.Assert.assertEquals;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -38,5 +41,25 @@ public class OracleConnectorScopeTest {
     assertEquals("oracle.logs.zip", LOGS.formatName());
     assertEquals("oracle.dump.zip", METADATA.formatName());
     assertEquals("oracle.stats.zip", STATS.formatName());
+  }
+
+  @Test
+  public void toFileName_forAssessment_success() {
+    Instant instant = Instant.ofEpochMilli(1715346130945L);
+    Clock clock = Clock.fixed(instant, ZoneId.systemDefault());
+
+    assertEquals("dwh-migration-oracle-logs-logs20240510T130210.zip", LOGS.toFileName(true, clock));
+    assertEquals("dwh-migration-oracle-metadata.zip", METADATA.toFileName(true, clock));
+    assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(true, clock));
+  }
+
+  @Test
+  public void toFileName_notForAssessment_success() {
+    Instant instant = Instant.ofEpochMilli(1715346130945L);
+    Clock clock = Clock.fixed(instant, ZoneId.systemDefault());
+
+    assertEquals("dwh-migration-oracle-logs-logs.zip", LOGS.toFileName(false, clock));
+    assertEquals("dwh-migration-oracle-metadata.zip", METADATA.toFileName(false, clock));
+    assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(false, clock));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -28,15 +28,15 @@ public class OracleConnectorScopeTest {
 
   @Test
   public void toDisplayName_success() {
-    assertEquals("oracle-logs", LOGS.toDisplayName());
-    assertEquals("oracle", METADATA.toDisplayName());
-    assertEquals("oracle-stats", STATS.toDisplayName());
+    assertEquals("oracle-logs", LOGS.displayName());
+    assertEquals("oracle", METADATA.displayName());
+    assertEquals("oracle-stats", STATS.displayName());
   }
 
   @Test
   public void toFormat_success() {
-    assertEquals("oracle.logs.zip", LOGS.toFormat());
-    assertEquals("oracle.dump.zip", METADATA.toFormat());
-    assertEquals("oracle.stats.zip", STATS.toFormat());
+    assertEquals("oracle.logs.zip", LOGS.formatName());
+    assertEquals("oracle.dump.zip", METADATA.formatName());
+    assertEquals("oracle.stats.zip", STATS.formatName());
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnectorTest.java
@@ -1,6 +1,22 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnectorTest.java
@@ -1,0 +1,17 @@
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OracleLogsConnectorTest {
+
+  @Test
+  public void getConnectorScope_success() {
+    OracleLogsConnector connector = new OracleLogsConnector();
+    assertEquals(OracleConnectorScope.LOGS, connector.getConnectorScope());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnectorTest.java
@@ -93,4 +93,10 @@ public class OracleMetadataConnectorTest {
             "SELECT OWNER, SYNONYM_NAME, DBMS_METADATA.GET_XML('SYNONYM', SYNONYM_NAME, OWNER) FROM DBA_SYNONYMS",
             "SELECT OWNER, SYNONYM_NAME, DBMS_METADATA.GET_XML('SYNONYM', SYNONYM_NAME, OWNER) FROM ALL_SYNONYMS"));
   }
+
+  @Test
+  public void getConnectorScope_success() {
+    OracleMetadataConnector connector = new OracleMetadataConnector();
+    assertEquals(OracleConnectorScope.METADATA, connector.getConnectorScope());
+  }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -1,0 +1,15 @@
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class OracleStatsConnectorTest {
+
+  @Test
+  public void getConnectorScope_success() {
+    OracleStatsConnector connector = new OracleStatsConnector();
+    assertEquals(OracleConnectorScope.STATS, connector.getConnectorScope());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -1,4 +1,22 @@
-import static org.junit.jupiter.api.Assertions.assertEquals;
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2023 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.utils;
+
+import static org.junit.Assert.assertEquals;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import org.junit.Test;
+
+public class ArchiveNameUtilTest {
+
+  @Test
+  public void getFileName_success() {
+    String name = "snowflake-information-schema-logs";
+
+    assertEquals(
+        "dwh-migration-snowflake-information-schema-logs.zip", ArchiveNameUtil.getFileName(name));
+  }
+
+  @Test
+  public void getFileNameWithTimestamp_success() {
+    Instant instant = Instant.ofEpochMilli(1715346130945L);
+    Clock clock = Clock.fixed(instant, ZoneId.systemDefault());
+    String name = "snowflake-information-schema-logs";
+
+    assertEquals(
+        "dwh-migration-snowflake-information-schema-logs20240510T130210.zip",
+        ArchiveNameUtil.getFileNameWithTimestamp(name, clock));
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
@@ -27,20 +27,23 @@ public class ArchiveNameUtilTest {
 
   @Test
   public void getFileName_success() {
-    String name = "snowflake-information-schema-logs";
+    String name = "snowflake";
+    String suffix = "information-schema-logs";
 
     assertEquals(
-        "dwh-migration-snowflake-information-schema-logs.zip", ArchiveNameUtil.getFileName(name));
+        "dwh-migration-snowflake-information-schema-logs.zip",
+        ArchiveNameUtil.getFileName(name, suffix));
   }
 
   @Test
   public void getFileNameWithTimestamp_success() {
     Instant instant = Instant.ofEpochMilli(1715346130945L);
     Clock clock = Clock.fixed(instant, ZoneId.systemDefault());
-    String name = "snowflake-information-schema-logs";
+    String name = "snowflake";
+    String suffix = "information-schema-logs";
 
     assertEquals(
         "dwh-migration-snowflake-information-schema-logs20240510T130210.zip",
-        ArchiveNameUtil.getFileNameWithTimestamp(name, clock));
+        ArchiveNameUtil.getFileNameWithTimestamp(name, suffix, clock));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
@@ -43,7 +43,7 @@ public class ArchiveNameUtilTest {
     String suffix = "information-schema-logs";
 
     assertEquals(
-        "dwh-migration-snowflake-information-schema-logs20240510T130210.zip",
+        "dwh-migration-snowflake-information-schema-logs-20240510T130210.zip",
         ArchiveNameUtil.getFileNameWithTimestamp(name, suffix, clock));
   }
 }


### PR DESCRIPTION
- create a connector that will be used to collect `oracle-stats` data
- add an enum to represent the connector type (`logs`, `metadata` or `stats`) and use it in Oracle
- add tests verifying Oracle connector type information in output filenames and help text