### PR TITLE
[b/341297017] Integrate the summary version of app_schemas.sql from the DMA tool

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -30,8 +30,8 @@ enum OracleConnectorScope {
   private final String formatName;
   private final String resultType;
 
-  OracleConnectorScope(String displayName, String formatName, String resultType) {
-    this.connectorName = displayName;
+  OracleConnectorScope(String connectorName, String formatName, String resultType) {
+    this.connectorName = connectorName;
     this.formatName = formatName;
     this.resultType = resultType;
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.io.Resources;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nonnull;
+
+@AutoValue
+public abstract class OracleStatsQuery {
+
+  abstract String name();
+
+  abstract StatsSource tool();
+
+  static OracleStatsQuery create(String name, StatsSource tool) {
+    return new AutoValue_OracleStatsQuery(name, tool);
+  }
+
+  @Nonnull
+  String queryText() throws IOException {
+    String path = String.format("oracle-stats/%s/%s.sql", tool().value, name());
+    URL queryUrl = Resources.getResource(path);
+    return Resources.toString(queryUrl, StandardCharsets.UTF_8);
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -16,12 +16,13 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.auto.value.AutoValue;
 import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 
 @AutoValue
@@ -39,6 +40,6 @@ public abstract class OracleStatsQuery {
   String queryText() throws IOException {
     String path = String.format("oracle-stats/%s/%s.sql", tool().value, name());
     URL queryUrl = Resources.getResource(path);
-    return Resources.toString(queryUrl, StandardCharsets.UTF_8);
+    return Resources.toString(queryUrl, UTF_8);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -37,17 +37,17 @@ public abstract class OracleStatsQuery {
   abstract String queryText();
 
   @Nonnull
-  abstract StatsSource tool();
+  abstract StatsSource statsSource();
 
-  static OracleStatsQuery create(String name, StatsSource tool) throws IOException {
-    String path = String.format("oracle-stats/%s/%s.sql", tool.value, name);
+  static OracleStatsQuery create(String name, StatsSource statsSource) throws IOException {
+    String path = String.format("oracle-stats/%s/%s.sql", statsSource.value, name);
     URL queryUrl = Resources.getResource(path);
     String queryText = Resources.toString(queryUrl, UTF_8);
-    return new AutoValue_OracleStatsQuery(name, queryText, tool);
+    return new AutoValue_OracleStatsQuery(name, queryText, statsSource);
   }
 
   @Nonnull
   String description() {
-    return String.format("Query{name=%s, tool=%s}", name(), tool());
+    return String.format("Query{name=%s, statsSource=%s}", name(), statsSource());
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -24,22 +24,30 @@ import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsT
 import java.io.IOException;
 import java.net.URL;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @AutoValue
+@ParametersAreNonnullByDefault
 public abstract class OracleStatsQuery {
 
+  @Nonnull
   abstract String name();
 
+  @Nonnull
+  abstract String queryText();
+
+  @Nonnull
   abstract StatsSource tool();
 
-  static OracleStatsQuery create(String name, StatsSource tool) {
-    return new AutoValue_OracleStatsQuery(name, tool);
+  static OracleStatsQuery create(String name, StatsSource tool) throws IOException {
+    String path = String.format("oracle-stats/%s/%s.sql", tool.value, name);
+    URL queryUrl = Resources.getResource(path);
+    String queryText = Resources.toString(queryUrl, UTF_8);
+    return new AutoValue_OracleStatsQuery(name, queryText, tool);
   }
 
   @Nonnull
-  String queryText() throws IOException {
-    String path = String.format("oracle-stats/%s/%s.sql", tool().value, name());
-    URL queryUrl = Resources.getResource(path);
-    return Resources.toString(queryUrl, UTF_8);
+  String description() {
+    return String.format("Query{name=%s, tool=%s}", name(), tool());
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -59,10 +59,7 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
   @Nonnull
   @Override
   public Summary doInConnection(
-      TaskRunContext context,
-      JdbcHandle jdbcHandle,
-      ByteSink sink,
-      Connection connection)
+      TaskRunContext context, JdbcHandle jdbcHandle, ByteSink sink, Connection connection)
       throws SQLException {
     ResultSetExtractor<Summary> extractor = newCsvResultSetExtractor(sink);
     Summary result = doSelect(connection, extractor, query);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteSink;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsQuery;
+import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
+import com.google.edwmigration.dumper.application.dumper.task.Summary;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import java.io.IOException;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.apache.commons.csv.CSVFormat;
+import org.springframework.jdbc.core.ResultSetExtractor;
+
+@ParametersAreNonnullByDefault
+class StatsJdbcTask extends AbstractJdbcTask<Summary> {
+
+  private final String query;
+
+  private StatsJdbcTask(String name, String query) {
+    super(name);
+    Preconditions.checkArgument(name.endsWith(".csv"));
+    this.query = query;
+  }
+
+  static Task<?> fromQuery(StatsQuery query) throws IOException {
+    String name = "oracle-stats/" + query.name() + ".csv";
+    String queryText = query.queryText();
+    return new StatsJdbcTask(name, queryText);
+  }
+
+  @Override
+  public Summary doInConnection(
+      @Nonnull TaskRunContext context,
+      @Nonnull JdbcHandle jdbcHandle,
+      @Nonnull ByteSink sink,
+      @Nonnull Connection connection)
+      throws SQLException {
+    ResultSetExtractor<Summary> extractor = newCsvResultSetExtractor(sink);
+    return doSelect(connection, extractor, query);
+  }
+
+  @Nonnull
+  @Override
+  public TaskCategory getCategory() {
+    return TaskCategory.REQUIRED;
+  }
+
+  @Nonnull
+  @Override
+  public String describeSourceData() {
+    return "";
+  }
+
+  @Override
+  @Nonnull
+  protected CSVFormat newCsvFormat(ResultSet resultSet) throws SQLException {
+    return FORMAT.builder().setHeader(resultSet).build();
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -59,10 +59,10 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
   @Nonnull
   @Override
   public Summary doInConnection(
-      @Nonnull TaskRunContext context,
-      @Nonnull JdbcHandle jdbcHandle,
-      @Nonnull ByteSink sink,
-      @Nonnull Connection connection)
+      TaskRunContext context,
+      JdbcHandle jdbcHandle,
+      ByteSink sink,
+      Connection connection)
       throws SQLException {
     ResultSetExtractor<Summary> extractor = newCsvResultSetExtractor(sink);
     Summary result = doSelect(connection, extractor, query);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -18,7 +18,6 @@ package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSink;
-import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsQuery;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
@@ -50,7 +49,7 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
   }
 
   @Nonnull
-  static Task<?> fromQuery(StatsQuery query) throws IOException {
+  static Task<?> fromQuery(OracleStatsQuery query) throws IOException {
     String name = "oracle-stats/" + query.name() + ".csv";
     String queryText = query.queryText();
     return new StatsJdbcTask(name, queryText);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -24,7 +24,6 @@ import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
-import java.io.IOException;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -20,7 +20,6 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.io.IOException;
 import java.net.URL;
@@ -44,7 +43,7 @@ class StatsTaskListGenerator {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
 
     for (StatsQuery item : QUERIES) {
-      builder.add(item.toTask());
+      builder.add(StatsJdbcTask.fromQuery(item));
     }
     return builder.build();
   }
@@ -74,11 +73,10 @@ class StatsTaskListGenerator {
     }
 
     @Nonnull
-    Task<?> toTask() throws IOException {
+    String queryText() throws IOException {
       String path = String.format("oracle-stats/%s/%s.sql", tool().value, name());
       URL queryUrl = Resources.getResource(path);
-      String query = Resources.toString(queryUrl, StandardCharsets.UTF_8);
-      return new JdbcSelectTask("oracle-stats/" + name() + ".csv", query);
+      return Resources.toString(queryUrl, StandardCharsets.UTF_8);
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -26,19 +26,19 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 class StatsTaskListGenerator {
 
-  private static final ImmutableList<OracleStatsQuery> QUERIES =
-      ImmutableList.of(
-          OracleStatsQuery.create("hist-cmd-types", StatsSource.STATSPACK),
-          OracleStatsQuery.create("app-schemas-pdbs", StatsSource.METADATA),
-          OracleStatsQuery.create("app-schemas-summary", StatsSource.METADATA)
-          // TODO: add entries for other SQLs to this list
-          );
-
   @Nonnull
   ImmutableList<Task<?>> createTasks(ConnectorArguments arguments) throws IOException {
+    ImmutableList<OracleStatsQuery> queries =
+        ImmutableList.of(
+            OracleStatsQuery.create("hist-cmd-types", StatsSource.STATSPACK),
+            OracleStatsQuery.create("app-schemas-pdbs", StatsSource.METADATA),
+            OracleStatsQuery.create("app-schemas-summary", StatsSource.METADATA)
+            // TODO: add entries for other SQLs to this list
+            );
+
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
 
-    for (OracleStatsQuery item : QUERIES) {
+    for (OracleStatsQuery item : queries) {
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     return builder.build();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -34,7 +34,8 @@ class StatsTaskListGenerator {
   private static final ImmutableList<StatsQuery> QUERIES =
       ImmutableList.of(
           StatsQuery.create("hist-cmd-types", StatsSource.STATSPACK),
-          StatsQuery.create("app-schemas-pdbs", StatsSource.METADATA)
+          StatsQuery.create("app-schemas-pdbs", StatsSource.METADATA),
+          StatsQuery.create("app-schemas-summary", StatsSource.METADATA)
           // TODO: add entries for other SQLs to this list
           );
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -16,25 +16,21 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 class StatsTaskListGenerator {
 
-  private static final ImmutableList<StatsQuery> QUERIES =
+  private static final ImmutableList<OracleStatsQuery> QUERIES =
       ImmutableList.of(
-          StatsQuery.create("hist-cmd-types", StatsSource.STATSPACK),
-          StatsQuery.create("app-schemas-pdbs", StatsSource.METADATA),
-          StatsQuery.create("app-schemas-summary", StatsSource.METADATA)
+          OracleStatsQuery.create("hist-cmd-types", StatsSource.STATSPACK),
+          OracleStatsQuery.create("app-schemas-pdbs", StatsSource.METADATA),
+          OracleStatsQuery.create("app-schemas-summary", StatsSource.METADATA)
           // TODO: add entries for other SQLs to this list
           );
 
@@ -42,7 +38,7 @@ class StatsTaskListGenerator {
   ImmutableList<Task<?>> createTasks(ConnectorArguments arguments) throws IOException {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
 
-    for (StatsQuery item : QUERIES) {
+    for (OracleStatsQuery item : QUERIES) {
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     return builder.build();
@@ -58,25 +54,6 @@ class StatsTaskListGenerator {
 
     StatsSource(String value) {
       this.value = value;
-    }
-  }
-
-  @AutoValue
-  abstract static class StatsQuery {
-
-    abstract String name();
-
-    abstract StatsSource tool();
-
-    static StatsQuery create(String name, StatsSource tool) {
-      return new AutoValue_StatsTaskListGenerator_StatsQuery(name, tool);
-    }
-
-    @Nonnull
-    String queryText() throws IOException {
-      String path = String.format("oracle-stats/%s/%s.sql", tool().value, name());
-      URL queryUrl = Resources.getResource(path);
-      return Resources.toString(queryUrl, StandardCharsets.UTF_8);
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -110,6 +110,11 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
   }
 
   @Nonnull
+  public ResultSetExtractor<Summary> newCsvResultSetExtractor(@Nonnull ByteSink sink) {
+    return newCsvResultSetExtractor(sink, -1);
+  }
+
+  @Nonnull
   protected ExtendableResultSetExtractor newCsvResultSetExtractor(
       @Nonnull ByteSink sink, @CheckForSigned long count) {
     return rs -> {

--- a/dumper/app/src/main/resources/oracle-stats/metadata/app-schemas-summary.sql
+++ b/dumper/app/src/main/resources/oracle-stats/metadata/app-schemas-summary.sql
@@ -1,0 +1,97 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+    D.source "Source",
+    D.dbid "DbId",
+    D.pdb_id "PdbId",
+    D.pdb_name "PdbName",
+    D.st "Status",
+    D.logging "Logging",
+    D.con_id "ConId",
+    D.con_uid "ConUid",
+    (
+      SELECT min(E.owner) min_owner FROM dba_tab_columns E
+      WHERE E.table_name = 'FND_PRODUCT_GROUPS'
+        AND E.column_name = 'RELEASE_NAME'
+        AND E.data_type = 'VARCHAR2'
+    ) "EbsOwner",
+    (
+      SELECT min(G.owner) FROM dba_tab_columns G
+      WHERE G.table_name = 'S_REPOSITORY'
+        AND G.column_name = 'ROW_ID'
+        AND G.data_type = 'VARCHAR2'
+    ) "SiebelOwner",
+    (
+      SELECT min(I.owner) FROM dba_tab_columns I
+      WHERE table_name = 'PSSTATUS'
+        AND column_name = 'TOOLSREL'
+        AND data_type = 'VARCHAR2'
+    ) "PsftOwner",
+    (
+      SELECT count(1) FROM dba_objects K
+      WHERE K.owner = 'RDSADMIN'
+        AND K.object_name = 'RDAADMIN_UTIL'
+    ) "RdaMatchCount",
+    (
+      SELECT count(1) FROM dba_views M
+      WHERE view_name = 'OCI_AUTONOMOUS_DATABASES'
+    ) "OciAutoViewMatches",
+    nvl(R.count, 0) "DbmsCloudMatches",
+    (
+      SELECT count(1) FROM dba_objects S
+      JOIN dba_users T
+        ON S.object_name = 'WWV_FLOW'
+        AND S.object_type = 'PACKAGE'
+        AND T.username = 'apex_public_user'
+    ) "ApexMatches",
+    (
+      SELECT min(V.owner) FROM dba_tab_columns V
+      WHERE V.table_name = 'DD02T'
+        AND V.column_name = 'DDLANGUAGE'
+        AND V.data_type = 'VARCHAR2'
+    ) "SapOwner"
+FROM (
+  SELECT
+    'pdbs' source,
+    A.dbid,
+    A.pdb_id,
+    A.pdb_name pdb_name,
+    A.status st,
+    A.logging,
+    A.con_id con_id,
+    A.con_uid
+  FROM dba_pdbs A
+  UNION
+  SELECT
+    'sys' source,
+    B.dbid,
+    B.con_id# pdb_id,
+    C.name pdb_name,
+    to_char(B.status) st,
+    to_char(B.flags) logging,
+    B.con_id# con_id,
+    B.con_uid
+  FROM sys.container$ B
+  JOIN sys.obj$ C
+  ON B.obj# = C.obj# AND B.con_id# = 1
+) D
+LEFT JOIN (
+  SELECT Q.con_id, count(1) count FROM dba_objects P
+  JOIN v$parameter Q
+    ON P.object_name = 'DBMS_CLOUD'
+    AND Q.name = 'common_user_prefix'
+    AND P.owner = 'CLOUD$SERVICE' || Q.value
+  GROUP BY Q.con_id
+) R ON D.con_id = R.con_id

--- a/dumper/app/src/main/resources/oracle-stats/metadata/app-schemas-summary.sql
+++ b/dumper/app/src/main/resources/oracle-stats/metadata/app-schemas-summary.sql
@@ -35,9 +35,9 @@ SELECT
     ) "SiebelOwner",
     (
       SELECT min(I.owner) FROM dba_tab_columns I
-      WHERE table_name = 'PSSTATUS'
-        AND column_name = 'TOOLSREL'
-        AND data_type = 'VARCHAR2'
+      WHERE I.table_name = 'PSSTATUS'
+        AND I.column_name = 'TOOLSREL'
+        AND I.data_type = 'VARCHAR2'
     ) "PsftOwner",
     (
       SELECT count(1) FROM dba_objects K


### PR DESCRIPTION
b/341297017
- Add the summary version of app_schemas.sql from DMA
- Add a version of newCsvResultSetExtractor in AbstractJdbcTask that avoids the '-1' dummy value
- Add a JdbcTask class for oracle-stats
- Use StatsJdbcTask to avoid printing entire SQLs for each query
- Use a simpler CSV format logic for StatsJdbcTask
- Add a check and change annotations to improve null handling in StatsJdbcTask