### PR TITLE
[b/345177751] Revert the deprecation of translation file tasks

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ArgumentsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ArgumentsTask.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import javax.annotation.Nonnull;
 
 /** @author shevek */
-@Deprecated // Use DumpMetadataTask
 public class ArgumentsTask extends AbstractTask<Void> {
 
   @Nonnull private final ConnectorArguments arguments;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/FormatTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/FormatTask.java
@@ -24,7 +24,6 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.MetadataDumperConsta
 import java.nio.charset.StandardCharsets;
 
 /** @author shevek */
-@Deprecated // Use DumpMetadataTask
 public class FormatTask extends AbstractTask<Void> {
 
   private final String format;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/VersionTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/VersionTask.java
@@ -23,7 +23,6 @@ import java.nio.charset.StandardCharsets;
 import org.anarres.jdiagnostics.ProductMetadata;
 
 /** @author shevek */
-@Deprecated // Use DumpMetadataTask
 public class VersionTask extends AbstractTask<Void> {
 
   public VersionTask(String targetPath) {


### PR DESCRIPTION
b/345177751
The classes ArgumentsTask, FormatTask and VersionTask will continue to be used. Remove the @.Deprecated annotation from these classes