### PR TITLE
[b/343037983] Extract catalogs from HMS

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -306,7 +306,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
   }
 
-  private static class CatalogsTask extends AbstractHiveMetadataTask implements FunctionsFormat {
+  private static class CatalogsTask extends AbstractHiveMetadataTask {
 
     private CatalogsTask() {
       super("catalogs.jsonl", unused -> true);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -27,6 +27,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.MetadataConne
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.ext.hive.metastore.Database;
 import com.google.edwmigration.dumper.ext.hive.metastore.Field;
 import com.google.edwmigration.dumper.ext.hive.metastore.Function;
@@ -305,6 +306,36 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
   }
 
+  private static class CatalogsTask extends AbstractHiveMetadataTask implements FunctionsFormat {
+
+    private CatalogsTask() {
+      super("catalogs.jsonl", unused -> true);
+    }
+
+    @Override
+    protected void run(Writer writer, ThriftClientHandle thriftClientHandle) throws Exception {
+      try (HiveMetastoreThriftClient client = thriftClientHandle.newClient("catalogs-task-client");
+          RecordProgressMonitor monitor =
+              new RecordProgressMonitor("Writing catalogs to " + getTargetPath())) {
+        for (String catalogJson : client.getCatalogsAsJsonl()) {
+          monitor.count();
+          writer.write(catalogJson);
+          writer.write('\n');
+        }
+      }
+    }
+
+    @Override
+    public TaskCategory getCategory() {
+      return TaskCategory.OPTIONAL;
+    }
+
+    @Override
+    protected String toCallDescription() {
+      return "get_catalogs()*.get_catalog()";
+    }
+  }
+
   public HiveMetadataConnector() {
     super("hiveql");
   }
@@ -320,6 +351,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     out.add(new SchemataTask(databasePredicate));
     out.add(new TablesJsonTask(databasePredicate, shouldDumpPartitions));
     out.add(new FunctionsTask(databasePredicate));
+    out.add(new CatalogsTask());
 
     if (arguments.isAssessment()) {
       out.add(new DatabasesTask(databasePredicate));

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -16,17 +16,25 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.hive;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.Main;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnectorTest;
 import com.google.edwmigration.dumper.application.dumper.connector.hive.support.HiveServerSupport;
 import com.google.edwmigration.dumper.application.dumper.connector.hive.support.HiveTestSchemaBuilder;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.progress.ConcurrentProgressMonitor;
 import com.google.edwmigration.dumper.plugin.ext.jdk.progress.ConcurrentRecordProgressMonitor;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -63,6 +71,21 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
   @Test
   public void testConnector() throws Exception {
     testConnectorDefaults(connector);
+  }
+
+  @Test
+  public void addTasksTo_catalogsTask_success() throws IOException {
+    ConnectorArguments args = new ConnectorArguments("--connector", "hiveql");
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(tasks, args);
+
+    // Assert
+    ImmutableList<String> taskNames = tasks.stream().map(Task::getName).collect(toImmutableList());
+    assertTrue(
+        "Task names must contain 'catalogs.jsonl'. Actual tasks: " + taskNames,
+        taskNames.contains("catalogs.jsonl"));
   }
 
   @Test
@@ -116,7 +139,7 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
               "--output",
               tmpFile.getAbsolutePath());
 
-          Assert.assertTrue(tmpFile.exists());
+          assertTrue(tmpFile.exists());
 
           try (ZipFile zipFile = new ZipFile(tmpFile)) {
             List<ZipArchiveEntry> entries = Collections.list(zipFile.getEntries());

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
@@ -245,4 +245,12 @@ public abstract class HiveMetastoreThriftClient implements AutoCloseable {
 
   @Nonnull
   public abstract List<? extends Function> getFunctions() throws Exception;
+
+  /**
+   * Returns all the catalogs as the list of JSON messages that correspond to the response from the
+   * Hive Metastore API.
+   *
+   * @return list of JSON messages
+   */
+  public abstract ImmutableList<String> getCatalogsAsJsonl() throws Exception;
 }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -27,6 +27,8 @@ import static com.google.edwmigration.dumper.ext.hive.metastore.utils.PartitionN
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.FieldSchema;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogRequest;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogsResponse;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -504,24 +506,16 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
   @Override
   public ImmutableList<String> getCatalogsAsJsonl() throws TException {
     TSerializer serializer = new TSerializer(new TSimpleJSONProtocol.Factory());
-    com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogsResponse
-        catalogs = client.get_catalogs();
+    GetCatalogsResponse catalogs = client.get_catalogs();
     return catalogs.getNames().stream()
         .map(
             catalogName -> {
               try {
-                return serializer.toString(getCatalogAsJson(catalogName));
+                return serializer.toString(client.get_catalog(new GetCatalogRequest(catalogName)));
               } catch (TException e) {
                 throw new IllegalStateException(e);
               }
             })
         .collect(toImmutableList());
-  }
-
-  private com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogResponse
-      getCatalogAsJson(String catalogName) throws TException {
-    return client.get_catalog(
-        new com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogRequest(
-            catalogName));
   }
 }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -497,4 +497,10 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
       throw new IOException("Unable to shutdown Thrift client.", e);
     }
   }
+
+  @Override
+  public ImmutableList<String> getCatalogsAsJsonl() {
+    LOG.info("Catalogs are not supported in Hive 2.3.6");
+    return ImmutableList.of();
+  }
 }


### PR DESCRIPTION
Catalogs are saved to the JSONL file, obtained by the conversion of each of the catalogs received from Thrift message directly to JSON.