### PR TITLE
[b/342534698] fix: missing summary after oracle-stats completes

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -24,8 +24,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Closer;
 import com.google.common.io.Files;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
-import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.io.FileSystemOutputHandleFactory;
 import com.google.edwmigration.dumper.application.dumper.io.OutputHandleFactory;
@@ -197,7 +195,8 @@ public class MetadataDumper {
       }
 
       printTaskResults(summaryPrinter, state);
-      printDumperSummary(summaryPrinter, connector, outputFileLocation);
+      String summary = connector.summary(outputFileLocation);
+      summaryPrinter.printSummarySection(summary);
       boolean result = checkRequiredTaskSuccess(summaryPrinter, state, outputFileLocation);
       logStatusSummary(summaryPrinter, state);
       return result;
@@ -241,15 +240,6 @@ public class MetadataDumper {
                 fileName));
       }
       return isZipFile ? fileName : path.resolve(defaultFileName).toString();
-    }
-  }
-
-  private void printDumperSummary(
-      SummaryPrinter summaryPrinter, Connector connector, String outputFileName) {
-    if (connector instanceof MetadataConnector) {
-      summaryPrinter.printSummarySection("Metadata has been saved to " + outputFileName);
-    } else if (connector instanceof LogsConnector) {
-      summaryPrinter.printSummarySection("Logs have been saved to " + outputFileName);
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -45,4 +45,7 @@ public interface Connector {
   public default Class<? extends Enum<? extends ConnectorProperty>> getConnectorProperties() {
     return DefaultProperties.class;
   }
+
+  @Nonnull
+  String summary(@Nonnull String fileName);
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -32,4 +32,10 @@ public interface LogsConnector extends Connector {
       return ArchiveNameUtil.getFileName(getName());
     }
   }
+
+  @Nonnull
+  @Override
+  default String summary(@Nonnull String fileName) {
+    return "Logs have been saved to " + fileName;
+  }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -28,4 +28,10 @@ public interface MetadataConnector extends Connector {
   default String getDefaultFileName(boolean isAssessment, Clock clock) {
     return ArchiveNameUtil.getFileName(getName() + "-metadata");
   }
+
+  @Nonnull
+  @Override
+  default String summary(@Nonnull String fileName) {
+    return "Metadata has been saved to " + fileName;
+  }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -23,6 +23,7 @@ import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.util.List;
+import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @AutoService(Connector.class)
@@ -39,5 +40,11 @@ public class OracleStatsConnector extends AbstractOracleConnector {
     StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
     out.add(new DumpMetadataTask(arguments, getFormatName()));
     out.addAll(taskListGenerator.createTasks(arguments));
+  }
+
+  @Nonnull
+  @Override
+  public String summary(String fileName) {
+    return String.format("Oracle statistics saved to %s", fileName);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/DriverClasspathTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/DriverClasspathTest.java
@@ -38,7 +38,6 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaCompiler.CompilationTask;
 import javax.tools.JavaFileObject;
 import javax.tools.ToolProvider;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -93,7 +92,7 @@ public class DriverClasspathTest {
     String driverPaths = driverJarPath + "," + supportJarPath;
     String[] args = {"--connector", "ignored", "--driver", driverPaths};
 
-    try (Handle ignored = new DummyConnector("dummy").open(new ConnectorArguments(args))) {
+    try (Handle ignored = new DummyConnector().open(new ConnectorArguments(args))) {
       Assert.assertTrue("Driver instantiated.", true);
     }
   }
@@ -108,8 +107,7 @@ public class DriverClasspathTest {
         Assert.assertThrows(
             SQLException.class,
             () -> {
-              try (Handle ignored =
-                  new DummyConnector("dummy").open(new ConnectorArguments(args))) {
+              try (Handle ignored = new DummyConnector().open(new ConnectorArguments(args))) {
                 Assert.assertTrue("Driver instantiated.", true);
               }
             });
@@ -123,14 +121,14 @@ public class DriverClasspathTest {
 
   private static class DummyConnector extends AbstractJdbcConnector {
 
-    public DummyConnector(@Nonnull String name) {
-      super(name);
+    public DummyConnector() {
+      super("dummy");
     }
 
     @Nonnull
     @Override
     public String getDefaultFileName(boolean isAssessment, Clock clock) {
-      return StringUtils.EMPTY;
+      return "";
     }
 
     @Override
@@ -142,6 +140,12 @@ public class DriverClasspathTest {
     public Handle open(@Nonnull ConnectorArguments arguments) throws Exception {
       newDriver(arguments.getDriverPaths(), "foo.bar.DummyDriver");
       return () -> {};
+    }
+
+    @Nonnull
+    @Override
+    public String summary(@Nonnull String fileName) {
+      return "";
     }
   }
 }


### PR DESCRIPTION
b/342534698
- add missing oracle-stats summary
- enable summaries for all connectors, not just logs and metadata
- allow connectors to override summaries
- separate connector summary from MetadataDumper logic
