### PR TITLE
Rename name to targetPath in StatsJdbcTask

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -41,9 +41,9 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
 
   private final OracleStatsQuery query;
 
-  private StatsJdbcTask(String name, OracleStatsQuery query) {
-    super(name);
-    Preconditions.checkArgument(name.endsWith(".csv"));
+  private StatsJdbcTask(String targetPath, OracleStatsQuery query) {
+    super(targetPath);
+    Preconditions.checkArgument(targetPath.endsWith(".csv"));
     this.query = query;
   }
 


### PR DESCRIPTION
I'm renaming the parameter to follow the convention used in other task classes.