### PR TITLE
[b/343047614] Hide migration metadata extraction behind a flag

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/AbstractHiveConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/AbstractHiveConnector.java
@@ -253,7 +253,9 @@ public abstract class AbstractHiveConnector extends AbstractConnector {
             + " SASL connection between hadoop and the dumper. Allowed values: '"
             + HadoopRpcProtection.ALLOWED_VALUES
             + "'.",
-        HadoopRpcProtection.PRIVACY.name());
+        HadoopRpcProtection.PRIVACY.name()),
+    MIGRATION_METADATA(
+        "migration.metadata", "Extraction of the metadata necessary for migration.", "false");
 
     private final String name;
     private final String description;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -46,6 +46,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import org.apache.commons.csv.CSVPrinter;
+import org.apache.commons.lang3.BooleanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -384,8 +385,11 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     out.add(new SchemataTask(databasePredicate));
     out.add(new TablesJsonTask(databasePredicate, shouldDumpPartitions));
     out.add(new FunctionsTask(databasePredicate));
-    out.add(new CatalogsTask());
-    out.add(new DatabasesJsonlTask());
+    if (BooleanUtils.toBoolean(
+        arguments.getDefinitionOrDefault(HiveConnectorProperty.MIGRATION_METADATA))) {
+      out.add(new CatalogsTask());
+      out.add(new DatabasesJsonlTask());
+    }
 
     if (arguments.isAssessment()) {
       out.add(new DatabasesTask(databasePredicate));

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -72,14 +72,43 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
     testConnectorDefaults(connector);
   }
 
-  @DataPoints("expectedTaskNames")
+  @DataPoints("commonTaskNames")
   public static final ImmutableList<String> EXPECTED_TASK_NAMES =
+      ImmutableList.of(
+          "compilerworks-metadata.yaml",
+          "compilerworks-format.txt",
+          "schemata.csv",
+          "tables.jsonl",
+          "functions.csv");
+
+  @Theory
+  public void addTasksTo_taskExists_success(
+      @FromDataPoints("commonTaskNames") String taskName, boolean migrationMetadataEnabled)
+      throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector", "hiveql", "-Dhiveql.migration.metadata=" + migrationMetadataEnabled);
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(tasks, args);
+
+    // Assert
+    ImmutableList<String> taskNames = tasks.stream().map(Task::getName).collect(toImmutableList());
+    assertTrue(
+        "Task names must contain '" + taskName + "'. Actual tasks: " + taskNames,
+        taskNames.contains(taskName));
+  }
+
+  @DataPoints("migrationMetadataTaskNames")
+  public static final ImmutableList<String> EXPECTED_TASK_NAMES_WITH_MIGRATION_METADATA_ENABLED =
       ImmutableList.of("catalogs.jsonl", "databases.jsonl");
 
   @Theory
-  public void addTasksTo_taskExists_success(@FromDataPoints("expectedTaskNames") String taskName)
-      throws IOException {
-    ConnectorArguments args = new ConnectorArguments("--connector", "hiveql");
+  public void addTasksTo_migrationMetadataTaskExists_success(
+      @FromDataPoints("migrationMetadataTaskNames") String taskName) throws IOException {
+    ConnectorArguments args =
+        new ConnectorArguments("--connector", "hiveql", "-Dhiveql.migration.metadata=true");
     List<Task<?>> tasks = new ArrayList<>();
 
     // Act


### PR DESCRIPTION
Do not extract migration metadata by default, so that the discovery for assessment can be used without additional metadata required by migration.

For migration case require the `-Dhiveql.migration.metadata=true` flag.