### PR TITLE
[b/343862780] add a compilerworks-format text file in oracle-logs and -stats output

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnector.java
@@ -21,6 +21,7 @@ import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
+import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
@@ -40,18 +41,22 @@ public class OracleLogsConnector extends AbstractOracleConnector
   /** Exists so we can extract query text CLOBs to Strings before they reach the CSVPrinter. */
   private static class QueryHistoryTask extends JdbcSelectTask {
 
-    public QueryHistoryTask(@Nonnull String targetPath, @Nonnull String sql) {
-      super(targetPath, sql);
+    QueryHistoryTask() {
+      super(ZIP_ENTRY_FILENAME, sql());
+    }
+
+    private static String sql() {
+      return "SELECT sql_fulltext, cpu_time, elapsed_time, disk_reads, runtime_mem FROM v$sql";
     }
   }
 
   @Override
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception {
-    out.add(new DumpMetadataTask(arguments, getFormatName()));
-    // It's not clear to me whether we should be using v$sqlarea instead here.
-    String query =
-        "SELECT sql_fulltext, cpu_time, elapsed_time, disk_reads, runtime_mem FROM v$sql";
-    out.add(new QueryHistoryTask(ZIP_ENTRY_FILENAME, query).withHeaderClass(Header.class));
+    String format = getConnectorScope().formatName();
+
+    out.add(new DumpMetadataTask(arguments, format));
+    out.add(new FormatTask(format));
+    out.add(new QueryHistoryTask());
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -19,7 +19,6 @@ package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.util.List;
@@ -38,7 +37,6 @@ public class OracleStatsConnector extends AbstractOracleConnector {
   @Override
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) throws Exception {
     StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
-    out.add(new DumpMetadataTask(arguments, getFormatName()));
     out.addAll(taskListGenerator.createTasks(arguments));
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -21,6 +21,8 @@ import static com.google.edwmigration.dumper.application.dumper.connector.oracle
 
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
+import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.io.IOException;
 import javax.annotation.Nonnull;
@@ -28,6 +30,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
 class StatsTaskListGenerator {
+
+  private final OracleConnectorScope scope = OracleConnectorScope.STATS;
 
   @Nonnull
   ImmutableList<Task<?>> createTasks(ConnectorArguments arguments) throws IOException {
@@ -43,7 +47,8 @@ class StatsTaskListGenerator {
             );
 
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
-
+    builder.add(new DumpMetadataTask(arguments, scope.formatName()));
+    builder.add(new FormatTask(scope.formatName()));
     for (OracleStatsQuery item : queries) {
       builder.add(StatsJdbcTask.fromQuery(item));
     }


### PR DESCRIPTION
Add the file compilerworks-format.txt to oracle-logs and -stats outputs

The contents of the files are simply:

```
oracle.logs.zip
```

```
oracle.stats.zip
```