### PR TITLE
[b/343069385] Extract tables from HMS

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -291,6 +291,75 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
   }
 
+  private static class TablesRawJsonlTask extends AbstractHiveMetadataTask {
+
+    private TablesRawJsonlTask(Predicate<String> databasePredicate) {
+      super("tables-raw.jsonl", databasePredicate);
+    }
+
+    @Override
+    protected void run(@Nonnull Writer writer, @Nonnull ThriftClientHandle thriftClientHandle)
+        throws Exception {
+      try (ThriftClientPool clientPool =
+          thriftClientHandle.newMultiThreadedThriftClientPool("tables-raw-task-pooled-client")) {
+        clientPool.execute(
+            thriftClient -> {
+              ImmutableList<String> allDatabases = thriftClient.getAllDatabaseNames();
+              for (String databaseName : allDatabases) {
+                if (isIncludedDatabase(databaseName)) {
+                  ImmutableList<String> allTables =
+                      thriftClient.getAllTableNamesInDatabase(databaseName);
+                  try (ConcurrentProgressMonitor monitor =
+                      new ConcurrentRecordProgressMonitor(
+                          "Writing tables in database '" + databaseName + "' to " + getTargetPath(),
+                          allTables.size())) {
+                    for (String tableName : allTables) {
+                      dumpTable(monitor, writer, clientPool, databaseName, tableName);
+                    }
+                  }
+                }
+              }
+            });
+      }
+    }
+
+    private void dumpTable(
+        @Nonnull ConcurrentProgressMonitor monitor,
+        @Nonnull Writer writer,
+        @Nonnull ThriftClientPool clientPool,
+        @Nonnull String databaseName,
+        @Nonnull String tableName) {
+      clientPool.execute(
+          (thriftClient) -> {
+            try {
+              monitor.count();
+              String tableJson = thriftClient.getTable(databaseName, tableName).toJson();
+              synchronized (writer) {
+                writer.write("{\"table\":");
+                writer.write(tableJson);
+                writer.write("}");
+                writer.write('\n');
+              }
+            } catch (Exception e) {
+              // Failure to dump a single table should not prevent the rest of the tables from being
+              // dumped.
+              LOG.warn(
+                  "Metadata cannot be dumped for table "
+                      + databaseName
+                      + "."
+                      + tableName
+                      + " due to an exception, skipping it.",
+                  e);
+            }
+          });
+    }
+
+    @Override
+    protected String toCallDescription() {
+      return "get_all_databases()*.get_all_tables()";
+    }
+  }
+
   private static class FunctionsTask extends AbstractHiveMetadataTask implements FunctionsFormat {
 
     private FunctionsTask(@Nonnull Predicate<String> databasePredicate) {
@@ -490,7 +559,6 @@ public class HiveMetadataConnector extends AbstractHiveConnector
         arguments.isHiveMetastorePartitionMetadataDumpingEnabled() || arguments.isAssessment();
 
     out.add(new SchemataTask(databasePredicate));
-    out.add(new TablesJsonTask(databasePredicate, shouldDumpPartitions));
     out.add(new FunctionsTask(databasePredicate));
     if (BooleanUtils.toBoolean(
         arguments.getDefinitionOrDefault(HiveConnectorProperty.MIGRATION_METADATA))) {
@@ -500,6 +568,9 @@ public class HiveMetadataConnector extends AbstractHiveConnector
       out.add(new DelegationTokensTask());
       out.add(new FunctionsJsonlTask());
       out.add(new ResourcePlansJsonlTask());
+      out.add(new TablesRawJsonlTask(databasePredicate));
+    } else {
+      out.add(new TablesJsonTask(databasePredicate, shouldDumpPartitions));
     }
 
     if (arguments.isAssessment()) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -333,10 +333,12 @@ public class HiveMetadataConnector extends AbstractHiveConnector
           (thriftClient) -> {
             try {
               monitor.count();
-              String tableJson = thriftClient.getTable(databaseName, tableName).toJson();
+              TBase<?, ?> table =
+                  thriftClient.getTable(databaseName, tableName).getRawThriftObject();
+              ThriftJsonSerializer serializer = new ThriftJsonSerializer();
               synchronized (writer) {
                 writer.write("{\"table\":");
-                writer.write(tableJson);
+                writer.write(serializer.serialize(table));
                 writer.write("}");
                 writer.write('\n');
               }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnectorTest.java
@@ -78,7 +78,6 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
           "compilerworks-metadata.yaml",
           "compilerworks-format.txt",
           "schemata.csv",
-          "tables.jsonl",
           "functions.csv");
 
   @Theory
@@ -100,6 +99,21 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
         taskNames.contains(taskName));
   }
 
+  @Test
+  public void addTasksTo_originalTableJsonl_success() throws IOException {
+    ConnectorArguments args = new ConnectorArguments("--connector", "hiveql");
+    List<Task<?>> tasks = new ArrayList<>();
+
+    // Act
+    connector.addTasksTo(tasks, args);
+
+    // Assert
+    ImmutableList<String> taskNames = tasks.stream().map(Task::getName).collect(toImmutableList());
+    assertTrue(
+        "Task names must contain 'tables.jsonl'. Actual tasks: " + taskNames,
+        taskNames.contains("tables.jsonl"));
+  }
+
   @DataPoints("migrationMetadataTaskNames")
   public static final ImmutableList<String> EXPECTED_TASK_NAMES_WITH_MIGRATION_METADATA_ENABLED =
       ImmutableList.of(
@@ -108,7 +122,8 @@ public class HiveMetadataConnectorTest extends AbstractConnectorTest {
           "master-keys.csv",
           "delegation-tokens.csv",
           "functions.jsonl",
-          "resource-plans.jsonl");
+          "resource-plans.jsonl",
+          "tables-raw.jsonl");
 
   @Theory
   public void addTasksTo_migrationMetadataTaskExists_success(

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -468,6 +468,11 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
                 })
             .collect(toImmutableList());
       }
+
+      @Override
+      public String toJson() throws Exception {
+        return createJsonSerializer().toString(table);
+      }
     };
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -470,8 +470,8 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
       }
 
       @Override
-      public String toJson() throws Exception {
-        return createJsonSerializer().toString(table);
+      public TBase<?, ?> getRawThriftObject() {
+        return table;
       }
     };
   }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -464,6 +464,11 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
                 })
             .collect(toImmutableList());
       }
+
+      @Override
+      public String toJson() throws Exception {
+        return createJsonSerializer().toString(table);
+      }
     };
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -466,8 +466,8 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
       }
 
       @Override
-      public String toJson() throws Exception {
-        return createJsonSerializer().toString(table);
+      public TBase<?, ?> getRawThriftObject() {
+        return table;
       }
     };
   }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.ext.hive.metastore;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.apache.thrift.TBase;
 
 public interface Table {
 
@@ -92,5 +93,5 @@ public interface Table {
   public List<? extends Partition> getPartitions() throws Exception;
 
   @Nonnull
-  public String toJson() throws Exception;
+  TBase<?, ?> getRawThriftObject();
 }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
@@ -90,4 +90,7 @@ public interface Table {
 
   @Nonnull
   public List<? extends Partition> getPartitions() throws Exception;
+
+  @Nonnull
+  public String toJson() throws Exception;
 }


### PR DESCRIPTION
Extract tables in the new format to the `tables-raw.jsonl` file.

The file contains the JSON serialization of the raw response from Hive Metastore API, each table on a separate line.