### PR TITLE
Address concurrency issues in TaskSetState

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -252,11 +252,11 @@ public class MetadataDumper {
 
   private boolean checkRequiredTaskSuccess(
       SummaryPrinter summaryPrinter, Impl state, String outputFileName) {
-    long requiredTasksNotSucceeded = state.failedRequiredTaskCount();
-    if (requiredTasksNotSucceeded > 0) {
+    long failedRequiredTasks = state.failedRequiredTaskCount();
+    if (failedRequiredTasks > 0) {
       summaryPrinter.printSummarySection(
           linePrinter -> {
-            linePrinter.println("ERROR: %s required task[s] failed.", requiredTasksNotSucceeded);
+            linePrinter.println("ERROR: %s required task[s] failed.", failedRequiredTasks);
             linePrinter.println(
                 "Output, including debugging information, has been saved to '%s'.", outputFileName);
           });

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -32,7 +32,6 @@ import com.google.edwmigration.dumper.application.dumper.task.JdbcRunSQLScript;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskGroup;
 import com.google.edwmigration.dumper.application.dumper.task.TaskSetState;
-import com.google.edwmigration.dumper.application.dumper.task.TaskSetState.Impl;
 import com.google.edwmigration.dumper.application.dumper.task.TaskSetState.TaskResultSummary;
 import com.google.edwmigration.dumper.application.dumper.task.TaskSetState.TasksReport;
 import com.google.edwmigration.dumper.application.dumper.task.VersionTask;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -243,7 +243,7 @@ public class MetadataDumper {
     summaryPrinter.printSummarySection(
         linePrinter -> {
           linePrinter.println("Task Summary:");
-          for (TaskResultSummary item : state.taskResultSummaries()) {
+          for (TaskResultSummary item : state.getTaskResultSummaries()) {
             linePrinter.println(item.toString());
           }
         });
@@ -251,7 +251,7 @@ public class MetadataDumper {
 
   private boolean checkRequiredTaskSuccess(
       SummaryPrinter summaryPrinter, TaskSetState state, String outputFileName) {
-    long failedRequiredTasks = state.failedRequiredTaskCount();
+    long failedRequiredTasks = state.getFailedRequiredTaskCount();
     if (failedRequiredTasks > 0) {
       summaryPrinter.printSummarySection(
           linePrinter -> {
@@ -267,7 +267,7 @@ public class MetadataDumper {
   private void logStatusSummary(SummaryPrinter summaryPrinter, TaskSetState state) {
     summaryPrinter.printSummarySection(
         linePrinter -> {
-          for (TasksReport item : state.tasksReports()) {
+          for (TasksReport item : state.getTasksReports()) {
             linePrinter.println("%s", item);
           }
         });

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -240,7 +240,7 @@ public class MetadataDumper {
     }
   }
 
-  private void printTaskResults(SummaryPrinter summaryPrinter, TaskSetState.Impl state) {
+  private void printTaskResults(SummaryPrinter summaryPrinter, TaskSetState state) {
     summaryPrinter.printSummarySection(
         linePrinter -> {
           linePrinter.println("Task Summary:");
@@ -251,7 +251,7 @@ public class MetadataDumper {
   }
 
   private boolean checkRequiredTaskSuccess(
-      SummaryPrinter summaryPrinter, Impl state, String outputFileName) {
+      SummaryPrinter summaryPrinter, TaskSetState state, String outputFileName) {
     long failedRequiredTasks = state.failedRequiredTaskCount();
     if (failedRequiredTasks > 0) {
       summaryPrinter.printSummarySection(
@@ -265,7 +265,7 @@ public class MetadataDumper {
     return true;
   }
 
-  private void logStatusSummary(SummaryPrinter summaryPrinter, TaskSetState.Impl state) {
+  private void logStatusSummary(SummaryPrinter summaryPrinter, TaskSetState state) {
     summaryPrinter.printSummarySection(
         linePrinter -> {
           for (TasksReport item : state.tasksReports()) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -79,6 +79,7 @@ public interface TaskSetState {
 
     private final Map<Task<?>, TaskResult<?>> resultMap = new HashMap<>();
 
+    @Override
     public synchronized long failedRequiredTaskCount() {
       long result = 0;
       for (Task<?> key : resultMap.keySet()) {
@@ -90,6 +91,8 @@ public interface TaskSetState {
       return result;
     }
 
+    @Nonnull
+    @Override
     public synchronized ImmutableList<TaskResultSummary> taskResultSummaries() {
       ImmutableList.Builder<TaskResultSummary> builder = ImmutableList.builder();
       resultMap.forEach(
@@ -100,6 +103,8 @@ public interface TaskSetState {
       return builder.build();
     }
 
+    @Nonnull
+    @Override
     public synchronized ImmutableList<TasksReport> tasksReports() {
       ImmutableList.Builder<TasksReport> builder = ImmutableList.builder();
       resultMap.values().stream()
@@ -124,6 +129,14 @@ public interface TaskSetState {
       resultMap.put(task, new TaskResult<>(state, exception));
     }
   }
+
+  long failedRequiredTaskCount();
+
+  @Nonnull
+  ImmutableList<TaskResultSummary> taskResultSummaries();
+
+  @Nonnull
+  ImmutableList<TasksReport> tasksReports();
 
   @CheckForNull
   public <T> TaskResult<T> getTaskResult(@Nonnull Task<T> task);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -80,13 +80,6 @@ public interface TaskSetState {
 
     private final Object lock = new Object();
 
-    @Nonnull
-    public Map<Task<?>, TaskResult<?>> getTaskResultMap() {
-      synchronized (lock) {
-        return resultMap;
-      }
-    }
-
     public long failedRequiredTaskCount() {
       synchronized (lock) {
         return resultMap.entrySet().stream()

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -129,8 +129,8 @@ public interface TaskSetState {
       resultMap.put(task, new TaskResult<>(state, value));
     }
 
-    public synchronized <T> void setTaskException(
-        @Nonnull Task<T> task, @Nonnull TaskState state, @CheckForNull Exception exception) {
+    public synchronized void setTaskException(
+        @Nonnull Task<?> task, @Nonnull TaskState state, @CheckForNull Exception exception) {
       resultMap.put(task, new TaskResult<>(state, exception));
     }
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -16,6 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.task;
 
+import static com.google.edwmigration.dumper.application.dumper.task.TaskCategory.REQUIRED;
+import static com.google.edwmigration.dumper.application.dumper.task.TaskState.FAILED;
+
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
@@ -77,10 +80,14 @@ public interface TaskSetState {
     private final Map<Task<?>, TaskResult<?>> resultMap = new HashMap<>();
 
     public synchronized long failedRequiredTaskCount() {
-      return resultMap.entrySet().stream()
-          .filter(e -> TaskCategory.REQUIRED.equals(e.getKey().getCategory()))
-          .filter(e -> TaskState.FAILED.equals(e.getValue().getState()))
-          .count();
+      long result = 0;
+      for (Task<?> key : resultMap.keySet()) {
+        TaskState state = resultMap.get(key).getState();
+        if (key.getCategory() == REQUIRED && state == FAILED) {
+          result++;
+        }
+      }
+      return result;
     }
 
     public synchronized ImmutableList<TaskResultSummary> taskResultSummaries() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -22,6 +22,7 @@ import static com.google.edwmigration.dumper.application.dumper.task.TaskState.F
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.groupingBy;
 
+import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
@@ -34,29 +35,27 @@ import net.jcip.annotations.ThreadSafe;
 /** @author shevek */
 public interface TaskSetState {
 
+  @AutoValue
   @ParametersAreNonnullByDefault
-  static class TaskResultSummary {
-    private final String exception;
-    private final Task<?> task;
-    private final TaskState state;
+  abstract static class TaskResultSummary {
+    abstract String exception();
 
-    private TaskResultSummary(String exception, Task<?> task, TaskState state) {
-      this.exception = exception;
-      this.task = task;
-      this.state = state;
-    }
+    abstract Task<?> task();
+
+    abstract TaskState state();
 
     @Nonnull
     static TaskResultSummary create(Task<?> task, TaskResult<?> result) {
       String optionalException = String.format(": %s", result.getException());
       String exceptionDescription = result.getException() == null ? "" : optionalException;
-      return new TaskResultSummary(exceptionDescription, task, result.getState());
+      return new AutoValue_TaskSetState_TaskResultSummary(
+          exceptionDescription, task, result.getState());
     }
 
     @Nonnull
     @Override
     public String toString() {
-      return String.format("Task %s (%s) %s%s", state, task.getCategory(), task, exception);
+      return String.format("Task %s (%s) %s%s", state(), task().getCategory(), task(), exception());
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -57,6 +57,7 @@ public interface TaskSetState {
     }
   }
 
+  @ParametersAreNonnullByDefault
   public static class TasksReport {
 
     private final long count;
@@ -68,8 +69,8 @@ public interface TaskSetState {
       return String.format("%d TASKS %s", count, state);
     }
 
-    TasksReport(Long count, TaskState state) {
-      this.count = count == null ? 0 : count;
+    TasksReport(long count, TaskState state) {
+      this.count = count;
       this.state = state;
     }
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -120,7 +120,7 @@ public interface TaskSetState {
 
     @Nonnull
     @Override
-    public TaskState getTaskState(@Nonnull Task<?> task) {
+    public synchronized TaskState getTaskState(@Nonnull Task<?> task) {
       TaskResult<?> result = resultMap.get(task);
       return (result == null) ? TaskState.NOT_STARTED : result.getState();
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -59,21 +59,22 @@ public interface TaskSetState {
     }
   }
 
+  @AutoValue
   @ParametersAreNonnullByDefault
-  public static class TasksReport {
+  abstract static class TasksReport {
 
-    private final long count;
-    private final TaskState state;
+    abstract long count();
+
+    abstract TaskState state();
 
     @Nonnull
     @Override
     public String toString() {
-      return String.format("%d TASKS %s", count, state);
+      return String.format("%d TASKS %s", count(), state());
     }
 
-    TasksReport(long count, TaskState state) {
-      this.count = count;
-      this.state = state;
+    static TasksReport create(long count, TaskState state) {
+      return new AutoValue_TaskSetState_TasksReport(count, state);
     }
   }
 
@@ -113,7 +114,7 @@ public interface TaskSetState {
           .collect(groupingBy(TaskResult::getState, counting()))
           .entrySet()
           .stream()
-          .map(entry -> new TasksReport(entry.getValue(), entry.getKey()))
+          .map(entry -> TasksReport.create(entry.getValue(), entry.getKey()))
           .collect(toImmutableList());
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.task;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.edwmigration.dumper.application.dumper.task.TaskCategory.REQUIRED;
 import static com.google.edwmigration.dumper.application.dumper.task.TaskState.FAILED;
 
@@ -99,13 +100,9 @@ public interface TaskSetState {
     @Nonnull
     @Override
     public synchronized ImmutableList<TaskResultSummary> taskResultSummaries() {
-      ImmutableList.Builder<TaskResultSummary> builder = ImmutableList.builder();
-      resultMap.forEach(
-          (task, result) -> {
-            TaskResultSummary summary = TaskResultSummary.create(task, result);
-            builder.add(summary);
-          });
-      return builder.build();
+      return resultMap.entrySet().stream()
+          .map((entry) -> TaskResultSummary.create(entry.getKey(), entry.getValue()))
+          .collect(toImmutableList());
     }
 
     @Deprecated // Use TaskSetState instead of TaskSetState.Impl

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -26,6 +26,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -38,7 +39,7 @@ public interface TaskSetState {
   @AutoValue
   @ParametersAreNonnullByDefault
   abstract static class TaskResultSummary {
-    abstract Throwable throwable();
+    abstract Optional<Throwable> throwable();
 
     abstract Task<?> task();
 
@@ -46,8 +47,8 @@ public interface TaskSetState {
 
     @Nonnull
     static TaskResultSummary create(Task<?> task, TaskResult<?> result) {
-      return new AutoValue_TaskSetState_TaskResultSummary(
-          result.getException(), task, result.getState());
+      Optional<Throwable> throwable = Optional.ofNullable(result.getException());
+      return new AutoValue_TaskSetState_TaskResultSummary(throwable, task, result.getState());
     }
 
     @Nonnull
@@ -55,8 +56,8 @@ public interface TaskSetState {
     public String toString() {
       String prefix = String.format("Task %s (%s) %s", state(), task().getCategory(), task());
       StringBuilder buf = new StringBuilder(prefix);
-      if (throwable() != null) {
-        buf.append(": ").append(throwable());
+      if (throwable().isPresent()) {
+        buf.append(": ").append(throwable().get());
       }
       return buf.toString();
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -26,6 +26,7 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.concurrent.GuardedBy;
 import net.jcip.annotations.ThreadSafe;
 
 /** @author shevek */
@@ -78,6 +79,7 @@ public interface TaskSetState {
   @ThreadSafe
   public static class Impl implements TaskSetState {
 
+    @GuardedBy("this")
     private final Map<Task<?>, TaskResult<?>> resultMap = new HashMap<>();
 
     @Deprecated // Use TaskSetState instead of TaskSetState.Impl

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -102,7 +102,7 @@ public interface TaskSetState {
     @Override
     public synchronized ImmutableList<TaskResultSummary> getTaskResultSummaries() {
       return resultMap.entrySet().stream()
-          .map((entry) -> TaskResultSummary.create(entry.getKey(), entry.getValue()))
+          .map(entry -> TaskResultSummary.create(entry.getKey(), entry.getValue()))
           .collect(toImmutableList());
     }
 
@@ -114,7 +114,7 @@ public interface TaskSetState {
           .collect(groupingBy(TaskResult::getState, counting()))
           .entrySet()
           .stream()
-          .map((entry) -> new TasksReport(entry.getValue(), entry.getKey()))
+          .map(entry -> new TasksReport(entry.getValue(), entry.getKey()))
           .collect(toImmutableList());
     }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -19,11 +19,12 @@ package com.google.edwmigration.dumper.application.dumper.task;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.edwmigration.dumper.application.dumper.task.TaskCategory.REQUIRED;
 import static com.google.edwmigration.dumper.application.dumper.task.TaskState.FAILED;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.groupingBy;
 
 import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -110,7 +111,7 @@ public interface TaskSetState {
     @Override
     public synchronized ImmutableList<TasksReport> tasksReports() {
       return resultMap.values().stream()
-          .collect(Collectors.groupingBy(TaskResult::getState, Collectors.counting()))
+          .collect(groupingBy(TaskResult::getState, counting()))
           .entrySet()
           .stream()
           .map((entry) -> new TasksReport(entry.getValue(), entry.getKey()))

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -86,9 +86,9 @@ public interface TaskSetState {
     @Override
     public synchronized long failedRequiredTaskCount() {
       long result = 0;
-      for (Task<?> key : resultMap.keySet()) {
-        TaskState state = resultMap.get(key).getState();
-        if (key.getCategory() == REQUIRED && state == FAILED) {
+      for (Map.Entry<Task<?>, TaskResult<?>> entry : resultMap.entrySet()) {
+        TaskState state = entry.getValue().getState();
+        if (entry.getKey().getCategory() == REQUIRED && state == FAILED) {
           result++;
         }
       }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -79,6 +79,7 @@ public interface TaskSetState {
 
     private final Map<Task<?>, TaskResult<?>> resultMap = new HashMap<>();
 
+    @Deprecated // Use TaskSetState instead of TaskSetState.Impl
     @Override
     public synchronized long failedRequiredTaskCount() {
       long result = 0;
@@ -91,6 +92,7 @@ public interface TaskSetState {
       return result;
     }
 
+    @Deprecated // Use TaskSetState instead of TaskSetState.Impl
     @Nonnull
     @Override
     public synchronized ImmutableList<TaskResultSummary> taskResultSummaries() {
@@ -103,6 +105,7 @@ public interface TaskSetState {
       return builder.build();
     }
 
+    @Deprecated // Use TaskSetState instead of TaskSetState.Impl
     @Nonnull
     @Override
     public synchronized ImmutableList<TasksReport> tasksReports() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -109,11 +109,12 @@ public interface TaskSetState {
     @Nonnull
     @Override
     public synchronized ImmutableList<TasksReport> tasksReports() {
-      ImmutableList.Builder<TasksReport> builder = ImmutableList.builder();
-      resultMap.values().stream()
+      return resultMap.values().stream()
           .collect(Collectors.groupingBy(TaskResult::getState, Collectors.counting()))
-          .forEach((key, value) -> builder.add(new TasksReport(value, key)));
-      return builder.build();
+          .entrySet()
+          .stream()
+          .map((entry) -> new TasksReport(entry.getValue(), entry.getKey()))
+          .collect(toImmutableList());
     }
 
     @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -38,7 +38,7 @@ public interface TaskSetState {
   @AutoValue
   @ParametersAreNonnullByDefault
   abstract static class TaskResultSummary {
-    abstract String exception();
+    abstract Throwable throwable();
 
     abstract Task<?> task();
 
@@ -46,16 +46,19 @@ public interface TaskSetState {
 
     @Nonnull
     static TaskResultSummary create(Task<?> task, TaskResult<?> result) {
-      String optionalException = String.format(": %s", result.getException());
-      String exceptionDescription = result.getException() == null ? "" : optionalException;
       return new AutoValue_TaskSetState_TaskResultSummary(
-          exceptionDescription, task, result.getState());
+          result.getException(), task, result.getState());
     }
 
     @Nonnull
     @Override
     public String toString() {
-      return String.format("Task %s (%s) %s%s", state(), task().getCategory(), task(), exception());
+      String prefix = String.format("Task %s (%s) %s", state(), task().getCategory(), task());
+      StringBuilder buf = new StringBuilder(prefix);
+      if (throwable() != null) {
+        buf.append(": ").append(throwable());
+      }
+      return buf.toString();
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -86,7 +86,7 @@ public interface TaskSetState {
 
     @Deprecated // Use TaskSetState instead of TaskSetState.Impl
     @Override
-    public synchronized long failedRequiredTaskCount() {
+    public synchronized long getFailedRequiredTaskCount() {
       long result = 0;
       for (Map.Entry<Task<?>, TaskResult<?>> entry : resultMap.entrySet()) {
         TaskState state = entry.getValue().getState();
@@ -100,7 +100,7 @@ public interface TaskSetState {
     @Deprecated // Use TaskSetState instead of TaskSetState.Impl
     @Nonnull
     @Override
-    public synchronized ImmutableList<TaskResultSummary> taskResultSummaries() {
+    public synchronized ImmutableList<TaskResultSummary> getTaskResultSummaries() {
       return resultMap.entrySet().stream()
           .map((entry) -> TaskResultSummary.create(entry.getKey(), entry.getValue()))
           .collect(toImmutableList());
@@ -109,7 +109,7 @@ public interface TaskSetState {
     @Deprecated // Use TaskSetState instead of TaskSetState.Impl
     @Nonnull
     @Override
-    public synchronized ImmutableList<TasksReport> tasksReports() {
+    public synchronized ImmutableList<TasksReport> getTasksReports() {
       return resultMap.values().stream()
           .collect(groupingBy(TaskResult::getState, counting()))
           .entrySet()
@@ -136,13 +136,13 @@ public interface TaskSetState {
     }
   }
 
-  long failedRequiredTaskCount();
+  long getFailedRequiredTaskCount();
 
   @Nonnull
-  ImmutableList<TaskResultSummary> taskResultSummaries();
+  ImmutableList<TaskResultSummary> getTaskResultSummaries();
 
   @Nonnull
-  ImmutableList<TasksReport> tasksReports();
+  ImmutableList<TasksReport> getTasksReports();
 
   @Nonnull
   TaskState getTaskState(@Nonnull Task<?> task);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -79,7 +79,7 @@ public interface TaskSetState {
   }
 
   @ThreadSafe
-  public static class Impl implements TaskSetState {
+  static class Impl implements TaskSetState {
 
     @GuardedBy("this")
     private final Map<Task<?>, TaskResult<?>> resultMap = new HashMap<>();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -116,10 +116,11 @@ public interface TaskSetState {
       return builder.build();
     }
 
+    @Nonnull
     @Override
-    @SuppressWarnings("unchecked")
-    public synchronized <T> TaskResult<T> getTaskResult(@Nonnull Task<T> task) {
-      return (TaskResult<T>) resultMap.get(task);
+    public TaskState getTaskState(@Nonnull Task<?> task) {
+      TaskResult<?> result = resultMap.get(task);
+      return (result == null) ? TaskState.NOT_STARTED : result.getState();
     }
 
     public synchronized <T> void setTaskResult(
@@ -141,12 +142,6 @@ public interface TaskSetState {
   @Nonnull
   ImmutableList<TasksReport> tasksReports();
 
-  @CheckForNull
-  public <T> TaskResult<T> getTaskResult(@Nonnull Task<T> task);
-
   @Nonnull
-  public default TaskState getTaskState(@Nonnull Task<?> task) {
-    TaskResult<?> result = getTaskResult(task);
-    return (result == null) ? TaskState.NOT_STARTED : result.getState();
-  }
+  TaskState getTaskState(@Nonnull Task<?> task);
 }


### PR DESCRIPTION
TaskSetState has a synchronization mechanism, which intends to provide mutual exclusion when accessing the private `resultMap`. However, the public method:
```
getTaskResultMap()
```
returns `resultMap` to the caller, which makes such synchronization ineffective, as the caller is able to read and write to this map freely.

The primary goal of this PR is to replace this approach with methods that have correct synchronization.

- replace getTaskResultMap with safe methods
- add classes representing return types needed by the new methods
- in the newly added methods, discourage accessing them directly from `Impl`
- inline a redundant method, remove unchecked cast
- fix a variable name referring to "tasksNotSucceeded", when it actually represents only the tasks that ended in failure
- remove the redundant `lock` object