### PR TITLE
Summary cleanup

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -45,7 +45,4 @@ public interface Connector {
   public default Class<? extends Enum<? extends ConnectorProperty>> getConnectorProperties() {
     return DefaultProperties.class;
   }
-
-  @Nonnull
-  String summary(@Nonnull String fileName);
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/LogsConnector.java
@@ -32,10 +32,4 @@ public interface LogsConnector extends Connector {
       return ArchiveNameUtil.getFileName(getName());
     }
   }
-
-  @Nonnull
-  @Override
-  default String summary(@Nonnull String fileName) {
-    return "Logs have been saved to " + fileName;
-  }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/MetadataConnector.java
@@ -28,10 +28,4 @@ public interface MetadataConnector extends Connector {
   default String getDefaultFileName(boolean isAssessment, Clock clock) {
     return ArchiveNameUtil.getFileName(getName() + "-metadata");
   }
-
-  @Nonnull
-  @Override
-  default String summary(@Nonnull String fileName) {
-    return "Metadata has been saved to " + fileName;
-  }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsPermissionExtractionConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsPermissionExtractionConnector.java
@@ -82,10 +82,4 @@ public class HdfsPermissionExtractionConnector extends AbstractConnector {
   public Class<? extends Enum<? extends ConnectorProperty>> getConnectorProperties() {
     return super.getConnectorProperties();
   }
-
-  @Nonnull
-  @Override
-  public String summary(String fileName) {
-    return String.format("HDFS metadata has been saved to %s", fileName);
-  }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -27,7 +27,6 @@ import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.time.Duration;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @AutoService(Connector.class)
@@ -47,12 +46,6 @@ public class OracleStatsConnector extends AbstractOracleConnector {
     StatsTaskListGenerator taskListGenerator = new StatsTaskListGenerator();
     Duration queriedDuration = getQueriedDuration(arguments);
     out.addAll(taskListGenerator.createTasks(arguments, queriedDuration));
-  }
-
-  @Nonnull
-  @Override
-  public String summary(String fileName) {
-    return String.format("Oracle statistics saved to %s", fileName);
   }
 
   static Duration getQueriedDuration(ConnectorArguments arguments) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskSetState.java
@@ -67,15 +67,9 @@ public interface TaskSetState {
   @ParametersAreNonnullByDefault
   abstract static class TasksReport {
 
-    abstract long count();
+    public abstract long count();
 
-    abstract TaskState state();
-
-    @Nonnull
-    @Override
-    public String toString() {
-      return String.format("%d TASKS %s", count(), state());
-    }
+    public abstract TaskState state();
 
     static TasksReport create(long count, TaskState state) {
       return new AutoValue_TaskSetState_TasksReport(count, state);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/DriverClasspathTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/DriverClasspathTest.java
@@ -144,11 +144,5 @@ public class DriverClasspathTest {
       newDriver(arguments.getDriverPaths(), "foo.bar.DummyDriver");
       return () -> {};
     }
-
-    @Nonnull
-    @Override
-    public String summary(@Nonnull String fileName) {
-      return "";
-    }
   }
 }


### PR DESCRIPTION
I'm moving the most important details about the dumper execution to the last 3 lines of the summary printed at the end of the dumper execution.

Before:
```
********************************************************************
* Dumper wrote 44010458 bytes.
* Dumper took 5.056 min.
********************************************************************
* Task Summary:
* Task SUCCEEDED (INFORMATIONAL) Write compilerworks-version.txt from product version information.
* Task SUCCEEDED (REQUIRED) Write compilerworks-format.txt containing 'teradata.logs.zip'.
* Task SUCCEEDED (REQUIRED) Write utility_logs_2024-03-14T00:00:00Z.csv ...
* ...
********************************************************************
* Logs have been saved to /home/joe/dwh-migration-teradata-logs-20240717T143924.zip
********************************************************************
* 8 TASKS SUCCEEDED
* 5 TASKS FAILED
********************************************************************
```

After:
```
********************************************************************
* Task Summary:
* Task SUCCEEDED (INFORMATIONAL) Write compilerworks-version.txt from product version information.
* Task SUCCEEDED (REQUIRED) Write compilerworks-format.txt containing 'teradata.logs.zip'.
* Task SUCCEEDED (REQUIRED) Write utility_logs_2024-03-14T00:00:00Z.csv ...
* ...
***********************************
* Dumper wrote 44010458 bytes, took 5.056 min.
* Task summary: 12 SUCCEEDED, 5 FAILED
* Output saved to '/home/joe/dwh-migration-teradata-logs-20240717T143924.zip'
***********************************
```