### PR TITLE
[b/352469141] Make oracle-stats duration customizable

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/AbstractOracleConnector.java
@@ -20,6 +20,7 @@ import static com.google.edwmigration.dumper.application.dumper.ConnectorArgumen
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_ORACLE_SERVICE;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_ORACLE_SID;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_PORT;
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_QUERY_LOG_DAYS;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_URI;
 
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -72,7 +73,9 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 @RespectsArgumentPassword
 @RespectsArgumentUri
 @RespectsInputs({
-  // Although RespectsInput is @Repeatable, errorprone fails on it.
+  @RespectsInput(
+      arg = OPT_QUERY_LOG_DAYS,
+      description = "The number of days of query history to dump."),
   @RespectsInput(
       order = 450,
       arg = ConnectorArguments.OPT_ORACLE_SID,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -49,15 +49,15 @@ public class OracleStatsConnector extends AbstractOracleConnector {
   }
 
   static int getQueryLogDays(ConnectorArguments arguments) {
-    Integer asObject = arguments.getQueryLogDays();
+    Integer queryLogDaysObject = arguments.getQueryLogDays();
     int shortTimeInDays = 7;
     int longTimeInDays = 30;
-    if (asObject == null || asObject == longTimeInDays) {
+    if (queryLogDaysObject == null || queryLogDaysObject == longTimeInDays) {
       return longTimeInDays;
-    } else if (asObject == shortTimeInDays) {
+    } else if (queryLogDaysObject == shortTimeInDays) {
       return shortTimeInDays;
     } else {
-      throw invalidDuration(asObject.intValue());
+      throw invalidDuration(queryLogDaysObject.intValue());
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -50,12 +50,12 @@ public class OracleStatsConnector extends AbstractOracleConnector {
 
   static int getQueryLogDays(ConnectorArguments arguments) {
     Integer asObject = arguments.getQueryLogDays();
-    int shortTime = 7;
-    int longTime = 30;
-    if (asObject == null || asObject == longTime) {
-      return longTime;
-    } else if (asObject == shortTime) {
-      return shortTime;
+    int shortTimeInDays = 7;
+    int longTimeInDays = 30;
+    if (asObject == null || asObject == longTimeInDays) {
+      return longTimeInDays;
+    } else if (asObject == shortTimeInDays) {
+      return shortTimeInDays;
     } else {
       throw invalidDuration(asObject.intValue());
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -16,7 +16,10 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
+import static java.time.Duration.ofDays;
+
 import com.google.auto.service.AutoService;
+import com.google.common.collect.Range;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -32,8 +35,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class OracleStatsConnector extends AbstractOracleConnector {
 
-  static final Duration DEFAULT_DURATION = Duration.ofDays(30);
-  static final Duration MAX_DURATION = Duration.ofDays(10000);
+  static final Duration DEFAULT_DURATION = ofDays(30);
+  static final Duration MAX_DURATION = ofDays(10000);
 
   public OracleStatsConnector() {
     super(OracleConnectorScope.STATS);
@@ -54,8 +57,7 @@ public class OracleStatsConnector extends AbstractOracleConnector {
 
   static Duration getQueriedDuration(ConnectorArguments arguments) {
     Duration queriedDuration = extractFromArgs(arguments);
-    if (queriedDuration.compareTo(Duration.ofDays(1)) >= 0
-        && queriedDuration.compareTo(MAX_DURATION) < 1) {
+    if (Range.closed(ofDays(1), MAX_DURATION).contains(queriedDuration)) {
       return queriedDuration;
     } else {
       throw new MetadataDumperUsageException(
@@ -70,7 +72,7 @@ public class OracleStatsConnector extends AbstractOracleConnector {
       return DEFAULT_DURATION;
     } else {
       int queriedDays = arguments.getQueryLogDays();
-      return Duration.ofDays(queriedDays);
+      return ofDays(queriedDays);
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -16,8 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static java.util.Objects.requireNonNullElse;
-
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
@@ -53,7 +51,12 @@ public class OracleStatsConnector extends AbstractOracleConnector {
   }
 
   static int getQueryLogDays(ConnectorArguments arguments) {
-    int queriedDays = requireNonNullElse(arguments.getQueryLogDays(), 30);
+    int queriedDays;
+    if (arguments.getQueryLogDays() == null) {
+      queriedDays = 30;
+    } else {
+      queriedDays = arguments.getQueryLogDays();
+    }
     if (queriedDays > 0 && queriedDays <= MAX_DAYS) {
       return queriedDays;
     } else {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -60,14 +60,10 @@ public class OracleStatsConnector extends AbstractOracleConnector {
     if (queriedDays > 0 && queriedDays <= MAX_DAYS) {
       return queriedDays;
     } else {
-      throw invalidDuration(queriedDays);
+      throw new MetadataDumperUsageException(
+          String.format(
+              "The number of days must be positive and not greater than %s. Was: %s",
+              MAX_DAYS, queriedDays));
     }
-  }
-
-  private static MetadataDumperUsageException invalidDuration(int days) {
-    String message =
-        String.format(
-            "The number of days must be positive and not greater than %s. Was: %s", MAX_DAYS, days);
-    return new MetadataDumperUsageException(message);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -42,8 +42,8 @@ public class OracleStatsConnector extends AbstractOracleConnector {
   @Override
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) throws Exception {
     StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
-    int queryLogDays = getQueryLogDays(arguments);
-    out.addAll(taskListGenerator.createTasks(arguments, queryLogDays));
+    int queriedDays = getQueryLogDays(arguments);
+    out.addAll(taskListGenerator.createTasks(arguments, queriedDays));
   }
 
   @Nonnull
@@ -53,11 +53,11 @@ public class OracleStatsConnector extends AbstractOracleConnector {
   }
 
   static int getQueryLogDays(ConnectorArguments arguments) {
-    int queryLogDays = requireNonNullElse(arguments.getQueryLogDays(), 30);
-    if (queryLogDays > 0 && queryLogDays <= MAX_DAYS) {
-      return queryLogDays;
+    int queriedDays = requireNonNullElse(arguments.getQueryLogDays(), 30);
+    if (queriedDays > 0 && queriedDays <= MAX_DAYS) {
+      return queriedDays;
     } else {
-      throw invalidDuration(queryLogDays);
+      throw invalidDuration(queriedDays);
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -54,7 +54,7 @@ public class OracleStatsConnector extends AbstractOracleConnector {
 
   static Duration getQueriedDuration(ConnectorArguments arguments) {
     Duration queriedDuration = extractFromArgs(arguments);
-    if (queriedDuration.compareTo(Duration.ofDays(0)) == 1
+    if (queriedDuration.compareTo(Duration.ofDays(1)) >= 0
         && queriedDuration.compareTo(MAX_DURATION) < 1) {
       return queriedDuration;
     } else {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -32,8 +32,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class OracleStatsConnector extends AbstractOracleConnector {
 
-  static final int MAX_DAYS = 10000;
-  static final Duration maxDuration = Duration.ofDays(MAX_DAYS);
+  static final Duration DEFAULT_DURATION = Duration.ofDays(30);
+  static final Duration MAX_DURATION = Duration.ofDays(10000);
 
   public OracleStatsConnector() {
     super(OracleConnectorScope.STATS);
@@ -55,23 +55,22 @@ public class OracleStatsConnector extends AbstractOracleConnector {
   static Duration getQueriedDuration(ConnectorArguments arguments) {
     Duration queriedDuration = extractFromArgs(arguments);
     if (queriedDuration.compareTo(Duration.ofDays(0)) == 1
-        && queriedDuration.compareTo(maxDuration) < 1) {
+        && queriedDuration.compareTo(MAX_DURATION) < 1) {
       return queriedDuration;
     } else {
       throw new MetadataDumperUsageException(
           String.format(
               "The number of days must be positive and not greater than %s. Was: %s",
-              MAX_DAYS, queriedDuration.toDays()));
+              MAX_DURATION.toDays(), queriedDuration.toDays()));
     }
   }
 
   private static Duration extractFromArgs(ConnectorArguments arguments) {
-    int queriedDays;
     if (arguments.getQueryLogDays() == null) {
-      queriedDays = 30;
+      return DEFAULT_DURATION;
     } else {
-      queriedDays = arguments.getQueryLogDays();
+      int queriedDays = arguments.getQueryLogDays();
+      return Duration.ofDays(queriedDays);
     }
-    return Duration.ofDays(queriedDays);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -23,6 +23,7 @@ import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource;
 import java.io.IOException;
 import java.net.URL;
+import java.time.Duration;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -30,7 +31,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public abstract class OracleStatsQuery {
 
-  abstract int queriedDays();
+  abstract Duration queriedDuration();
 
   @Nonnull
   abstract String name();
@@ -41,10 +42,10 @@ public abstract class OracleStatsQuery {
   @Nonnull
   abstract StatsSource statsSource();
 
-  static OracleStatsQuery create(String name, StatsSource statsSource, int queriedDays)
+  static OracleStatsQuery create(String name, StatsSource statsSource, Duration queriedDuration)
       throws IOException {
     String path = String.format("oracle-stats/%s/%s.sql", statsSource.value, name);
-    return new AutoValue_OracleStatsQuery(queriedDays, name, loadFile(path), statsSource);
+    return new AutoValue_OracleStatsQuery(queriedDuration, name, loadFile(path), statsSource);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -30,6 +30,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public abstract class OracleStatsQuery {
 
+  abstract int queriedDays();
+
   @Nonnull
   abstract String name();
 
@@ -39,9 +41,10 @@ public abstract class OracleStatsQuery {
   @Nonnull
   abstract StatsSource statsSource();
 
-  static OracleStatsQuery create(String name, StatsSource statsSource) throws IOException {
+  static OracleStatsQuery create(String name, StatsSource statsSource, int days)
+      throws IOException {
     String path = String.format("oracle-stats/%s/%s.sql", statsSource.value, name);
-    return new AutoValue_OracleStatsQuery(name, loadFile(path), statsSource);
+    return new AutoValue_OracleStatsQuery(days, name, loadFile(path), statsSource);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -41,10 +41,10 @@ public abstract class OracleStatsQuery {
   @Nonnull
   abstract StatsSource statsSource();
 
-  static OracleStatsQuery create(String name, StatsSource statsSource, int days)
+  static OracleStatsQuery create(String name, StatsSource statsSource, int queriedDays)
       throws IOException {
     String path = String.format("oracle-stats/%s/%s.sql", statsSource.value, name);
-    return new AutoValue_OracleStatsQuery(days, name, loadFile(path), statsSource);
+    return new AutoValue_OracleStatsQuery(queriedDays, name, loadFile(path), statsSource);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -37,7 +37,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 @ParametersAreNonnullByDefault
-class StatsJdbcTask extends AbstractJdbcTask<Summary> {
+final class StatsJdbcTask extends AbstractJdbcTask<Summary> {
 
   private static final Logger LOG = LoggerFactory.getLogger(StatsJdbcTask.class);
 
@@ -64,7 +64,8 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
     if (query.statsSource() == NATIVE) {
       result = doSelect(connection, extractor, query.queryText());
     } else {
-      result = doSelect(connection, extractor, query.queryText(), query.queriedDays());
+      long days = query.queriedDuration().toDays();
+      result = doSelect(connection, extractor, query.queryText(), days);
     }
     if (result == null) {
       LOG.warn("Unexpected data extraction result: null");

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
+
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
@@ -58,7 +60,12 @@ class StatsJdbcTask extends AbstractJdbcTask<Summary> {
       TaskRunContext context, JdbcHandle jdbcHandle, ByteSink sink, Connection connection)
       throws SQLException {
     ResultSetExtractor<Summary> extractor = newCsvResultSetExtractor(sink);
-    Summary result = doSelect(connection, extractor, query.queryText());
+    Summary result;
+    if (query.statsSource() == NATIVE) {
+      result = doSelect(connection, extractor, query.queryText());
+    } else {
+      result = doSelect(connection, extractor, query.queryText(), query.queriedDays());
+    }
     if (result == null) {
       LOG.warn("Unexpected data extraction result: null");
       return Summary.EMPTY;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -61,20 +61,21 @@ class StatsTaskListGenerator {
       ImmutableList.of("hist-cmd-types-statspack", "sql-stats-statspack");
 
   @Nonnull
-  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, int logDays) throws IOException {
+  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, int queriedDays)
+      throws IOException {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
     builder.add(new DumpMetadataTask(arguments, scope.formatName()));
     builder.add(new FormatTask(scope.formatName()));
     for (String name : awrNames()) {
-      OracleStatsQuery item = OracleStatsQuery.create(name, AWR, logDays);
+      OracleStatsQuery item = OracleStatsQuery.create(name, AWR, queriedDays);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : nativeNames()) {
-      OracleStatsQuery item = OracleStatsQuery.create(name, NATIVE, logDays);
+      OracleStatsQuery item = OracleStatsQuery.create(name, NATIVE, queriedDays);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : statspackNames()) {
-      OracleStatsQuery query = OracleStatsQuery.create(name, STATSPACK, logDays);
+      OracleStatsQuery query = OracleStatsQuery.create(name, STATSPACK, queriedDays);
       builder.add(StatsJdbcTask.fromQuery(query));
     }
     return builder.build();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -61,20 +61,20 @@ class StatsTaskListGenerator {
       ImmutableList.of("hist-cmd-types-statspack", "sql-stats-statspack");
 
   @Nonnull
-  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments) throws IOException {
+  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, int logDays) throws IOException {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
     builder.add(new DumpMetadataTask(arguments, scope.formatName()));
     builder.add(new FormatTask(scope.formatName()));
     for (String name : awrNames()) {
-      OracleStatsQuery item = OracleStatsQuery.create(name, AWR);
+      OracleStatsQuery item = OracleStatsQuery.create(name, AWR, logDays);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : nativeNames()) {
-      OracleStatsQuery item = OracleStatsQuery.create(name, NATIVE);
+      OracleStatsQuery item = OracleStatsQuery.create(name, NATIVE, logDays);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : statspackNames()) {
-      OracleStatsQuery query = OracleStatsQuery.create(name, STATSPACK);
+      OracleStatsQuery query = OracleStatsQuery.create(name, STATSPACK, logDays);
       builder.add(StatsJdbcTask.fromQuery(query));
     }
     return builder.build();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -26,6 +26,7 @@ import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.io.IOException;
+import java.time.Duration;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -61,21 +62,21 @@ class StatsTaskListGenerator {
       ImmutableList.of("hist-cmd-types-statspack", "sql-stats-statspack");
 
   @Nonnull
-  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, int queriedDays)
+  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, Duration queriedDuration)
       throws IOException {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
     builder.add(new DumpMetadataTask(arguments, scope.formatName()));
     builder.add(new FormatTask(scope.formatName()));
     for (String name : awrNames()) {
-      OracleStatsQuery item = OracleStatsQuery.create(name, AWR, queriedDays);
+      OracleStatsQuery item = OracleStatsQuery.create(name, AWR, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : nativeNames()) {
-      OracleStatsQuery item = OracleStatsQuery.create(name, NATIVE, queriedDays);
+      OracleStatsQuery item = OracleStatsQuery.create(name, NATIVE, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : statspackNames()) {
-      OracleStatsQuery query = OracleStatsQuery.create(name, STATSPACK, queriedDays);
+      OracleStatsQuery query = OracleStatsQuery.create(name, STATSPACK, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(query));
     }
     return builder.build();

--- a/dumper/app/src/main/resources/oracle-stats/awr/hist-cmd-types-awr.sql
+++ b/dumper/app/src/main/resources/oracle-stats/awr/hist-cmd-types-awr.sql
@@ -37,7 +37,7 @@ INNER JOIN cdb_hist_snapshot C
   ON A.snap_id = C.snap_id
   AND A.dbid = C.dbid
   AND A.instance_number = C.instance_number
-  AND C.end_interval_time > sysdate - 30
+  AND C.end_interval_time > sysdate - ?
 LEFT JOIN audit_actions D
   ON B.command_type = D.action
 GROUP BY

--- a/dumper/app/src/main/resources/oracle-stats/awr/source-conn-latest.sql
+++ b/dumper/app/src/main/resources/oracle-stats/awr/source-conn-latest.sql
@@ -27,7 +27,7 @@ INNER JOIN cdb_hist_snapshot B
   AND A.instance_number = B.instance_number
   AND A.dbid = B.dbid
   AND A.session_type = 'FOREGROUND'
-  AND B.end_interval_time > sysdate - 30
+  AND B.end_interval_time > sysdate - ?
 INNER JOIN v$sqlcommand C
   ON A.sql_opcode = C.command_type
 GROUP BY

--- a/dumper/app/src/main/resources/oracle-stats/awr/sql-stats-awr.sql
+++ b/dumper/app/src/main/resources/oracle-stats/awr/sql-stats-awr.sql
@@ -42,7 +42,7 @@ JOIN cdb_hist_snapshot B
 ON A.dbid = B.dbid
     AND A.instance_number = B.instance_number
     AND A.snap_id = B.snap_id
-    AND B.end_interval_time > sysdate - 30
+    AND B.end_interval_time > sysdate - ?
 GROUP BY
     A.con_id,
     A.dbid,

--- a/dumper/app/src/main/resources/oracle-stats/statspack/hist-cmd-types-statspack.sql
+++ b/dumper/app/src/main/resources/oracle-stats/statspack/hist-cmd-types-statspack.sql
@@ -40,7 +40,7 @@ INNER JOIN stats$snapshot C
   ON A.dbid = C.dbid
   AND A.snap_id = C.snap_id
   AND A.instance_number = C.instance_number
-  AND C.snap_time > sysdate - 30
+  AND C.snap_time > sysdate - ?
 GROUP BY
   A.dbid,
   A.instance_number,

--- a/dumper/app/src/main/resources/oracle-stats/statspack/sql-stats-statspack.sql
+++ b/dumper/app/src/main/resources/oracle-stats/statspack/sql-stats-statspack.sql
@@ -38,7 +38,7 @@ INNER JOIN stats$sql_summary B
   ON A.dbid = B.dbid
   AND A.snap_id = B.snap_id
   AND A.instance_number = B.instance_number
-  AND A.snap_time > sysdate - 30
+  AND A.snap_time > sysdate - ?
 GROUP BY
   A.dbid,
   A.instance_number,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -59,7 +59,10 @@ public class OracleStatsConnectorTest {
             () -> OracleStatsConnector.getQueryLogDays(arguments));
 
     assertTrue(exception.getMessage().contains(time.asDays));
-    assertTrue(exception.getMessage().startsWith("The number of days must be positive and not greater than"));
+    assertTrue(
+        exception
+            .getMessage()
+            .startsWith("The number of days must be positive and not greater than"));
   }
 
   enum InvalidLogTime {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -53,7 +53,9 @@ public class OracleStatsConnectorTest {
     ConnectorArguments arguments =
         new ConnectorArguments(
             "--connector", "oracle-stats", "--query-log-days", String.valueOf(time.asDays));
+
     int days = OracleStatsConnector.getQueryLogDays(arguments);
+
     assertEquals(time.asDays, days);
   }
 
@@ -61,10 +63,12 @@ public class OracleStatsConnectorTest {
   public void getQueryLogDays_wrongNumberOfDays_throwsException() throws IOException {
     ConnectorArguments arguments =
         new ConnectorArguments("--connector", "oracle-stats", "--query-log-days", "999");
+
     MetadataDumperUsageException exception =
         assertThrows(
             MetadataDumperUsageException.class,
             () -> OracleStatsConnector.getQueryLogDays(arguments));
+
     assertTrue(exception.getMessage().contains("999"));
     assertTrue(exception.getMessage().startsWith("The number of days must be either 7 or 30"));
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -89,7 +89,7 @@ public class OracleStatsConnectorTest {
     MIN(Duration.ofDays(1)),
     SHORT(Duration.ofDays(7)),
     LONG(Duration.ofDays(30)),
-    MAX(OracleStatsConnector.maxDuration);
+    MAX(OracleStatsConnector.MAX_DURATION);
 
     final Duration duration;
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -17,17 +17,55 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertThrows;
 
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.io.IOException;
 import org.junit.Test;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
 
-@RunWith(JUnit4.class)
+@RunWith(Theories.class)
 public class OracleStatsConnectorTest {
 
   @Test
   public void getConnectorScope_success() {
     OracleStatsConnector connector = new OracleStatsConnector();
     assertEquals(OracleConnectorScope.STATS, connector.getConnectorScope());
+  }
+
+  enum LogTime {
+    SHORT(7),
+    LONG(30);
+
+    final int asDays;
+
+    LogTime(int asDays) {
+      this.asDays = asDays;
+    }
+  }
+
+  @Theory
+  public void getQueryLogDays_success(LogTime time) throws IOException {
+    ConnectorArguments arguments =
+        new ConnectorArguments(
+            "--connector", "oracle-stats", "--query-log-days", String.valueOf(time.asDays));
+    int days = OracleStatsConnector.getQueryLogDays(arguments);
+    assertEquals(time.asDays, days);
+  }
+
+  @Test
+  public void getQueryLogDays_wrongNumberOfDays_throwsException() throws IOException {
+    ConnectorArguments arguments =
+        new ConnectorArguments("--connector", "oracle-stats", "--query-log-days", "999");
+    MetadataDumperUsageException exception =
+        assertThrows(
+            MetadataDumperUsageException.class,
+            () -> OracleStatsConnector.getQueryLogDays(arguments));
+    assertTrue(exception.getMessage().contains("999"));
+    assertTrue(exception.getMessage().startsWith("The number of days must be either 7 or 30"));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnectorTest.java
@@ -17,8 +17,8 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
@@ -20,6 +20,7 @@ import static com.google.edwmigration.dumper.application.dumper.connector.oracle
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.time.Duration;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,7 +30,7 @@ public class OracleStatsQueryTest {
 
   @Test
   public void description_success() throws IOException {
-    OracleStatsQuery query = OracleStatsQuery.create("db-objects", NATIVE, 30);
+    OracleStatsQuery query = OracleStatsQuery.create("db-objects", NATIVE, Duration.ofDays(30));
     assertEquals("Query{name=db-objects, statsSource=NATIVE}", query.description());
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
@@ -29,7 +29,7 @@ public class OracleStatsQueryTest {
 
   @Test
   public void description_success() throws IOException {
-    OracleStatsQuery query = OracleStatsQuery.create("db-objects", NATIVE);
+    OracleStatsQuery query = OracleStatsQuery.create("db-objects", NATIVE, 30);
     assertEquals("Query{name=db-objects, statsSource=NATIVE}", query.description());
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import java.io.IOException;
+import java.time.Duration;
 import org.junit.Test;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
@@ -46,7 +47,7 @@ public class StatsJdbcTaskTest {
 
   @Theory
   public void toString_success(ResultProperty property) throws IOException {
-    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE, 30);
+    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE, Duration.ofDays(30));
     Task<?> task = StatsJdbcTask.fromQuery(query);
 
     // Act
@@ -58,7 +59,7 @@ public class StatsJdbcTaskTest {
 
   @Test
   public void getCategory_success() throws IOException {
-    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE, 30);
+    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE, Duration.ofDays(30));
     Task<?> task = StatsJdbcTask.fromQuery(query);
 
     assertEquals(TaskCategory.REQUIRED, task.getCategory());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
@@ -46,7 +46,7 @@ public class StatsJdbcTaskTest {
 
   @Theory
   public void toString_success(ResultProperty property) throws IOException {
-    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE);
+    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE, 30);
     Task<?> task = StatsJdbcTask.fromQuery(query);
 
     // Act
@@ -58,7 +58,7 @@ public class StatsJdbcTaskTest {
 
   @Test
   public void getCategory_success() throws IOException {
-    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE);
+    OracleStatsQuery query = OracleStatsQuery.create("pdbs-info", NATIVE, 30);
     Task<?> task = StatsJdbcTask.fromQuery(query);
 
     assertEquals(TaskCategory.REQUIRED, task.getCategory());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -21,6 +21,7 @@ import static com.google.edwmigration.dumper.application.dumper.connector.oracle
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.time.Duration;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
 import org.junit.experimental.theories.Theories;
@@ -40,12 +41,12 @@ public class StatsTaskListGeneratorTest {
   @Theory
   public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name)
       throws IOException {
-    OracleStatsQuery.create(name, NATIVE, 7);
+    OracleStatsQuery.create(name, NATIVE, Duration.ofDays(7));
   }
 
   @Theory
   public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name)
       throws IOException {
-    OracleStatsQuery.create(name, AWR, 7);
+    OracleStatsQuery.create(name, AWR, Duration.ofDays(7));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -40,12 +40,12 @@ public class StatsTaskListGeneratorTest {
   @Theory
   public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name)
       throws IOException {
-    OracleStatsQuery.create(name, NATIVE);
+    OracleStatsQuery.create(name, NATIVE, 7);
   }
 
   @Theory
   public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name)
       throws IOException {
-    OracleStatsQuery.create(name, AWR);
+    OracleStatsQuery.create(name, AWR, 7);
   }
 }


### PR DESCRIPTION
The user can optionally provide the number of days for query logs, similarly to existing logs-type connectors.
The end of the timeframe will be the present time, the start will be the present time minus the provided number of days.

The number of days can be a value from the inclusive range [1, 10000]