### PR TITLE
[b/343187503] Change output paths to avoid subdirectories

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -49,8 +49,7 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
 
   @Nonnull
   static Task<?> fromQuery(OracleStatsQuery query) {
-    String name = "oracle-stats/" + query.name() + ".csv";
-    return new StatsJdbcTask(name, query);
+    return new StatsJdbcTask(query.name() + ".csv", query);
   }
 
   @Nonnull


### PR DESCRIPTION
unzip output:
```
Archive:  dwh-migration-oracle-stats.zip
  inflating: compilerworks-version.txt  
  inflating: compilerworks-arguments.txt  
  inflating: compilerworks-metadata.yaml  
  inflating: db-features.csv         
  inflating: db-instances.csv        
  inflating: pdbs-info.csv           
  inflating: app-schemas-pdbs.csv    
  inflating: app-schemas-summary.csv  
  inflating: hist-cmd-types.csv
```