### PR TITLE
[b/341097448] Use temporary directory for extracting scripts

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -52,7 +52,6 @@ dependencies {
     implementation libs.commons.io
     implementation libs.apache.commons.csv
     implementation libs.apache.commons.lang3
-    implementation libs.apache.commons.exec
     implementation libs.hadoop.common
     implementation libs.hadoop.hdfs.client
     implementation libs.spring.core
@@ -416,9 +415,6 @@ licenseReport {
             ],
             "commons-io:commons-io": [
                 licenseUrl: "https://raw.githubusercontent.com/apache/commons-io/master/LICENSE.txt",
-            ],
-            "org.apache.commons:commons-exec": [
-                licenseUrl: "https://raw.githubusercontent.com/apache/commons-exec/master/LICENSE.txt",
             ],
             "org.apache.hadoop:hadoop-common": [
                 projectUrl: "https://github.com/apache/hadoop",

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/BashTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/BashTask.java
@@ -24,10 +24,10 @@ import com.google.edwmigration.dumper.application.dumper.io.OutputHandle;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
-import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.Writer;
+import java.nio.file.Path;
 import java.time.Duration;
 import org.apache.commons.exec.CommandLine;
 import org.apache.commons.exec.DefaultExecutor;
@@ -53,8 +53,8 @@ public class BashTask implements Task<Void> {
   private void doRun(ByteSink outputSink, ByteSink errorSink, ByteSink exitStatusSink)
       throws IOException {
     String scriptFilename = scriptName + ".sh";
-    File scriptFile = HadoopScripts.extract(scriptFilename);
-    CommandLine cmdLine = CommandLine.parse("/bin/bash " + scriptFile.getAbsolutePath());
+    Path scriptFile = HadoopScripts.extract(scriptFilename);
+    CommandLine cmdLine = CommandLine.parse("/bin/bash " + scriptFile.toAbsolutePath());
     DefaultExecutor executor = DefaultExecutor.builder().get();
     executor.setExitValue(1);
     ExecuteWatchdog watchdog = ExecuteWatchdog.builder().setTimeout(SCRIPT_TIMEOUT).get();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
@@ -62,7 +62,7 @@ class HadoopScripts {
   }
 
   /** Extracts the script from the resources directory inside the jar to the local filesystem. */
-  static synchronized Path extract(String scriptFilename) throws IOException {
+  static Path extract(String scriptFilename) throws IOException {
     byte[] scriptBody = HadoopScripts.read(scriptFilename);
     Path scriptDir = SCRIPT_DIR_SUPPLIER.get();
     checkState(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
@@ -16,13 +16,17 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.hadoop;
 
+import static com.google.common.base.Suppliers.memoize;
+
 import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.util.function.Supplier;
 
 class HadoopScripts {
+  private static final Supplier<File> SCRIPT_DIR_SUPPLIER = memoize(Files::createTempDir);
 
   /** Reads the script from the resources directory inside the jar. */
   static byte[] read(String scriptFilename) throws IOException {
@@ -31,11 +35,9 @@ class HadoopScripts {
   }
 
   /** Extracts the script from the resources directory inside the jar to the local filesystem. */
-  static File extract(String scriptFilename) throws IOException {
+  static synchronized File extract(String scriptFilename) throws IOException {
     byte[] scriptBody = HadoopScripts.read(scriptFilename);
-    File scriptDir = new File("dwh-migration-tools-tmp");
-    scriptDir.mkdirs();
-    File scriptFile = new File(scriptDir, scriptFilename);
+    File scriptFile = new File(SCRIPT_DIR_SUPPLIER.get(), scriptFilename);
     Files.write(scriptBody, scriptFile);
     scriptFile.setExecutable(true);
     return scriptFile;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
@@ -36,20 +36,14 @@ class HadoopScripts {
       memoize(
           () -> {
             Path tmpDir;
-            LOG.info("Creating temporary directory...");
+            Path workingDir = Paths.get("");
+            LOG.info(
+                "Creating temporary directory in the working directory '{}'...",
+                workingDir.toAbsolutePath());
             try {
-              tmpDir = Files.createTempDirectory(TMP_DIR_PREFIX);
+              tmpDir = Files.createTempDirectory(workingDir, TMP_DIR_PREFIX);
             } catch (IOException e) {
-              LOG.error("Error creating temporary directory in the system temporary directory.", e);
-              Path workingDir = Paths.get("");
-              LOG.info(
-                  "Falling back to creating the temporary directory in the working directory: '{}'.",
-                  workingDir.toAbsolutePath());
-              try {
-                tmpDir = Files.createTempDirectory(workingDir, TMP_DIR_PREFIX);
-              } catch (IOException e2) {
-                throw new IllegalStateException("Error creating temporary directory.", e2);
-              }
+              throw new IllegalStateException("Error creating temporary directory.", e);
             }
             LOG.info("Temporary directory created: '{}'.", tmpDir);
             return tmpDir;
@@ -67,8 +61,9 @@ class HadoopScripts {
     Path scriptDir = SCRIPT_DIR_SUPPLIER.get();
     checkState(
         Files.exists(scriptDir) && Files.isDirectory(scriptDir),
-        "Temporary directory '%s' does not exist.",
+        "Directory '%s' does not exist.",
         scriptDir);
+    LOG.info("Extracting '{}' to '{}'...", scriptFilename, scriptDir);
     Path scriptPath = scriptDir.resolve(scriptFilename);
     Files.write(scriptPath, scriptBody);
     scriptPath.toFile().setExecutable(true);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
@@ -19,9 +19,9 @@ package com.google.edwmigration.dumper.application.dumper.connector.hadoop;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -29,12 +29,14 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class HadoopScriptsTest {
-  File extractedFile;
+  Path extractedFile;
 
   @After
-  public void tearDown() {
-    if (extractedFile != null && extractedFile.exists()) {
-      extractedFile.delete();
+  public void tearDown() throws IOException {
+    if (extractedFile != null) {
+      if (Files.exists(extractedFile)) {
+        Files.delete(extractedFile);
+      }
     }
   }
 
@@ -52,7 +54,6 @@ public class HadoopScriptsTest {
     extractedFile = HadoopScripts.extract(scriptFilename);
 
     // Assert
-    assertArrayEquals(
-        HadoopScripts.read(scriptFilename), Files.readAllBytes(extractedFile.toPath()));
+    assertArrayEquals(HadoopScripts.read(scriptFilename), Files.readAllBytes(extractedFile));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
@@ -33,10 +33,8 @@ public class HadoopScriptsTest {
 
   @After
   public void tearDown() throws IOException {
-    if (extractedFile != null) {
-      if (Files.exists(extractedFile)) {
-        Files.delete(extractedFile);
-      }
+    if ((extractedFile != null) && Files.exists(extractedFile)) {
+      Files.delete(extractedFile);
     }
   }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,6 @@
 apache-commons-compress = "1.18"
 apache-commons-csv = "1.10.0"
 apache-commons-lang3 = "3.8.1"
-apache-commons-exec = "1.4.0"
 auto-service = "1.1.1"
 auto-value = "1.10.2"
 aws-java-sdk = "1.12.520"
@@ -55,7 +54,6 @@ version-catalog-update-plugin = "0.8.1"
 apache-commons-compress = { module = "org.apache.commons:commons-compress", version.ref = "apache-commons-compress" }
 apache-commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "apache-commons-csv" }
 apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "apache-commons-lang3" }
-apache-commons-exec = { module = "org.apache.commons:commons-exec", version.ref = "apache-commons-exec" }
 auto-service = { module = "com.google.auto.service:auto-service", version.ref = "auto-service" }
 auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-value" }
 auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }


### PR DESCRIPTION
Create a temporary directory in the current working directory to extract the scripts.

Remove the Apache commons-exec dependency.