### PR TITLE
Remove the special handling of count=-1 in newCsvRSE

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
@@ -132,7 +132,7 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
     @Nonnull
     private ResultSetExtractor<Summary> newCountedResultSetExtractor(
         @Nonnull ByteSink sink, @Nonnull Connection connection) throws SQLException {
-      long count = -1;
+      Optional<Long> count = Optional.empty();
       if (sqlCount != null) {
         // It's a lot of infrastructure, but we don't have to write it.
         RowMapper<Long> rowMapper = new SingleColumnRowMapper<>(Long.class);
@@ -140,12 +140,12 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
             new RowMapperResultSetExtractor<>(rowMapper);
         List<Long> results = doSelect(connection, resultSetExtractor, sqlCount);
         Long result = DataAccessUtils.nullableSingleResult(results);
-        if (result != null) count = result;
+        count = Optional.ofNullable(result).filter(x -> x >= 0);
       }
-      if (count < 0) {
-        return newCsvResultSetExtractor(sink);
+      if (count.isPresent()) {
+        return newCsvResultSetExtractor(sink, count.get());
       } else {
-        return newCsvResultSetExtractor(sink, count);
+        return newCsvResultSetExtractor(sink);
       }
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
@@ -138,7 +138,7 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
         ResultSetExtractor<List<Long>> extractor = new RowMapperResultSetExtractor<>(rowMapper);
         List<Long> results = doSelect(connection, extractor, sqlCount);
         Long count = nullableSingleResult(results);
-        if (count != null && count >= 0) {
+        if (count != null) {
           return newCsvResultSetExtractor(sink, count);
         }
       }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
@@ -137,9 +137,9 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
         RowMapper<Long> rowMapper = new SingleColumnRowMapper<>(Long.class);
         ResultSetExtractor<List<Long>> extractor = new RowMapperResultSetExtractor<>(rowMapper);
         List<Long> results = doSelect(connection, extractor, sqlCount);
-        Optional<Long> count = Optional.ofNullable(nullableSingleResult(results));
-        if (count.isPresent() && count.get() >= 0) {
-          return newCsvResultSetExtractor(sink, count.get());
+        Long count = nullableSingleResult(results);
+        if (count != null && count >= 0) {
+          return newCsvResultSetExtractor(sink, count);
         }
       }
       return newCsvResultSetExtractor(sink);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/AbstractTeradataConnector.java
@@ -142,7 +142,11 @@ public abstract class AbstractTeradataConnector extends AbstractJdbcConnector {
         Long result = DataAccessUtils.nullableSingleResult(results);
         if (result != null) count = result;
       }
-      return newCsvResultSetExtractor(sink, count);
+      if (count < 0) {
+        return newCsvResultSetExtractor(sink);
+      } else {
+        return newCsvResultSetExtractor(sink, count);
+      }
     }
 
     @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
@@ -132,7 +132,7 @@ public class Teradata14LogsConnector extends AbstractTeradataConnector
         @Nonnull Connection connection)
         throws SQLException {
       String sql = getSql(jdbcHandle);
-      ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink, -1);
+      ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
       return doSelect(connection, withInterval(rse, interval), sql);
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
@@ -156,7 +156,7 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
       TaskRunContext context, JdbcHandle jdbcHandle, ByteSink sink, Connection connection)
       throws SQLException {
     String sql = getOrCreateSql(jdbcHandle);
-    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink, -1);
+    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
     return doSelect(connection, withInterval(rse, interval), sql);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilityLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataUtilityLogsJdbcTask.java
@@ -202,7 +202,7 @@ public class TeradataUtilityLogsJdbcTask extends AbstractJdbcTask<Summary> {
       TaskRunContext context, JdbcHandle jdbcHandle, ByteSink sink, Connection connection)
       throws SQLException {
     String sql = getOrCreateSql(jdbcHandle);
-    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink, -1);
+    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
     return doSelect(connection, withInterval(rse, interval), sql);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -39,7 +39,7 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Base64;
 import javax.annotation.CheckForNull;
-import javax.annotation.CheckForSigned;
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.sql.DataSource;
 import org.apache.commons.csv.CSVFormat;
@@ -124,12 +124,9 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
 
   @Nonnull
   protected ResultSetExtractor<Summary> newCsvResultSetExtractor(
-      @Nonnull ByteSink sink, @CheckForSigned long count) {
+      @Nonnull ByteSink sink, @Nonnegative long count) {
     return rs -> {
-      try (RecordProgressMonitor monitor =
-              count >= 0
-                  ? new RecordProgressMonitor(getName(), count)
-                  : new RecordProgressMonitor(getName());
+      try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName(), count);
           Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
         iterateResults(rs, monitor, writer);
         return new Summary(monitor.getCount());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -152,7 +152,7 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
     }
   }
 
-  public static Object convertObject(Object object) throws IOException, SQLException {
+  private static Object convertObject(Object object) throws IOException, SQLException {
     if (object instanceof byte[]) {
       return Base64.getEncoder().encodeToString((byte[]) object);
     } else if (object instanceof Clob) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -139,7 +139,7 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
     };
   }
 
