### PR TITLE
Wrap IOException for oracle-stats SQL resources

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -43,6 +43,9 @@ public abstract class OracleStatsQuery {
   abstract String name();
 
   @Nonnull
+  abstract String queryText();
+
+  @Nonnull
   abstract StatsSource statsSource();
 
   @Nonnull
@@ -62,15 +65,10 @@ public abstract class OracleStatsQuery {
 
   private static OracleStatsQuery create(
       boolean isRequired, Duration queriedDuration, String name, StatsSource statsSource) {
-    return new AutoValue_OracleStatsQuery(isRequired, queriedDuration, name, statsSource);
-  }
-
-  @Nonnull
-  String queryText() {
-    String source = statsSource().value;
-    String tenantSetup = "cdb";
-    String path = String.format("oracle-stats/%s/%s/%s.sql", tenantSetup, source, name());
-    return loadFile(path);
+        String source = statsSource.value;
+        String tenantSetup = "cdb";
+        String path = String.format("oracle-stats/%s/%s/%s.sql", tenantSetup, source, name);
+    return new AutoValue_OracleStatsQuery(isRequired, queriedDuration, name, loadFile(path), statsSource);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -83,8 +83,8 @@ public abstract class OracleStatsQuery {
       URL queryUrl = Resources.getResource(path);
       return Resources.toString(queryUrl, UTF_8);
     } catch (IOException e) {
-      String message = String.format("An invalid file was provided: %s.", path);
-      throw new IllegalArgumentException(message, e);
+      throw new IllegalArgumentException(
+          String.format("An invalid file was provided: %s.", path), e);
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -83,7 +83,7 @@ public abstract class OracleStatsQuery {
       return Resources.toString(queryUrl, UTF_8);
     } catch (IOException e) {
       throw new IllegalArgumentException(
-          String.format("An invalid file was provided: %s.", path), e);
+          String.format("An invalid file was provided: '%s'.", path), e);
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -83,7 +83,7 @@ public abstract class OracleStatsQuery {
       URL queryUrl = Resources.getResource(path);
       return Resources.toString(queryUrl, UTF_8);
     } catch (IOException e) {
-      String message = String.format("IOException caused by invalid file: %s.", path);
+      String message = String.format("An invalid file was provided: %s.", path);
       throw new IllegalArgumentException(message, e);
     }
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -65,10 +65,11 @@ public abstract class OracleStatsQuery {
 
   private static OracleStatsQuery create(
       boolean isRequired, Duration queriedDuration, String name, StatsSource statsSource) {
-        String source = statsSource.value;
-        String tenantSetup = "cdb";
-        String path = String.format("oracle-stats/%s/%s/%s.sql", tenantSetup, source, name);
-    return new AutoValue_OracleStatsQuery(isRequired, queriedDuration, name, loadFile(path), statsSource);
+    String source = statsSource.value;
+    String tenantSetup = "cdb";
+    String path = String.format("oracle-stats/%s/%s/%s.sql", tenantSetup, source, name);
+    return new AutoValue_OracleStatsQuery(
+        isRequired, queriedDuration, name, loadFile(path), statsSource);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -16,9 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
 
-import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
@@ -44,7 +44,7 @@ final class StatsJdbcTask extends AbstractJdbcTask<Summary> {
 
   private StatsJdbcTask(String targetPath, OracleStatsQuery query) {
     super(targetPath);
-    Preconditions.checkArgument(targetPath.endsWith(".csv"));
+    checkArgument(targetPath.endsWith(".csv"));
     this.query = query;
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -21,7 +21,6 @@ import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
-import java.io.IOException;
 import java.time.Duration;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -61,8 +60,7 @@ class StatsTaskListGenerator {
       ImmutableList.of("hist-cmd-types-statspack", "sql-stats-statspack");
 
   @Nonnull
-  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, Duration queriedDuration)
-      throws IOException {
+  ImmutableList<Task<?>> createTasks(ConnectorArguments arguments, Duration queriedDuration) {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.<Task<?>>builder();
     builder.add(new DumpMetadataTask(arguments, scope.formatName()));
     builder.add(new FormatTask(scope.formatName()));

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
@@ -19,7 +19,6 @@ package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 import static java.time.Duration.ofDays;
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,7 +27,7 @@ import org.junit.runners.JUnit4;
 public class OracleStatsQueryTest {
 
   @Test
-  public void description_success() throws IOException {
+  public void description_success() {
     boolean isRequired = true;
     OracleStatsQuery query = OracleStatsQuery.createNative("db-objects", isRequired, ofDays(30));
     assertEquals("Query{name=db-objects, statsSource=NATIVE}", query.description());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
-import java.io.IOException;
 import java.time.Duration;
 import org.junit.Test;
 import org.junit.experimental.theories.Theories;
@@ -45,7 +44,7 @@ public class StatsJdbcTaskTest {
   }
 
   @Theory
-  public void toString_success(ResultProperty property) throws IOException {
+  public void toString_success(ResultProperty property) {
     boolean isRequired = false;
     OracleStatsQuery query =
         OracleStatsQuery.createNative("pdbs-info", isRequired, Duration.ofDays(30));
@@ -59,7 +58,7 @@ public class StatsJdbcTaskTest {
   }
 
   @Test
-  public void getCategory_isNotRequired_success() throws IOException {
+  public void getCategory_isNotRequired_success() {
     boolean isRequired = false;
     OracleStatsQuery query =
         OracleStatsQuery.createNative("pdbs-info", isRequired, Duration.ofDays(30));
@@ -69,7 +68,7 @@ public class StatsJdbcTaskTest {
   }
 
   @Test
-  public void getCategory_isRequired_success() throws IOException {
+  public void getCategory_isRequired_success() {
     boolean isRequired = true;
     OracleStatsQuery query =
         OracleStatsQuery.createNative("pdbs-info", isRequired, Duration.ofDays(30));

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -16,8 +16,10 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
+import static java.time.Duration.ofDays;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 import com.google.common.collect.ImmutableList;
-import java.time.Duration;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
 import org.junit.experimental.theories.Theories;
@@ -44,16 +46,22 @@ public class StatsTaskListGeneratorTest {
 
   @Theory
   public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name) {
-    OracleStatsQuery.createNative(name, /* isRequired= */ true, Duration.ofDays(7));
+    OracleStatsQuery query = OracleStatsQuery.createNative(name, /* isRequired= */ true, ofDays(7));
+
+    assertDoesNotThrow(query::queryText);
   }
 
   @Theory
   public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name) {
-    OracleStatsQuery.createAwr(name, Duration.ofDays(7));
+    OracleStatsQuery query = OracleStatsQuery.createAwr(name, ofDays(7));
+
+    assertDoesNotThrow(query::queryText);
   }
 
   @Theory
   public void statspackNames_allNamedFilesExist(@FromDataPoints("statspackNames") String name) {
-    OracleStatsQuery.createStatspack(name, Duration.ofDays(7));
+    OracleStatsQuery query = OracleStatsQuery.createStatspack(name, ofDays(7));
+
+    assertDoesNotThrow(query::queryText);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static java.time.Duration.ofDays;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.experimental.theories.DataPoints;
@@ -48,20 +47,20 @@ public class StatsTaskListGeneratorTest {
   public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name) {
     OracleStatsQuery query = OracleStatsQuery.createNative(name, /* isRequired= */ true, ofDays(7));
 
-    assertDoesNotThrow(query::queryText);
+    query.queryText();
   }
 
   @Theory
   public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name) {
     OracleStatsQuery query = OracleStatsQuery.createAwr(name, ofDays(7));
 
-    assertDoesNotThrow(query::queryText);
+    query.queryText();
   }
 
   @Theory
   public void statspackNames_allNamedFilesExist(@FromDataPoints("statspackNames") String name) {
     OracleStatsQuery query = OracleStatsQuery.createStatspack(name, ofDays(7));
 
-    assertDoesNotThrow(query::queryText);
+    query.queryText();
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -16,9 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static java.time.Duration.ofDays;
-
 import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.time.Duration;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
 import org.junit.experimental.theories.Theories;
@@ -44,23 +44,20 @@ public class StatsTaskListGeneratorTest {
   public static final ImmutableList<String> statspackNames = generator.statspackNames();
 
   @Theory
-  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name) {
-    OracleStatsQuery query = OracleStatsQuery.createNative(name, /* isRequired= */ true, ofDays(7));
-
-    query.queryText();
+  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name)
+      throws IOException {
+    OracleStatsQuery.createNative(name, /* isRequired= */ true, Duration.ofDays(7));
   }
 
   @Theory
-  public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name) {
-    OracleStatsQuery query = OracleStatsQuery.createAwr(name, ofDays(7));
-
-    query.queryText();
+  public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name)
+      throws IOException {
+    OracleStatsQuery.createAwr(name, Duration.ofDays(7));
   }
 
   @Theory
-  public void statspackNames_allNamedFilesExist(@FromDataPoints("statspackNames") String name) {
-    OracleStatsQuery query = OracleStatsQuery.createStatspack(name, ofDays(7));
-
-    query.queryText();
+  public void statspackNames_allNamedFilesExist(@FromDataPoints("statspackNames") String name)
+      throws IOException {
+    OracleStatsQuery.createStatspack(name, Duration.ofDays(7));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import com.google.common.collect.ImmutableList;
-import java.io.IOException;
 import java.time.Duration;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
@@ -44,20 +43,17 @@ public class StatsTaskListGeneratorTest {
   public static final ImmutableList<String> statspackNames = generator.statspackNames();
 
   @Theory
-  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name)
-      throws IOException {
+  public void nativeNames_allNamedFilesExist(@FromDataPoints("nativeNames") String name) {
     OracleStatsQuery.createNative(name, /* isRequired= */ true, Duration.ofDays(7));
   }
 
   @Theory
-  public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name)
-      throws IOException {
+  public void awrNames_allNamedFilesExist(@FromDataPoints("awrNames") String name) {
     OracleStatsQuery.createAwr(name, Duration.ofDays(7));
   }
 
   @Theory
-  public void statspackNames_allNamedFilesExist(@FromDataPoints("statspackNames") String name)
-      throws IOException {
+  public void statspackNames_allNamedFilesExist(@FromDataPoints("statspackNames") String name) {
     OracleStatsQuery.createStatspack(name, Duration.ofDays(7));
   }
 }


### PR DESCRIPTION
[oracle-stats connector]

The `IOException` thrown by a method in `common.io.Resources` is due to a general-purpose `read` method used by the implementation.

As the [documentation](https://docs.oracle.com/javase/8/docs/api/java/io/IOException.html) shows, the exception is very broad, covering various issues related to permissions, hosts, sockets, interrupts and other topics.

Oracle-stats uses `Resources` only to load SQLs included in the JAR. Almost all subclasses of IOException are inapplicable to this use case. The only issues with these files that we see somewhat frequently are:
- file is missing
- provided path to the file is incorrect

Neither  of these results in an IOException, because `Resources` will throw `IllegalArgumentException` before getting to the stage where an `IOException` could be thrown. An `IOException` being thrown when reading SQL for oracle-stats should be treated as programmer error, so it can use an unchecked exception class.

For the relevant cases, wrap `IOException` in an `IllegalArgumentException` that will inform about an invalid file to match the behavior of `io.Resources`