### PR TITLE
[b/343069385] Extract constraints from HMS

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabasePredicate;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -45,6 +46,7 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.HiveMetadataDumpForm
 import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import org.apache.commons.csv.CSVFormat;
@@ -335,32 +337,25 @@ public class HiveMetadataConnector extends AbstractHiveConnector
               monitor.count();
               Table table = thriftClient.getTable(databaseName, tableName);
               TBase<?, ?> rawTableThriftObject = table.getRawThriftObject();
-              ImmutableList<? extends TBase<?, ?>> primaryKeys = table.getRawPrimaryKeys();
-              ImmutableList<? extends TBase<?, ?>> foreignKeys = table.getRawForeignKeys();
-              ImmutableList<? extends TBase<?, ?>> uniqueConstraints =
-                  table.getRawUniqueConstraints();
-              ImmutableList<? extends TBase<?, ?>> nonNullConstraints =
-                  table.getRawNonNullConstraints();
-              ImmutableList<? extends TBase<?, ?>> defaultConstraints =
-                  table.getRawDefaultConstraints();
-              ImmutableList<? extends TBase<?, ?>> checkConstraints =
-                  table.getRawCheckConstraints();
+              ImmutableMap<String, ImmutableList<? extends TBase<?, ?>>> additionalMetadata =
+                  ImmutableMap.of(
+                      "primaryKeys", table.getRawPrimaryKeys(),
+                      "foreignKeys", table.getRawForeignKeys(),
+                      "uniqueConstraints", table.getRawUniqueConstraints(),
+                      "nonNullConstraints", table.getRawNonNullConstraints(),
+                      "defaultConstraints", table.getRawDefaultConstraints(),
+                      "checkConstraints", table.getRawCheckConstraints());
               ThriftJsonSerializer jsonSerializer = new ThriftJsonSerializer();
               synchronized (writer) {
                 writer.write("{\"table\":");
                 writer.write(jsonSerializer.serialize(rawTableThriftObject));
-                writer.write(",\"primaryKeys\":");
-                jsonSerializer.serialize(primaryKeys, writer);
-                writer.write(",\"foreignKeys\":");
-                jsonSerializer.serialize(foreignKeys, writer);
-                writer.write(",\"uniqueConstraints\":");
-                jsonSerializer.serialize(uniqueConstraints, writer);
-                writer.write(",\"nonNullConstraints\":");
-                jsonSerializer.serialize(nonNullConstraints, writer);
-                writer.write(",\"defaultConstraints\":");
-                jsonSerializer.serialize(defaultConstraints, writer);
-                writer.write(",\"checkConstraints\":");
-                jsonSerializer.serialize(checkConstraints, writer);
+                for (Map.Entry<String, ImmutableList<? extends TBase<?, ?>>> entry :
+                    additionalMetadata.entrySet()) {
+                  writer.write(",\"");
+                  writer.write(entry.getKey());
+                  writer.write("\":");
+                  jsonSerializer.serialize(entry.getValue(), writer);
+                }
                 writer.write("}");
                 writer.write('\n');
               }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -337,6 +337,14 @@ public class HiveMetadataConnector extends AbstractHiveConnector
               TBase<?, ?> rawTableThriftObject = table.getRawThriftObject();
               ImmutableList<? extends TBase<?, ?>> primaryKeys = table.getRawPrimaryKeys();
               ImmutableList<? extends TBase<?, ?>> foreignKeys = table.getRawForeignKeys();
+              ImmutableList<? extends TBase<?, ?>> uniqueConstraints =
+                  table.getRawUniqueConstraints();
+              ImmutableList<? extends TBase<?, ?>> nonNullConstraints =
+                  table.getRawNonNullConstraints();
+              ImmutableList<? extends TBase<?, ?>> defaultConstraints =
+                  table.getRawDefaultConstraints();
+              ImmutableList<? extends TBase<?, ?>> checkConstraints =
+                  table.getRawCheckConstraints();
               ThriftJsonSerializer jsonSerializer = new ThriftJsonSerializer();
               synchronized (writer) {
                 writer.write("{\"table\":");
@@ -345,6 +353,14 @@ public class HiveMetadataConnector extends AbstractHiveConnector
                 jsonSerializer.serialize(primaryKeys, writer);
                 writer.write(",\"foreignKeys\":");
                 jsonSerializer.serialize(foreignKeys, writer);
+                writer.write(",\"uniqueConstraints\":");
+                jsonSerializer.serialize(uniqueConstraints, writer);
+                writer.write(",\"nonNullConstraints\":");
+                jsonSerializer.serialize(nonNullConstraints, writer);
+                writer.write(",\"defaultConstraints\":");
+                jsonSerializer.serialize(defaultConstraints, writer);
+                writer.write(",\"checkConstraints\":");
+                jsonSerializer.serialize(checkConstraints, writer);
                 writer.write("}");
                 writer.write('\n');
               }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -26,11 +26,15 @@ import static com.google.edwmigration.dumper.ext.hive.metastore.utils.PartitionN
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.CheckConstraintsRequest;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.DefaultConstraintsRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.FieldSchema;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.ForeignKeysRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogsResponse;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.NotNullConstraintsRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.PrimaryKeysRequest;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.UniqueConstraintsRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.WMGetAllResourcePlanRequest;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -495,6 +499,42 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
                         databaseName,
                         tableName))
                 .getForeignKeys());
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawUniqueConstraints() throws Exception {
+        return ImmutableList.copyOf(
+            client
+                .get_unique_constraints(
+                    new UniqueConstraintsRequest(table.catName, databaseName, tableName))
+                .getUniqueConstraints());
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawNonNullConstraints() throws Exception {
+        return ImmutableList.copyOf(
+            client
+                .get_not_null_constraints(
+                    new NotNullConstraintsRequest(table.catName, databaseName, tableName))
+                .getNotNullConstraints());
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawDefaultConstraints() throws Exception {
+        return ImmutableList.copyOf(
+            client
+                .get_default_constraints(
+                    new DefaultConstraintsRequest(table.catName, databaseName, tableName))
+                .getDefaultConstraints());
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawCheckConstraints() throws Exception {
+        return ImmutableList.copyOf(
+            client
+                .get_check_constraints(
+                    new CheckConstraintsRequest(table.catName, databaseName, tableName))
+                .getCheckConstraints());
       }
     };
   }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -492,6 +492,26 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
                         tableName))
                 .getForeignKeys());
       }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawUniqueConstraints() {
+        return ImmutableList.of();
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawNonNullConstraints() {
+        return ImmutableList.of();
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawDefaultConstraints() {
+        return ImmutableList.of();
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawCheckConstraints() {
+        return ImmutableList.of();
+      }
     };
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
@@ -99,4 +99,12 @@ public interface Table {
   ImmutableList<? extends TBase<?, ?>> getRawPrimaryKeys() throws Exception;
 
   ImmutableList<? extends TBase<?, ?>> getRawForeignKeys() throws Exception;
+
+  ImmutableList<? extends TBase<?, ?>> getRawUniqueConstraints() throws Exception;
+
+  ImmutableList<? extends TBase<?, ?>> getRawNonNullConstraints() throws Exception;
+
+  ImmutableList<? extends TBase<?, ?>> getRawDefaultConstraints() throws Exception;
+
+  ImmutableList<? extends TBase<?, ?>> getRawCheckConstraints() throws Exception;
 }


### PR DESCRIPTION
Extracted unique, non-null, default and check constraints are added to the existing file `tables-raw.jsonl` as new fields: `uniqueConstraints`, `nonNullConstraints`, `defaultConstraints` and `checkConstraints`.