### PR TITLE
[b/343063007] Extract partitions from HMS

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.BooleanUtils;
@@ -381,6 +382,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
   }
 
+  @ParametersAreNonnullByDefault
   private static class PartitionsJsonlTask extends AbstractHiveMetadataTask {
 
     private PartitionsJsonlTask(Predicate<String> databasePredicate) {
@@ -388,8 +390,7 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
 
     @Override
-    protected void run(@Nonnull Writer writer, @Nonnull ThriftClientHandle thriftClientHandle)
-        throws Exception {
+    protected void run(Writer writer, ThriftClientHandle thriftClientHandle) throws Exception {
       try (ThriftClientPool clientPool =
           thriftClientHandle.newMultiThreadedThriftClientPool("partitions-task-pooled-client")) {
         clientPool.execute(
@@ -417,11 +418,11 @@ public class HiveMetadataConnector extends AbstractHiveConnector
     }
 
     private void dumpPartitions(
-        @Nonnull ConcurrentProgressMonitor monitor,
-        @Nonnull Writer writer,
-        @Nonnull ThriftClientPool clientPool,
-        @Nonnull String databaseName,
-        @Nonnull String tableName) {
+        ConcurrentProgressMonitor monitor,
+        Writer writer,
+        ThriftClientPool clientPool,
+        String databaseName,
+        String tableName) {
       clientPool.execute(
           (thriftClient) -> {
             try {

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -551,6 +551,12 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
                         databaseName, tableName, columnNames, /* engine= */ "hive"))
                 .getTableStats());
       }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawPartitions() throws Exception {
+        return ImmutableList.copyOf(
+            client.get_partitions(databaseName, tableName, /* max_parts= */ (short) -1));
+      }
     };
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -526,6 +526,12 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
                     new TableStatsRequest(databaseName, tableName, columnNames))
                 .getTableStats());
       }
+
+      @Override
+      public ImmutableList<? extends TBase<?, ?>> getRawPartitions() throws Exception {
+        return ImmutableList.copyOf(
+            client.get_partitions(databaseName, tableName, /* max_parts= */ (short) -1));
+      }
     };
   }
 

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/Table.java
@@ -109,4 +109,6 @@ public interface Table {
   ImmutableList<? extends TBase<?, ?>> getRawCheckConstraints() throws Exception;
 
   ImmutableList<? extends TBase<?, ?>> getRawTableStatistics() throws Exception;
+
+  ImmutableList<? extends TBase<?, ?>> getRawPartitions() throws Exception;
 }


### PR DESCRIPTION
Extract partitions in the new format to the `partitions.jsonl` file.

The file contains the JSON serialization of the raw response from Hive Metastore API, partitions for each table on a separate line.