### PR TITLE
[b/275708841] Fix duplicate "-logs" suffix in some output archive names

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -27,9 +27,9 @@ public interface LogsConnector extends Connector {
   @Override
   default String getDefaultFileName(boolean isAssessment, Clock clock) {
     if (isAssessment) {
-      return ArchiveNameUtil.getFileNameWithTimestamp(getName(), "logs", clock);
+      return ArchiveNameUtil.getFileNameWithTimestamp(getName(), clock);
     } else {
-      return ArchiveNameUtil.getFileName(getName(), "logs");
+      return ArchiveNameUtil.getFileName(getName());
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -26,6 +26,6 @@ public interface MetadataConnector extends Connector {
   @Nonnull
   @Override
   default String getDefaultFileName(boolean isAssessment, Clock clock) {
-    return ArchiveNameUtil.getFileName(getName(), "metadata");
+    return ArchiveNameUtil.getFileName(getName() + "-metadata");
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/generic/GenericConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/generic/GenericConnector.java
@@ -31,7 +31,9 @@ import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
+import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import java.sql.Driver;
+import java.time.Clock;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -152,5 +154,15 @@ public class GenericConnector extends AbstractJdbcConnector implements LogsConne
     Driver driver = newDriver(this.driverPaths, this.driverClass);
     DataSource dataSource = newSimpleDataSource(driver, this.uri, arguments);
     return JdbcHandle.newPooledJdbcHandle(dataSource, 2);
+  }
+
+  @Nonnull
+  @Override
+  public String getDefaultFileName(boolean isAssessment, Clock clock) {
+    if (isAssessment) {
+      return ArchiveNameUtil.getFileNameWithTimestamp(getName() + "-logs", clock);
+    } else {
+      return ArchiveNameUtil.getFileName(getName() + "-logs");
+    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -41,13 +41,8 @@ enum OracleConnectorScope {
   }
 
   String toFileName(boolean isAssessment, Clock clock) {
-    if (this == LOGS) {
-      // add "-logs" twice for consistency with previous versions
-      String suffix = String.format("%s-%s", resultType, resultType);
-      if (isAssessment) {
-        return ArchiveNameUtil.getFileNameWithTimestamp("oracle", suffix, clock);
-      }
-      return ArchiveNameUtil.getFileName("oracle", suffix);
+    if (this == LOGS && isAssessment) {
+      return ArchiveNameUtil.getFileNameWithTimestamp("oracle", resultType, clock);
     }
     return ArchiveNameUtil.getFileName("oracle", resultType);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScope.java
@@ -42,9 +42,9 @@ enum OracleConnectorScope {
 
   String toFileName(boolean isAssessment, Clock clock) {
     if (this == LOGS && isAssessment) {
-      return ArchiveNameUtil.getFileNameWithTimestamp("oracle", resultType, clock);
+      return ArchiveNameUtil.getFileNameWithTimestamp("oracle-" + resultType, clock);
     }
-    return ArchiveNameUtil.getFileName("oracle", resultType);
+    return ArchiveNameUtil.getFileName("oracle-" + resultType);
   }
 
   String formatName() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -30,10 +30,10 @@ public class ArchiveNameUtil {
    * @param clock The Clock instance to provide the date.
    * @return Full name for the .zip archive.
    */
-  public static String getFileNameWithTimestamp(String name, String suffix, Clock clock) {
+  public static String getFileNameWithTimestamp(String name, Clock clock) {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
     String timeSuffix = formatter.withZone(clock.getZone()).format(clock.instant());
-    return formatFileName(name, suffix + "-" + timeSuffix);
+    return formatFileName(name, timeSuffix);
   }
 
   /**
@@ -44,13 +44,12 @@ public class ArchiveNameUtil {
    * @param suffix Connector-specific suffix such as "metadata" or "logs".
    * @return Full name for the .zip archive.
    */
-  public static String getFileName(String name, String suffix) {
-    return formatFileName(name, suffix);
+  public static String getFileName(String name) {
+    return formatFileName(name);
   }
 
-  private static String formatFileName(String name, String suffix) {
-    String nameWithOptionalSuffix = name + (suffix.isEmpty() ? "" : "-" + suffix);
-    return String.format("dwh-migration-%s.zip", nameWithOptionalSuffix);
+  private static String formatFileName(String... terms) {
+    return String.format("dwh-migration-%s.zip", String.join("-", terms));
   }
 
   private ArchiveNameUtil() {}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/generic/GenericConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/generic/GenericConnectorTest.java
@@ -16,15 +16,18 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.generic;
 
+import static java.time.ZoneOffset.UTC;
+import static org.junit.Assert.assertEquals;
+
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnectorExecutionTest;
 import com.google.edwmigration.dumper.test.TestUtils;
 import java.io.File;
 import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * ./gradlew compilerworks-application-dumper:{clean,test} -Dtest.verbose=true
@@ -33,12 +36,32 @@ import org.slf4j.LoggerFactory;
 @RunWith(JUnit4.class)
 public class GenericConnectorTest extends AbstractConnectorExecutionTest {
 
-  private static final Logger LOG = LoggerFactory.getLogger(GenericConnectorTest.class);
-
   private static final String SUBPROJECT = "compilerworks-application-dumper";
 
   private static final File GENERIC_DUMPER_TEST =
       new File(TestUtils.getTestResourcesDir(SUBPROJECT), "dumper-test/generic.sql");
+
+  private final GenericConnector connector = new GenericConnector();
+
+  @Test
+  public void getDefaultFileName_forAssessment_success() {
+    Instant instant = Instant.ofEpochMilli(1715346130945L);
+    Clock clock = Clock.fixed(instant, UTC);
+
+    String fileName = connector.getDefaultFileName(/* isAssessment= */ true, clock);
+
+    assertEquals("dwh-migration-generic-logs-20240510T130210.zip", fileName);
+  }
+
+  @Test
+  public void getDefaultFileName_notForAssessment_success() {
+    Instant instant = Instant.ofEpochMilli(1715346130945L);
+    Clock clock = Clock.fixed(instant, UTC);
+
+    String fileName = connector.getDefaultFileName(/* isAssessment= */ false, clock);
+
+    assertEquals("dwh-migration-generic-logs.zip", fileName);
+  }
 
   @Test
   public void testGeneric() throws IOException, Exception {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleConnectorScopeTest.java
@@ -48,8 +48,7 @@ public class OracleConnectorScopeTest {
     Instant instant = Instant.ofEpochMilli(1715346130945L);
     Clock clock = Clock.fixed(instant, UTC);
 
-    assertEquals(
-        "dwh-migration-oracle-logs-logs-20240510T130210.zip", LOGS.toFileName(true, clock));
+    assertEquals("dwh-migration-oracle-logs-20240510T130210.zip", LOGS.toFileName(true, clock));
     assertEquals("dwh-migration-oracle-metadata.zip", METADATA.toFileName(true, clock));
     assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(true, clock));
   }
@@ -59,7 +58,7 @@ public class OracleConnectorScopeTest {
     Instant instant = Instant.ofEpochMilli(1715346130945L);
     Clock clock = Clock.fixed(instant, UTC);
 
-    assertEquals("dwh-migration-oracle-logs-logs.zip", LOGS.toFileName(false, clock));
+    assertEquals("dwh-migration-oracle-logs.zip", LOGS.toFileName(false, clock));
     assertEquals("dwh-migration-oracle-metadata.zip", METADATA.toFileName(false, clock));
     assertEquals("dwh-migration-oracle-stats.zip", STATS.toFileName(false, clock));
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
@@ -264,7 +264,7 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
 
     String fileName = connector.getDefaultFileName(/* isAssessment= */ true, clock);
 
-    assertEquals("dwh-migration-teradata-logs-logs-20240510T130210.zip", fileName);
+    assertEquals("dwh-migration-teradata-logs-20240510T130210.zip", fileName);
   }
 
   @Test
@@ -274,7 +274,7 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
 
     String fileName = connector.getDefaultFileName(/* isAssessment= */ false, clock);
 
-    assertEquals("dwh-migration-teradata-logs-logs.zip", fileName);
+    assertEquals("dwh-migration-teradata-logs.zip", fileName);
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
@@ -27,23 +27,20 @@ public class ArchiveNameUtilTest {
 
   @Test
   public void getFileName_success() {
-    String name = "snowflake";
-    String suffix = "information-schema-logs";
+    String name = "snowflake-information-schema-logs";
 
     assertEquals(
-        "dwh-migration-snowflake-information-schema-logs.zip",
-        ArchiveNameUtil.getFileName(name, suffix));
+        "dwh-migration-snowflake-information-schema-logs.zip", ArchiveNameUtil.getFileName(name));
   }
 
   @Test
   public void getFileNameWithTimestamp_success() {
     Instant instant = Instant.ofEpochMilli(1715346130945L);
     Clock clock = Clock.fixed(instant, UTC);
-    String name = "snowflake";
-    String suffix = "information-schema-logs";
+    String name = "snowflake-information-schema-logs";
 
     assertEquals(
         "dwh-migration-snowflake-information-schema-logs-20240510T130210.zip",
-        ArchiveNameUtil.getFileNameWithTimestamp(name, suffix, clock));
+        ArchiveNameUtil.getFileNameWithTimestamp(name, clock));
   }
 }


### PR DESCRIPTION
b/275708841
- fix all cases of duplicate "-logs" suffixes
- add tests to verify that output names in the generic connector remained correct

### Archive names after the fix (non-assessment version):
```
* bigquery-logs - dwh-migration-bigquery-logs.zip
* generic - dwh-migration-generic-logs.zip
* oracle-logs - dwh-migration-oracle-logs.zip
* redshift-logs - dwh-migration-redshift-logs.zip
* redshift-raw-logs - dwh-migration-redshift-raw-logs.zip
* snowflake-account-usage-logs - dwh-migration-snowflake-account-usage-logs.zip
* snowflake-information-schema-logs - dwh-migration-snowflake-information-schema-logs.zip
* snowflake-logs - dwh-migration-snowflake-logs.zip
* teradata14-logs - dwh-migration-teradata14-logs.zip
* teradata-logs - dwh-migration-teradata-logs.zip
* vertica-logs - dwh-migration-vertica-logs.zip
```