### PR TITLE
Add an optional Jacoco report task in Gradle

### DIFF
--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -151,7 +151,7 @@ tasks.named('test') {
             exceptionFormat "full"
         }
     }
-
+    finalizedBy jacocoTestReport // report is always generated after tests run
     ignoreFailures = false
 }
 

--- a/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/dwh-migration-dumper.java-common-conventions.gradle
@@ -151,7 +151,6 @@ tasks.named('test') {
             exceptionFormat "full"
         }
     }
-    finalizedBy jacocoTestReport // report is always generated after tests run
     ignoreFailures = false
 }
 

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -24,9 +24,11 @@ buildscript {
 
 plugins {
     id 'dwh-migration-dumper.java-application-conventions'
+    id 'jacoco'
 }
 
 apply plugin: 'com.github.jk1.dependency-license-report'
+apply plugin: "jacoco"
 
 configurations {
     sources {
@@ -90,6 +92,19 @@ dependencies {
 
     sources "org.slf4j:jcl-over-slf4j:${libs.versions.jcl.over.slf4j.get()}@sources"
     sources "ch.qos.logback:logback-classic:${libs.versions.logback.get()}@sources"
+}
+
+jacoco {
+    toolVersion = "0.8.11"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+    }
 }
 
 startScripts {

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -103,7 +103,7 @@ jacocoTestReport {
     reports {
         xml.required = false
         csv.required = false
-        html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+        html.outputLocation = layout.buildDirectory.dir('reports/jacocoHtml')
     }
 }
 


### PR DESCRIPTION
Add a Gradle task that generates coverage report for the Dumper app by running:
```
./gradlew dumper:app:jacocoTestReport
```
The task is optional and not included in any tests.

The generated reports are HTML and appear in `dumper/app/build/reports/jacocoHtml`.