### PR TITLE
Add RunWith JUnit4 annotation

### DIFF
--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/DriverClasspathTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/DriverClasspathTest.java
@@ -41,7 +41,10 @@ import javax.tools.ToolProvider;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class DriverClasspathTest {
 
   private static final Path RESOURCES =

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformationTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/clouddumper/DriverInformationTest.java
@@ -20,7 +20,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URI;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class DriverInformationTest {
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorExecutionTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorExecutionTest.java
@@ -27,7 +27,8 @@ import javax.annotation.Nonnull;
 import org.apache.commons.lang3.ArrayUtils;
 
 /** @author shevek */
-public class AbstractSnowflakeConnectorExecutionTest extends AbstractConnectorExecutionTest {
+public abstract class AbstractSnowflakeConnectorExecutionTest
+    extends AbstractConnectorExecutionTest {
 
   // TODO("Constants from SnowflakeValidator.")
   private static final ImmutableList<String> ARGS =

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -26,7 +26,10 @@ import com.google.edwmigration.dumper.application.dumper.connector.teradata.Abst
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class TeradataLogsJdbcTaskTest {
 
   private SharedState queryLogsState = new SharedState();

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
@@ -22,7 +22,10 @@ import static org.junit.Assert.assertEquals;
 import java.time.Clock;
 import java.time.Instant;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class ArchiveNameUtilTest {
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/MemoizationUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/MemoizationUtilTest.java
@@ -26,10 +26,13 @@ import java.io.IOException;
 import org.apache.commons.io.function.IOFunction;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 
+@RunWith(JUnit4.class)
 public class MemoizationUtilTest {
 
   @Rule public MockitoRule mockitoRule = MockitoJUnit.rule();

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/OptionalUtilsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/OptionalUtilsTest.java
@@ -20,7 +20,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Optional;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
+@RunWith(JUnit4.class)
 public class OptionalUtilsTest {
 
   @Test


### PR DESCRIPTION
The annotation `@RunWith(JUnit4.class)` was missing on a few classes. It doesn't affect test execution, but I'm adding it for consistency.