### PR TITLE
Handle null ResultSet

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -113,7 +113,7 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
   public ResultSetExtractor<Summary> newCsvResultSetExtractor(@Nonnull ByteSink sink) {
     return resultSet -> {
       RecordProgressMonitor monitor = new RecordProgressMonitor(getName());
-      printWithMonitor(sink, monitor, resultSet);
+      return printWithMonitor(sink, monitor, resultSet);
     };
   }
 
@@ -122,14 +122,15 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
       @Nonnull ByteSink sink, long count) {
     return resultSet -> {
       RecordProgressMonitor monitor = new RecordProgressMonitor(getName(), count);
-      printWithMonitor(sink, monitor, resultSet);
+      return printWithMonitor(sink, monitor, resultSet);
     };
   }
 
   private Summary printWithMonitor(
       @Nonnull ByteSink sink,
       @Nonnull RecordProgressMonitor monitor,
-      @CheckForNull ResultSet resultSet) {
+      @CheckForNull ResultSet resultSet)
+      throws SQLException {
     try {
       if (resultSet != null) {
         printAllResults(sink, resultSet, monitor);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -112,8 +112,9 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
   @Nonnull
   public ResultSetExtractor<Summary> newCsvResultSetExtractor(@Nonnull ByteSink sink) {
     return resultSet -> {
-      RecordProgressMonitor monitor = new RecordProgressMonitor(getName());
-      return printWithMonitor(sink, monitor, resultSet);
+      try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName())) {
+        return printWithMonitor(sink, monitor, resultSet);
+      }
     };
   }
 
@@ -121,8 +122,9 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
   protected ResultSetExtractor<Summary> newCsvResultSetExtractor(
       @Nonnull ByteSink sink, long count) {
     return resultSet -> {
-      RecordProgressMonitor monitor = new RecordProgressMonitor(getName(), count);
-      return printWithMonitor(sink, monitor, resultSet);
+      try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName(), count)) {
+        return printWithMonitor(sink, monitor, resultSet);
+      }
     };
   }
 
@@ -138,8 +140,6 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
       return new Summary(monitor.getCount());
     } catch (IOException e) {
       throw new SQLException(e);
-    } finally {
-      monitor.close();
     }
   }
 


### PR DESCRIPTION
### handle null resultset in AbstractJdbcTask

This is on hold, to be merged only if we confirm that null ResultSet's need to be handled.

This PR deals with the case where a null `ResultSet` is returned. Handling of this case seems to be missing, the Task fails with NPE. Add a null check and make Dumper write nothing if the `ResultSet` is null.

### remove try-with-resources for RecordProgressMonitor
[reverted]
