### PR TITLE
[b/343069385] Extract table statistics from HMS

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -344,7 +344,8 @@ public class HiveMetadataConnector extends AbstractHiveConnector
                       "uniqueConstraints", table.getRawUniqueConstraints(),
                       "nonNullConstraints", table.getRawNonNullConstraints(),
                       "defaultConstraints", table.getRawDefaultConstraints(),
-                      "checkConstraints", table.getRawCheckConstraints());
+                      "checkConstraints", table.getRawCheckConstraints(),
+                      "tableStatistics", table.getRawTableStatistics());
               ThriftJsonSerializer jsonSerializer = new ThriftJsonSerializer();
               synchronized (writer) {
                 writer.write("{\"table\":");

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -34,6 +34,7 @@ import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.Get
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.GetCatalogsResponse;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.NotNullConstraintsRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.PrimaryKeysRequest;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.TableStatsRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.UniqueConstraintsRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.superset.WMGetAllResourcePlanRequest;
 import java.io.IOException;
@@ -535,6 +536,20 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
                 .get_check_constraints(
                     new CheckConstraintsRequest(table.catName, databaseName, tableName))
                 .getCheckConstraints());
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawTableStatistics() throws Exception {
+        ImmutableList columnNames =
+            client.get_fields(databaseName, tableName).stream()
+                .map(FieldSchema::getName)
+                .collect(toImmutableList());
+        return ImmutableList.copyOf(
+            client
+                .get_table_statistics_req(
+                    new TableStatsRequest(
+                        databaseName, tableName, columnNames, /* engine= */ "hive"))
+                .getTableStats());
       }
     };
   }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.FieldSchema;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.ForeignKeysRequest;
 import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.PrimaryKeysRequest;
+import com.google.edwmigration.dumper.ext.hive.metastore.thrift.api.v2_3_6.TableStatsRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -511,6 +512,19 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
       @Override
       public ImmutableList<? extends TBase<?, ?>> getRawCheckConstraints() {
         return ImmutableList.of();
+      }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawTableStatistics() throws Exception {
+        ImmutableList columnNames =
+            client.get_fields(databaseName, tableName).stream()
+                .map(FieldSchema::getName)
+                .collect(toImmutableList());
+        return ImmutableList.copyOf(
+            client
+                .get_table_statistics_req(
+                    new TableStatsRequest(databaseName, tableName, columnNames))
+                .getTableStats());
       }
     };
   }

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
@@ -107,4 +107,6 @@ public interface Table {
   ImmutableList<? extends TBase<?, ?>> getRawDefaultConstraints() throws Exception;
 
   ImmutableList<? extends TBase<?, ?>> getRawCheckConstraints() throws Exception;
+
+  ImmutableList<? extends TBase<?, ?>> getRawTableStatistics() throws Exception;
 }


### PR DESCRIPTION
Extracted table statistics are added to the existing file `tables-raw.jsonl` as a new field `tableStatistics`.