### PR TITLE
Add a basic check for oracle-stats SQLs

### DIFF
--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StatsTaskListGeneratorTest {
+
+  private final StatsTaskListGenerator generator = new StatsTaskListGenerator();
+
+  // This is more of a configuration check than a unit test for app logic.
+  // Still, it's convenient to include it in Gradle test.
+  @Test
+  public void nativeNames_returnsValidNames() throws IOException {
+    ImmutableList<String> names = generator.nativeNames();
+    ArrayList<String> failed = new ArrayList<>(names.size());
+    // Act
+    for (String item : names) {
+      try {
+        OracleStatsQuery.create(item, NATIVE);
+      } catch (IllegalArgumentException e) {
+        failed.add(item);
+      }
+    }
+    // Assert
+    assertEquals(ImmutableList.of(), failed);
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -17,33 +17,28 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
-import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.util.ArrayList;
-import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
+@RunWith(Theories.class)
 public class StatsTaskListGeneratorTest {
 
-  private final StatsTaskListGenerator generator = new StatsTaskListGenerator();
+  static {
+    StatsTaskListGenerator generator = new StatsTaskListGenerator();
+    nameList = generator.nativeNames();
+  }
 
-  @Test
-  public void nativeNames_allNamedFilesExist() throws IOException {
-    ImmutableList<String> names = generator.nativeNames();
-    ArrayList<String> failed = new ArrayList<>(names.size());
-    // Act
-    for (String item : names) {
-      try {
-        OracleStatsQuery.create(item, NATIVE);
-      } catch (IllegalArgumentException e) {
-        failed.add(item);
-      }
-    }
-    // Assert
-    assertEquals(ImmutableList.of(), failed);
+  @DataPoints("nativeNames")
+  public static final ImmutableList<String> nameList;
+
+  @Theory
+  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name) throws IOException {
+    OracleStatsQuery.create(name, NATIVE);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -31,8 +31,6 @@ public class StatsTaskListGeneratorTest {
 
   private final StatsTaskListGenerator generator = new StatsTaskListGenerator();
 
-  // This is more of a configuration check than a unit test for app logic.
-  // Still, it's convenient to include it in Gradle test.
   @Test
   public void nativeNames_allNamedFilesExist() throws IOException {
     ImmutableList<String> names = generator.nativeNames();

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -29,16 +29,12 @@ import org.junit.runner.RunWith;
 @RunWith(Theories.class)
 public class StatsTaskListGeneratorTest {
 
-  static {
-    StatsTaskListGenerator generator = new StatsTaskListGenerator();
-    nameList = generator.nativeNames();
-  }
-
   @DataPoints("nativeNames")
-  public static final ImmutableList<String> nameList;
+  public static final ImmutableList<String> nameList = new StatsTaskListGenerator().nativeNames();
 
   @Theory
-  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name) throws IOException {
+  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name)
+      throws IOException {
     OracleStatsQuery.create(name, NATIVE);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -34,7 +34,7 @@ public class StatsTaskListGeneratorTest {
   // This is more of a configuration check than a unit test for app logic.
   // Still, it's convenient to include it in Gradle test.
   @Test
-  public void nativeNames_returnsValidNames() throws IOException {
+  public void nativeNames_allNamedFilesExist() throws IOException {
     ImmutableList<String> names = generator.nativeNames();
     ArrayList<String> failed = new ArrayList<>(names.size());
     // Act


### PR DESCRIPTION
Although the SQLs with scripts for oracle-stats are included in the JAR, there is no verification that they were added correctly. Until the application is run, there will be no symptoms of a missing SQL file, incorrect name or a file being in the wrong folder.

This PR aims to mitigate this issue by adding a configuration check in Junit. The new test will attempt to load all native-sourced files in the stats task list and lists all file names for which loading has failed.