### PR TITLE
[b/343047614] Extract databases from HMS

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -158,6 +158,11 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
 
     @Override
+    public TaskCategory getCategory() {
+      return TaskCategory.OPTIONAL;
+    }
+
+    @Override
     protected String toCallDescription() {
       return "get_all_databases()*.get_database()";
     }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -51,8 +51,11 @@ import org.apache.commons.lang3.SystemUtils;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,7 +63,7 @@ import org.slf4j.LoggerFactory;
  * Run this with: > ./gradlew :dumper:app:{cleanTest,test} --tests HiveMetadataConnectorTest
  * -Dtest.verbose=true -Dorg.gradle.java.home=/usr/lib/jvm/java-1.8.0-openjdk-amd64
  */
-@RunWith(JUnit4.class)
+@RunWith(Theories.class)
 public class HiveMetadataConnectorTest extends AbstractConnectorTest {
 
   private static final Logger LOG = LoggerFactory.getLogger(HiveMetadataConnectorTest.class);
@@ -73,8 +76,13 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
     testConnectorDefaults(connector);
   }
 
-  @Test
-  public void addTasksTo_catalogsTask_success() throws IOException {
+  @DataPoints("expectedTaskNames")
+  public static final ImmutableList<String> EXPECTED_TASK_NAMES =
+      ImmutableList.of("catalogs.jsonl", "databases.jsonl");
+
+  @Theory
+  public void addTasksTo_taskExists_success(@FromDataPoints("expectedTaskNames") String taskName)
+      throws IOException {
     ConnectorArguments args = new ConnectorArguments("--connector", "hiveql");
     List<Task<?>> tasks = new ArrayList<>();
 
@@ -84,8 +92,8 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
     // Assert
     ImmutableList<String> taskNames = tasks.stream().map(Task::getName).collect(toImmutableList());
     assertTrue(
-        "Task names must contain 'catalogs.jsonl'. Actual tasks: " + taskNames,
-        taskNames.contains("catalogs.jsonl"));
+        "Task names must contain '" + taskName + "'. Actual tasks: " + taskNames,
+        taskNames.contains(taskName));
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -59,10 +59,6 @@ import org.junit.runner.RunWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * Run this with: > ./gradlew :dumper:app:{cleanTest,test} --tests HiveMetadataConnectorTest
- * -Dtest.verbose=true -Dorg.gradle.java.home=/usr/lib/jvm/java-1.8.0-openjdk-amd64
- */
 @RunWith(Theories.class)
 public class HiveMetadataConnectorTest extends AbstractConnectorTest {
 
@@ -96,6 +92,14 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
         taskNames.contains(taskName));
   }
 
+  /**
+   * Run this with:
+   *
+   * <pre>
+   * ./gradlew :dumper:app:{cleanTest,test} --tests HiveMetadataConnectorTest
+   * -Dtest.verbose=true -Dorg.gradle.java.home=/usr/lib/jvm/java-1.8.0-openjdk-amd64
+   * </pre>
+   */
   @Test
   public void testLoadedHive312() throws Exception {
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient.java
@@ -30,8 +30,10 @@ import javax.annotation.concurrent.NotThreadSafe;
 import javax.security.sasl.Sasl;
 import javax.security.sasl.SaslException;
 import org.apache.thrift.TConfiguration;
+import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TSimpleJSONProtocol;
 import org.apache.thrift.transport.TSaslClientTransport;
 import org.apache.thrift.transport.TSocket;
 import org.apache.thrift.transport.TTransport;
@@ -236,6 +238,9 @@ public abstract class HiveMetastoreThriftClient implements AutoCloseable {
   public abstract Database getDatabase(@Nonnull String databaseName) throws Exception;
 
   @Nonnull
+  public abstract ImmutableList<String> getDatabasesAsJsonl() throws Exception;
+
+  @Nonnull
   public abstract ImmutableList<String> getAllTableNamesInDatabase(@Nonnull String databaseName)
       throws Exception;
 
@@ -253,4 +258,8 @@ public abstract class HiveMetastoreThriftClient implements AutoCloseable {
    * @return list of JSON messages
    */
   public abstract ImmutableList<String> getCatalogsAsJsonl() throws Exception;
+
+  protected TSerializer createJsonSerializer() throws TTransportException {
+    return new TSerializer(new TSimpleJSONProtocol.Factory());
+  }
 }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -37,6 +37,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.thrift.TException;
+import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -109,6 +110,21 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
         return database.getLocationUri();
       }
     };
+  }
+
+  @Override
+  public ImmutableList<String> getDatabasesAsJsonl() throws Exception {
+    TSerializer serializer = createJsonSerializer();
+    return client.get_all_databases().stream()
+        .map(
+            databaseName -> {
+              try {
+                return serializer.toString(client.get_database(databaseName));
+              } catch (TException e) {
+                throw new IllegalStateException(e);
+              }
+            })
+        .collect(toImmutableList());
   }
 
   @Nonnull


### PR DESCRIPTION
Extract all the fields from the databases and save the result in the new `databases.jsonl` file that contains a JSON serialization of the Thrift response.