### PR TITLE
Cleanup of redundant generics for String

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -28,6 +28,7 @@ import com.google.common.base.MoreObjects.ToStringHelper;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
@@ -612,7 +613,7 @@ public class ConnectorArguments extends DefaultArguments {
   }
 
   @Nonnull
-  public List<String> getDatabases() {
+  public ImmutableList<String> getDatabases() {
     return getOptions().valuesOf(optionDatabase).stream()
         .map(String::trim)
         .filter(StringUtils::isNotEmpty)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFile.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFile.java
@@ -72,24 +72,24 @@ public class JsonResponseFile {
   }
 
   @Nonnull
-  private static List<? extends String> to_arguments(@Nonnull File file) throws IOException {
+  private static List<String> to_arguments(@Nonnull File file) throws IOException {
     return convert(newObjectMapper().readTree(file));
   }
 
   @VisibleForTesting
-  /* pp */ static List<? extends String> to_arguments(@Nonnull String text)
+  /* pp */ static List<String> to_arguments(@Nonnull String text)
       throws IOException, JsonProcessingException {
     return convert(newObjectMapper().readTree(text));
   }
 
   @Nonnull
-  private static List<? extends String> convert(@Nonnull JsonNode node) {
+  private static List<String> convert(@Nonnull JsonNode node) {
     List<String> out = new ArrayList<>();
     convert(node, out);
     return out;
   }
 
-  private static void convert(@Nonnull JsonNode node, @Nonnull List<? super String> ret) {
+  private static void convert(@Nonnull JsonNode node, @Nonnull List<String> ret) {
     Preconditions.checkArgument(node.isObject(), "Object expected as root node of JSON file.");
     node.fields()
         .forEachRemaining(
@@ -102,7 +102,7 @@ public class JsonResponseFile {
   }
 
   private static void convertDefinitions(
-      String s, String s1, String s2, JsonNode childnode, List<? super String> ret) {
+      String s, String s1, String s2, JsonNode childnode, List<String> ret) {
     Preconditions.checkArgument(childnode.isObject(), "Definitions should be a JSON object");
     childnode
         .fields()
@@ -117,7 +117,7 @@ public class JsonResponseFile {
 
   /** Converts the given JsonNode into a set of --argument strings, within the given prefix. */
   private static void convertArgument(
-      @Nonnull String prefix, @Nonnull JsonNode node, @Nonnull List<? super String> ret) {
+      @Nonnull String prefix, @Nonnull JsonNode node, @Nonnull List<String> ret) {
     if (node.isObject()) {
       node.fields()
           .forEachRemaining(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFile.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/JsonResponseFile.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -72,21 +73,21 @@ public class JsonResponseFile {
   }
 
   @Nonnull
-  private static List<String> to_arguments(@Nonnull File file) throws IOException {
+  private static ImmutableList<String> to_arguments(@Nonnull File file) throws IOException {
     return convert(newObjectMapper().readTree(file));
   }
 
   @VisibleForTesting
-  /* pp */ static List<String> to_arguments(@Nonnull String text)
+  /* pp */ static ImmutableList<String> to_arguments(@Nonnull String text)
       throws IOException, JsonProcessingException {
     return convert(newObjectMapper().readTree(text));
   }
 
   @Nonnull
-  private static List<String> convert(@Nonnull JsonNode node) {
+  private static ImmutableList<String> convert(@Nonnull JsonNode node) {
     List<String> out = new ArrayList<>();
     convert(node, out);
-    return out;
+    return ImmutableList.copyOf(out);
   }
 
   private static void convert(@Nonnull JsonNode node, @Nonnull List<String> ret) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
@@ -71,7 +71,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
    */
   @Nonnull
   private static ClassLoader newDriverClassLoader(
-      @Nonnull ClassLoader parentClassLoader, @CheckForNull List<? extends String> driverPaths)
+      @Nonnull ClassLoader parentClassLoader, @CheckForNull List<String> driverPaths)
       throws PrivilegedActionException, MalformedURLException {
     if (driverPaths == null || driverPaths.isEmpty()) return parentClassLoader;
     List<URL> urls = new ArrayList<>();
@@ -108,7 +108,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
 
   @Nonnull
   protected Driver newDriver(
-      @CheckForNull List<? extends String> driverPaths, @Nonnull String... driverClassNames)
+      @CheckForNull List<String> driverPaths, @Nonnull String... driverClassNames)
       throws SQLException {
     Class<?> driverClass = null;
     try {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryLogsConnector.java
@@ -97,7 +97,7 @@ public class BigQueryLogsConnector extends AbstractBigQueryConnector
       // BigQuery.JobListOption allUsers = BigQuery.JobListOption.allUsers(); //XXX: using allUsers
       // causes NPE while getting values.
 
-      List<String> projectIds = arguments.getDatabases();
+      ImmutableList<String> projectIds = arguments.getDatabases();
       if (projectIds.isEmpty()) projectIds = ImmutableList.of(bigQuery.getOptions().getProjectId());
 
       ZonedIntervalIterable intervals =

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryLogsConnector.java
@@ -97,7 +97,7 @@ public class BigQueryLogsConnector extends AbstractBigQueryConnector
       // BigQuery.JobListOption allUsers = BigQuery.JobListOption.allUsers(); //XXX: using allUsers
       // causes NPE while getting values.
 
-      List<? extends String> projectIds = arguments.getDatabases();
+      List<String> projectIds = arguments.getDatabases();
       if (projectIds.isEmpty()) projectIds = ImmutableList.of(bigQuery.getOptions().getProjectId());
 
       ZonedIntervalIterable intervals =

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryMetadataConnector.java
@@ -35,6 +35,7 @@ import com.google.cloud.bigquery.TableId;
 import com.google.cloud.bigquery.TimePartitioning;
 import com.google.cloud.bigquery.ViewDefinition;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -97,13 +98,13 @@ public class BigQueryMetadataConnector extends AbstractBigQueryConnector
 
   public abstract static class AbstractBigQueryMetadataTask extends AbstractBigQueryTask {
 
-    private final List<String> databaseList;
+    private final ImmutableList<String> databaseList;
     private final Predicate<String> schemaPredicate;
 
     public AbstractBigQueryMetadataTask(
         String targetPath, @Nonnull List<String> databaseList, Predicate<String> schemaPredicate) {
       super(targetPath);
-      this.databaseList = Preconditions.checkNotNull(databaseList, "Database list was null.");
+      this.databaseList = ImmutableList.copyOf(databaseList);
       this.schemaPredicate =
           Preconditions.checkNotNull(schemaPredicate, "Schema predicate was null.");
     }
@@ -408,7 +409,7 @@ public class BigQueryMetadataConnector extends AbstractBigQueryConnector
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
-    List<String> databaseList = arguments.getDatabases();
+    ImmutableList<String> databaseList = arguments.getDatabases();
     Predicate<String> schemaPredicate = arguments.getSchemaPredicate();
     out.add(new DatasetsTask(databaseList, schemaPredicate));
     out.add(new TablesJsonTask(databaseList, schemaPredicate));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryMetadataConnector.java
@@ -97,13 +97,11 @@ public class BigQueryMetadataConnector extends AbstractBigQueryConnector
 
   public abstract static class AbstractBigQueryMetadataTask extends AbstractBigQueryTask {
 
-    private final List<? extends String> databaseList;
-    private final Predicate<? super String> schemaPredicate;
+    private final List<String> databaseList;
+    private final Predicate<String> schemaPredicate;
 
     public AbstractBigQueryMetadataTask(
-        String targetPath,
-        @Nonnull List<? extends String> databaseList,
-        Predicate<? super String> schemaPredicate) {
+        String targetPath, @Nonnull List<String> databaseList, Predicate<String> schemaPredicate) {
       super(targetPath);
       this.databaseList = Preconditions.checkNotNull(databaseList, "Database list was null.");
       this.schemaPredicate =
@@ -173,8 +171,7 @@ public class BigQueryMetadataConnector extends AbstractBigQueryConnector
       implements BigQueryMetadataDumpFormat.DatasetsTaskFormat {
 
     public DatasetsTask(
-        @Nonnull List<? extends String> databaseList,
-        @Nonnull Predicate<? super String> schemaPredicate) {
+        @Nonnull List<String> databaseList, @Nonnull Predicate<String> schemaPredicate) {
       super(ZIP_ENTRY_NAME, databaseList, schemaPredicate);
     }
 
@@ -241,8 +238,7 @@ public class BigQueryMetadataConnector extends AbstractBigQueryConnector
       implements BigQueryMetadataDumpFormat.TablesJsonTaskFormat {
 
     public TablesJsonTask(
-        @Nonnull List<? extends String> databaseList,
-        @Nonnull Predicate<? super String> schemaPredicate) {
+        @Nonnull List<String> databaseList, @Nonnull Predicate<String> schemaPredicate) {
       super(ZIP_ENTRY_NAME, databaseList, schemaPredicate);
     }
 
@@ -412,8 +408,8 @@ public class BigQueryMetadataConnector extends AbstractBigQueryConnector
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
-    List<? extends String> databaseList = arguments.getDatabases();
-    Predicate<? super String> schemaPredicate = arguments.getSchemaPredicate();
+    List<String> databaseList = arguments.getDatabases();
+    Predicate<String> schemaPredicate = arguments.getSchemaPredicate();
     out.add(new DatasetsTask(databaseList, schemaPredicate));
     out.add(new TablesJsonTask(databaseList, schemaPredicate));
     // out.add(new ColumnsTask(databaseList, schemaPredicate));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -85,7 +85,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           RecordProgressMonitor monitor =
               new RecordProgressMonitor("Writing database names to " + getTargetPath());
           CSVPrinter printer = FORMAT.withHeader(Header.class).print(writer)) {
-        List<? extends String> allDatabases = client.getAllDatabaseNames();
+        List<String> allDatabases = client.getAllDatabaseNames();
         for (String database : allDatabases) {
           monitor.count();
           printer.printRecord(database);
@@ -113,7 +113,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           RecordProgressMonitor monitor =
               new RecordProgressMonitor("Writing databases info to " + getTargetPath());
           CSVPrinter printer = FORMAT.withHeader(Header.class).print(writer)) {
-        List<? extends String> allDatabases = client.getAllDatabaseNames();
+        List<String> allDatabases = client.getAllDatabaseNames();
         for (String databaseName : allDatabases) {
           Database database = client.getDatabase(databaseName);
           monitor.count();
@@ -153,11 +153,10 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           thriftClientHandle.newMultiThreadedThriftClientPool("tables-task-pooled-client")) {
         clientPool.execute(
             thriftClient -> {
-              List<? extends String> allDatabases = thriftClient.getAllDatabaseNames();
+              List<String> allDatabases = thriftClient.getAllDatabaseNames();
               for (String databaseName : allDatabases) {
                 if (isIncludedDatabase(databaseName)) {
-                  List<? extends String> allTables =
-                      thriftClient.getAllTableNamesInDatabase(databaseName);
+                  List<String> allTables = thriftClient.getAllTableNamesInDatabase(databaseName);
                   try (ConcurrentProgressMonitor monitor =
                       new ConcurrentRecordProgressMonitor(
                           "Writing tables in database '" + databaseName + "' to " + getTargetPath(),

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.hive;
 import com.google.auto.service.AutoService;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabasePredicate;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -85,7 +86,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           RecordProgressMonitor monitor =
               new RecordProgressMonitor("Writing database names to " + getTargetPath());
           CSVPrinter printer = FORMAT.withHeader(Header.class).print(writer)) {
-        List<String> allDatabases = client.getAllDatabaseNames();
+        ImmutableList<String> allDatabases = client.getAllDatabaseNames();
         for (String database : allDatabases) {
           monitor.count();
           printer.printRecord(database);
@@ -113,7 +114,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           RecordProgressMonitor monitor =
               new RecordProgressMonitor("Writing databases info to " + getTargetPath());
           CSVPrinter printer = FORMAT.withHeader(Header.class).print(writer)) {
-        List<String> allDatabases = client.getAllDatabaseNames();
+        ImmutableList<String> allDatabases = client.getAllDatabaseNames();
         for (String databaseName : allDatabases) {
           Database database = client.getDatabase(databaseName);
           monitor.count();
@@ -153,10 +154,11 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           thriftClientHandle.newMultiThreadedThriftClientPool("tables-task-pooled-client")) {
         clientPool.execute(
             thriftClient -> {
-              List<String> allDatabases = thriftClient.getAllDatabaseNames();
+              ImmutableList<String> allDatabases = thriftClient.getAllDatabaseNames();
               for (String databaseName : allDatabases) {
                 if (isIncludedDatabase(databaseName)) {
-                  List<String> allTables = thriftClient.getAllTableNamesInDatabase(databaseName);
+                  ImmutableList<String> allTables =
+                      thriftClient.getAllTableNamesInDatabase(databaseName);
                   try (ConcurrentProgressMonitor monitor =
                       new ConcurrentRecordProgressMonitor(
                           "Writing tables in database '" + databaseName + "' to " + getTargetPath(),

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
@@ -146,7 +146,7 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
     }
 
     @Nonnull
-    protected abstract String getSql(@Nonnull Predicate<? super String> predicate);
+    protected abstract String getSql(@Nonnull Predicate<String> predicate);
 
     /**
      * Runs a test query to check whether a given projection expression is legal on this Teradata
@@ -189,7 +189,7 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
 
     @Override
     @Nonnull
-    protected String getSql(@Nonnull Predicate<? super String> predicate) {
+    protected String getSql(@Nonnull Predicate<String> predicate) {
       StringBuilder buf = new StringBuilder("SELECT ");
 
       String separator = "";
@@ -234,7 +234,7 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
 
     @Override
     @Nonnull
-    protected String getSql(@Nonnull Predicate<? super String> predicate) {
+    protected String getSql(@Nonnull Predicate<String> predicate) {
       StringBuilder buf = new StringBuilder("SELECT ");
 
       String separator = "";

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
@@ -177,15 +177,14 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
    * @return A SQL query containing every legal expression from EXPRESSIONS.
    */
   @Nonnull
-  /* pp */ String getOrCreateSql(
-      Predicate<String> predicate, ImmutableList<String> localExpressions) {
+  /* pp */ String getOrCreateSql(Predicate<String> predicate, List<String> localExpressions) {
     if (!sql.isPresent()) {
       sql = Optional.of(buildSql(predicate, localExpressions));
     }
     return sql.get();
   }
 
-  private String buildSql(Predicate<String> predicate, ImmutableList<String> localExpressions) {
+  private String buildSql(Predicate<String> predicate, List<String> localExpressions) {
     StringBuilder buf = new StringBuilder("SELECT ");
     String separator = "";
     boolean queryTableIncluded = false;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
@@ -178,15 +178,14 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
    */
   @Nonnull
   /* pp */ String getOrCreateSql(
-      Predicate<? super String> predicate, ImmutableList<String> localExpressions) {
+      Predicate<String> predicate, ImmutableList<String> localExpressions) {
     if (!sql.isPresent()) {
       sql = Optional.of(buildSql(predicate, localExpressions));
     }
     return sql.get();
   }
 
-  private String buildSql(
-      Predicate<? super String> predicate, ImmutableList<String> localExpressions) {
+  private String buildSql(Predicate<String> predicate, ImmutableList<String> localExpressions) {
     StringBuilder buf = new StringBuilder("SELECT ");
     String separator = "";
     boolean queryTableIncluded = false;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilityLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilityLogsJdbcTask.java
@@ -222,14 +222,14 @@ public class TeradataUtilityLogsJdbcTask extends AbstractJdbcTask<Summary> {
    * @param predicate A predicate to compute whether a given expression is legal.
    * @return A SQL query containing every legal expression from EXPRESSIONS.
    */
-  private String getOrCreateSql(@Nonnull Predicate<? super String> predicate) {
+  private String getOrCreateSql(@Nonnull Predicate<String> predicate) {
     if (!sql.isPresent()) {
       sql = Optional.of(buildSql(predicate));
     }
     return sql.get();
   }
 
-  private String buildSql(Predicate<? super String> predicate) {
+  private String buildSql(Predicate<String> predicate) {
     StringBuilder buf = new StringBuilder(" SELECT ");
     String separator = "";
     for (String expression : EXPRESSIONS) {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractConnectorExecutionTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractConnectorExecutionTest.java
@@ -224,7 +224,7 @@ public abstract class AbstractConnectorExecutionTest extends AbstractConnectorTe
 
     private final Set<String> expectedEntries = new HashSet<>();
     private final Set<String> allowedEntries = new HashSet<>();
-    @Nonnull private Predicate<? super String> allowedEntriesPredicate = Predicates.alwaysFalse();
+    @Nonnull private Predicate<String> allowedEntriesPredicate = Predicates.alwaysFalse();
     private final List<ZipEntryValidator<?>> entryValidators = new ArrayList<>();
     private String format;
 
@@ -256,7 +256,7 @@ public abstract class AbstractConnectorExecutionTest extends AbstractConnectorTe
      * <p>This predicate is considered additionally and separately to the explicitly allowed names.
      */
     @Nonnull
-    public ZipValidator withAllowedEntries(@Nonnull Predicate<? super String> allowedEntries) {
+    public ZipValidator withAllowedEntries(@Nonnull Predicate<String> allowedEntries) {
       this.allowedEntriesPredicate =
           MoreObjects.firstNonNull(allowedEntries, Predicates.alwaysFalse());
       return this;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorExecutionTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorExecutionTest.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.ArrayUtils;
 public class AbstractSnowflakeConnectorExecutionTest extends AbstractConnectorExecutionTest {
 
   // TODO("Constants from SnowflakeValidator.")
-  private static final ImmutableList<? extends String> ARGS =
+  private static final ImmutableList<String> ARGS =
       ImmutableList.of(
           "--host", "compilerworks.snowflakecomputing.com",
           "--database", "cw",

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
@@ -31,7 +31,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class AbstractSnowflakeConnectorTest extends AbstractConnectorTest {
-  private static final ImmutableList<? extends String> ARGS =
+  private static final ImmutableList<String> ARGS =
       ImmutableList.of(
           "--host", "compilerworks.snowflakecomputing.com",
           "--warehouse", "testwh",

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.ext.hive.metastore;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.List;
@@ -229,13 +230,13 @@ public abstract class HiveMetastoreThriftClient implements AutoCloseable {
   }
 
   @Nonnull
-  public abstract List<String> getAllDatabaseNames() throws Exception;
+  public abstract ImmutableList<String> getAllDatabaseNames() throws Exception;
 
   @Nonnull
   public abstract Database getDatabase(@Nonnull String databaseName) throws Exception;
 
   @Nonnull
-  public abstract List<String> getAllTableNamesInDatabase(@Nonnull String databaseName)
+  public abstract ImmutableList<String> getAllTableNamesInDatabase(@Nonnull String databaseName)
       throws Exception;
 
   @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
@@ -229,13 +229,13 @@ public abstract class HiveMetastoreThriftClient implements AutoCloseable {
   }
 
   @Nonnull
-  public abstract List<? extends String> getAllDatabaseNames() throws Exception;
+  public abstract List<String> getAllDatabaseNames() throws Exception;
 
   @Nonnull
   public abstract Database getDatabase(@Nonnull String databaseName) throws Exception;
 
   @Nonnull
-  public abstract List<? extends String> getAllTableNamesInDatabase(@Nonnull String databaseName)
+  public abstract List<String> getAllTableNamesInDatabase(@Nonnull String databaseName)
       throws Exception;
 
   @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -70,7 +70,7 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
 
   @Nonnull
   @Override
-  public List<? extends String> getAllDatabaseNames() throws Exception {
+  public List<String> getAllDatabaseNames() throws Exception {
     return client.get_all_databases();
   }
 
@@ -114,8 +114,7 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
 
   @Nonnull
   @Override
-  public List<? extends String> getAllTableNamesInDatabase(@Nonnull String databaseName)
-      throws Exception {
+  public List<String> getAllTableNamesInDatabase(@Nonnull String databaseName) throws Exception {
     return client.get_all_tables(databaseName);
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -70,8 +70,8 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
 
   @Nonnull
   @Override
-  public List<String> getAllDatabaseNames() throws Exception {
-    return client.get_all_databases();
+  public ImmutableList<String> getAllDatabaseNames() throws Exception {
+    return ImmutableList.copyOf(client.get_all_databases());
   }
 
   @Nonnull
@@ -114,8 +114,9 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
 
   @Nonnull
   @Override
-  public List<String> getAllTableNamesInDatabase(@Nonnull String databaseName) throws Exception {
-    return client.get_all_tables(databaseName);
+  public ImmutableList<String> getAllTableNamesInDatabase(@Nonnull String databaseName)
+      throws Exception {
+    return ImmutableList.copyOf(client.get_all_tables(databaseName));
   }
 
   @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -69,8 +69,8 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
 
   @Nonnull
   @Override
-  public List<String> getAllDatabaseNames() throws Exception {
-    return client.get_all_databases();
+  public ImmutableList<String> getAllDatabaseNames() throws Exception {
+    return ImmutableList.copyOf(client.get_all_databases());
   }
 
   @Nonnull
@@ -113,8 +113,9 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
 
   @Nonnull
   @Override
-  public List<String> getAllTableNamesInDatabase(@Nonnull String databaseName) throws Exception {
-    return client.get_all_tables(databaseName);
+  public ImmutableList<String> getAllTableNamesInDatabase(@Nonnull String databaseName)
+      throws Exception {
+    return ImmutableList.copyOf(client.get_all_tables(databaseName));
   }
 
   @Nonnull

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -69,7 +69,7 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
 
   @Nonnull
   @Override
-  public List<? extends String> getAllDatabaseNames() throws Exception {
+  public List<String> getAllDatabaseNames() throws Exception {
     return client.get_all_databases();
   }
 
@@ -113,8 +113,7 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
 
   @Nonnull
   @Override
-  public List<? extends String> getAllTableNamesInDatabase(@Nonnull String databaseName)
-      throws Exception {
+  public List<String> getAllTableNamesInDatabase(@Nonnull String databaseName) throws Exception {
     return client.get_all_tables(databaseName);
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/utils/PartitionNameGenerator.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/utils/PartitionNameGenerator.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.ext.hive.metastore.utils;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.Streams;
@@ -24,7 +25,6 @@ import java.net.URLEncoder;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.CheckForNull;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +61,7 @@ public final class PartitionNameGenerator {
 
   @CheckForNull
   private static String constructPartitionName(String partitionKey, String partitionValue) {
-    if (StringUtils.isEmpty(partitionValue)) {
+    if (isNullOrEmpty(partitionValue)) {
       // This is unexpected and the original code throws an exception here.
       LOG.warn("Got empty partition value for the key '{}', will ignore it.", partitionKey);
       return null;

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/utils/PartitionNameGenerator.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/utils/PartitionNameGenerator.java
@@ -16,13 +16,15 @@
  */
 package com.google.edwmigration.dumper.ext.hive.metastore.utils;
 
+import static java.util.stream.Collectors.joining;
+
 import com.google.common.collect.Streams;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,15 +56,14 @@ public final class PartitionNameGenerator {
             partitionValues.stream(),
             PartitionNameGenerator::constructPartitionName)
         .filter(Objects::nonNull)
-        .collect(Collectors.joining("/"));
+        .collect(joining("/"));
   }
 
   @CheckForNull
   private static String constructPartitionName(String partitionKey, String partitionValue) {
-    if (partitionValue == null || partitionValue.length() == 0) {
+    if (StringUtils.isEmpty(partitionValue)) {
       // This is unexpected and the original code throws an exception here.
-      LOG.warn(
-          String.format("Got empty partition value for the key %s, will ignore it.", partitionKey));
+      LOG.warn("Got empty partition value for the key '{}', will ignore it.", partitionKey);
       return null;
     }
     return escapePartitionPart(partitionKey) + "=" + escapePartitionPart(partitionValue);

--- a/dumper/lib-ext-hive-metastore/src/test/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClientTest.java
+++ b/dumper/lib-ext-hive-metastore/src/test/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClientTest.java
@@ -18,7 +18,7 @@ package com.google.edwmigration.dumper.ext.hive.metastore;
 
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
+import com.google.common.collect.ImmutableList;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -37,7 +37,7 @@ public class HiveMetastoreThriftClientTest {
   public void testClientAgainstLiveMetastore_v2_3_6() throws Exception {
     HiveMetastoreThriftClient client =
         new HiveMetastoreThriftClient.Builder("2.3.6").withHost("localhost").withPort(9083).build();
-    List<String> databaseNames = client.getAllDatabaseNames();
+    ImmutableList<String> databaseNames = client.getAllDatabaseNames();
     LOG.info("Databases in metastore: {}", databaseNames);
     assertTrue("Expected at least one database name.", databaseNames.size() > 0);
   }
@@ -54,7 +54,7 @@ public class HiveMetastoreThriftClientTest {
             .withHost("localhost")
             .withPort(9083)
             .build();
-    List<String> databaseNames = client.getAllDatabaseNames();
+    ImmutableList<String> databaseNames = client.getAllDatabaseNames();
     LOG.info("Databases in metastore: {}", databaseNames);
     assertTrue("Expected at least one database name.", databaseNames.size() > 0);
   }

--- a/dumper/lib-ext-hive-metastore/src/test/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClientTest.java
+++ b/dumper/lib-ext-hive-metastore/src/test/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClientTest.java
@@ -37,7 +37,7 @@ public class HiveMetastoreThriftClientTest {
   public void testClientAgainstLiveMetastore_v2_3_6() throws Exception {
     HiveMetastoreThriftClient client =
         new HiveMetastoreThriftClient.Builder("2.3.6").withHost("localhost").withPort(9083).build();
-    List<? extends String> databaseNames = client.getAllDatabaseNames();
+    List<String> databaseNames = client.getAllDatabaseNames();
     LOG.info("Databases in metastore: {}", databaseNames);
     assertTrue("Expected at least one database name.", databaseNames.size() > 0);
   }
@@ -54,7 +54,7 @@ public class HiveMetastoreThriftClientTest {
             .withHost("localhost")
             .withPort(9083)
             .build();
-    List<? extends String> databaseNames = client.getAllDatabaseNames();
+    List<String> databaseNames = client.getAllDatabaseNames();
     LOG.info("Databases in metastore: {}", databaseNames);
     assertTrue("Expected at least one database name.", databaseNames.size() > 0);
   }

--- a/dumper/lib-ext-hive-metastore/src/test/java/com/google/edwmigration/dumper/ext/hive/metastore/utils/PartitionNameGeneratorTest.java
+++ b/dumper/lib-ext-hive-metastore/src/test/java/com/google/edwmigration/dumper/ext/hive/metastore/utils/PartitionNameGeneratorTest.java
@@ -27,9 +27,9 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class PartitionNameGeneratorTest {
+
   @Test
   public void makePartitionName_emptySpec() {
-
     String partitionName = makePartitionName(ImmutableList.of(), ImmutableList.of());
 
     assertTrue(partitionName.isEmpty());


### PR DESCRIPTION
- String is final, so `? extends String` is not needed.
- Predicates work directly on Strings, so `? super String` is also not needed.
- small fix of logging placeholder and checking string emptiness in `PartitionNameGenerator`