-  private void iterateResults(ResultSet resultSet, RecordProgressMonitor monitor, Writer writer) 
+  private void iterateResults(ResultSet resultSet, RecordProgressMonitor monitor, Writer writer)
       throws IOException, SQLException {
     CSVFormat format = newCsvFormat(resultSet);
     try (CSVPrinter printer = format.print(writer)) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -40,7 +40,6 @@ import java.sql.Statement;
 import java.util.Arrays;
 import java.util.Base64;
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.sql.DataSource;
 import org.apache.commons.csv.CSVFormat;
@@ -124,7 +123,7 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
 
   @Nonnull
   protected ResultSetExtractor<Summary> newCsvResultSetExtractor(
-      @Nonnull ByteSink sink, @Nonnegative long count) {
+      @Nonnull ByteSink sink, long count) {
     return rs -> {
       try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName(), count)) {
         printAllResults(sink, rs, monitor);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -111,43 +111,63 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
 
   @Nonnull
   public ResultSetExtractor<Summary> newCsvResultSetExtractor(@Nonnull ByteSink sink) {
-    return newCsvResultSetExtractor(sink, -1);
+    return rs -> {
+      try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName());
+          Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
+        iterateResults(rs, monitor, writer);
+        return new Summary(monitor.getCount());
+      } catch (IOException e) {
+        throw new SQLException(e);
+      }
+    };
   }
 
   @Nonnull
   protected ResultSetExtractor<Summary> newCsvResultSetExtractor(
       @Nonnull ByteSink sink, @CheckForSigned long count) {
     return rs -> {
-      CSVFormat format = newCsvFormat(rs);
       try (RecordProgressMonitor monitor =
               count >= 0
                   ? new RecordProgressMonitor(getName(), count)
                   : new RecordProgressMonitor(getName());
-          Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream();
-          CSVPrinter printer = format.print(writer)) {
-        final int columnCount = rs.getMetaData().getColumnCount();
-        while (rs.next()) {
-          monitor.count();
-          for (int i = 1; i <= columnCount; i++) {
-            Object object = rs.getObject(i);
-            if (object instanceof byte[]) {
-              printer.print(Base64.getEncoder().encodeToString((byte[]) object));
-            } else if (object instanceof Clob) {
-              InputStream in = ((Clob) object).getAsciiStream();
-              StringWriter w = new StringWriter();
-              IOUtils.copy(in, w);
-              printer.print(w.toString());
-            } else {
-              printer.print(object);
-            }
-          }
-          printer.println();
-        }
+          Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
+        iterateResults(rs, monitor, writer);
         return new Summary(monitor.getCount());
       } catch (IOException e) {
         throw new SQLException(e);
       }
     };
+  }
+
+  private void iterateResults(ResultSet resultSet, RecordProgressMonitor monitor, Writer writer) 
+      throws IOException, SQLException {
+    CSVFormat format = newCsvFormat(resultSet);
+    try (CSVPrinter printer = format.print(writer)) {
+      int columnCount = resultSet.getMetaData().getColumnCount();
+      while (resultSet.next()) {
+        monitor.count();
+        for (int i = 1; i <= columnCount; i++) {
+          Object object = resultSet.getObject(i);
+          printer.print(convertObject(object));
+        }
+        printer.println();
+      }
+    }
+  }
+
+  public static Object convertObject(Object object) throws IOException, SQLException {
+    if (object instanceof byte[]) {
+      return Base64.getEncoder().encodeToString((byte[]) object);
+    } else if (object instanceof Clob) {
+      InputStream in = ((Clob) object).getAsciiStream();
+      StringWriter w = new StringWriter();
+      IOUtils.copy(in, w);
+      return w.toString();
+    } else {
+      // TODO: add explicit conversions for remaining types so that the return type can become
+      // String instead of Object.
+      return object;
+    }
   }
 
   public static ResultSetExtractor<Summary> withInterval(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectIntervalTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectIntervalTask.java
@@ -47,7 +47,7 @@ public class JdbcSelectIntervalTask extends JdbcSelectTask {
       @Nonnull ByteSink sink,
       @Nonnull Connection connection)
       throws SQLException {
-    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink, -1);
+    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
     return doSelect(connection, withInterval(rse, interval), getSql());
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectTask.java
@@ -64,7 +64,7 @@ public class JdbcSelectTask extends AbstractJdbcTask<Summary> {
       @Nonnull ByteSink sink,
       @Nonnull Connection connection)
       throws SQLException {
-    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink, -1);
+    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
     return doSelect(connection, rse, sql);
   }
 

--- a/dumper/lib-common/src/main/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitor.java
+++ b/dumper/lib-common/src/main/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitor.java
@@ -45,7 +45,7 @@ public class RecordProgressMonitor extends AbstractProgressMonitor {
   private long nextSeconds = 0;
   private long nextMinSeconds = 0;
 
-  public RecordProgressMonitor(@Nonnull String name, @Nonnegative long total) {
+  public RecordProgressMonitor(@Nonnull String name, long total) {
     checkArgument(total >= 0, "Total must be nonnegative. Was: %s", total);
     this.name = name;
     this.total = total;

--- a/dumper/lib-common/src/main/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitor.java
+++ b/dumper/lib-common/src/main/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitor.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.plugin.ext.jdk.progress;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.common.base.Stopwatch;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nonnegative;
@@ -44,6 +46,7 @@ public class RecordProgressMonitor extends AbstractProgressMonitor {
   private long nextMinSeconds = 0;
 
   public RecordProgressMonitor(@Nonnull String name, @Nonnegative long total) {
+    checkArgument(total >= 0, "Total must be nonnegative. Was: %s", total);
     this.name = name;
     this.total = total;
     this.stepPercent = Math.max(total / 10, 1); // 10% or 1 count.


### PR DESCRIPTION
The method newCsvResultSetExtractor in AbstractJdbcTask takes a special value of count=-1 to indicate that `count` is not provided. A version of the same method with no `count` parameter was added earlier.

- instead of passing count=-1, use the method with no 'count' parameter
- disallow negative values of 'count' in the future