### PR TITLE
Remove an ignored test in RecordProgressMonitor

### DIFF
--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.plugin.ext.jdk.progress;
 
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -25,13 +27,16 @@ import org.junit.runners.JUnit4;
 public class RecordProgressMonitorTest {
 
   @Test
-  public void testFast() {
-    int n = 187317;
-    try (RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n)) {
+  public void count_totalExceeded_noExceptionThrown() {
+    int counterTotal = 187317;
+    // TODO: legacy value, (counterTotal + 1) should be enough for this test
+    int updateCount = 2 + 2 * counterTotal;
+    try (RecordProgressMonitor monitor = new RecordProgressMonitor("fast", counterTotal)) {
       // deliberate overflow
-      for (int i = 0; i < n * 2 + 2; i++) {
+      for (int i = 0; i < updateCount; i++) {
         monitor.count();
       }
+      assertEquals(updateCount, monitor.getCount());
     }
   }
 }

--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -16,7 +16,6 @@
  */
 package com.google.edwmigration.dumper.plugin.ext.jdk.progress;
 
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -28,12 +28,13 @@ public class RecordProgressMonitorTest {
   @Test
   public void testFast() {
     int n = 187317;
-    RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n);
-    // deliberate overflow
-    for (int i = 0; i < n * 2; i++) {
+    try (RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n)) {
+      // deliberate overflow
+      for (int i = 0; i < n * 2; i++) {
+        monitor.count();
+      }
+      monitor.count();
       monitor.count();
     }
-    monitor.count();
-    monitor.count();
   }
 }

--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -29,8 +29,10 @@ public class RecordProgressMonitorTest {
   public void testFast() {
     int n = 187317;
     RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n);
-    for (int i = 0; i < n * 2; i++) // deliberate overflow
-    monitor.count();
+    // deliberate overflow
+    for (int i = 0; i < n * 2; i++) {
+      monitor.count();
+    }
     monitor.count();
     monitor.count();
   }

--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -34,17 +34,4 @@ public class RecordProgressMonitorTest {
     monitor.count();
     monitor.count();
   }
-
-  @Ignore("ohmygodslow")
-  @Test
-  public void testSlow() throws Exception {
-    int n = 1827317;
-    RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n);
-    for (int i = 0; i < n; i++) {
-      Thread.sleep(100);
-      monitor.count();
-    }
-    monitor.count();
-    monitor.count();
-  }
 }

--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -29,11 +29,9 @@ public class RecordProgressMonitorTest {
     int n = 187317;
     try (RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n)) {
       // deliberate overflow
-      for (int i = 0; i < n * 2; i++) {
+      for (int i = 0; i < n * 2 + 2; i++) {
         monitor.count();
       }
-      monitor.count();
-      monitor.count();
     }
   }
 }

--- a/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
+++ b/dumper/lib-common/src/test/java/com/google/edwmigration/dumper/plugin/ext/jdk/progress/RecordProgressMonitorTest.java
@@ -16,8 +16,7 @@
  */
 package com.google.edwmigration.dumper.plugin.ext.jdk.progress;
 
-import static org.junit.Assert.assertEquals;
-
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,16 +26,12 @@ import org.junit.runners.JUnit4;
 public class RecordProgressMonitorTest {
 
   @Test
-  public void count_totalExceeded_noExceptionThrown() {
-    int counterTotal = 187317;
-    // TODO: legacy value, (counterTotal + 1) should be enough for this test
-    int updateCount = 2 + 2 * counterTotal;
-    try (RecordProgressMonitor monitor = new RecordProgressMonitor("fast", counterTotal)) {
-      // deliberate overflow
-      for (int i = 0; i < updateCount; i++) {
-        monitor.count();
-      }
-      assertEquals(updateCount, monitor.getCount());
-    }
+  public void testFast() {
+    int n = 187317;
+    RecordProgressMonitor monitor = new RecordProgressMonitor("fast", n);
+    for (int i = 0; i < n * 2; i++) // deliberate overflow
+    monitor.count();
+    monitor.count();
+    monitor.count();
   }
 }


### PR DESCRIPTION
`testSlow` sleeps for a total of about 50 hours. It has been disabled since the migration to GitHub. The behavior it tests is already tested in testFast, although with fewer iterations (10^6 instead of 10^7).