### PR TITLE
Group together the attributes related to SQL scripts subdirectories

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -72,7 +72,7 @@ public abstract class OracleStatsQuery {
     MULTI_TENANT("cdb"),
     SINGLE_TENANT("dba");
 
-    private final String code;
+    final String code;
 
     TenantSetup(String code) {
       this.code = code;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -24,7 +24,6 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.io.Resources;
-import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource;
 import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
@@ -49,18 +48,21 @@ public abstract class OracleStatsQuery {
 
   @Nonnull
   static OracleStatsQuery createAwr(String name, Duration queriedDuration) {
-    return create(false, queriedDuration, name, AWR, MULTI_TENANT);
+    QueryGroup queryGroup = QueryGroup.create(false, AWR, MULTI_TENANT);
+    return create(name, queryGroup, queriedDuration);
   }
 
   @Nonnull
   static OracleStatsQuery createNative(
       String name, boolean isRequired, Duration queriedDuration, TenantSetup tenantSetup) {
-    return create(isRequired, queriedDuration, name, NATIVE, tenantSetup);
+    QueryGroup queryGroup = QueryGroup.create(isRequired, NATIVE, tenantSetup);
+    return create(name, queryGroup, queriedDuration);
   }
 
   @Nonnull
   static OracleStatsQuery createStatspack(String name, Duration queriedDuration) {
-    return create(false, queriedDuration, name, STATSPACK, MULTI_TENANT);
+    QueryGroup queryGroup = QueryGroup.create(false, STATSPACK, MULTI_TENANT);
+    return create(name, queryGroup, queriedDuration);
   }
 
   enum TenantSetup {
@@ -74,15 +76,8 @@ public abstract class OracleStatsQuery {
     }
   }
 
-  private static OracleStatsQuery create(
-      boolean isRequired,
-      Duration queriedDuration,
-      String name,
-      StatsSource statsSource,
-      TenantSetup tenantSetup) {
-    QueryGroup queryGroup = QueryGroup.create(isRequired, statsSource, tenantSetup);
-    String source = statsSource.value;
-    String path = String.format("oracle-stats/%s/%s/%s.sql", tenantSetup.code, source, name);
+  static OracleStatsQuery create(String name, QueryGroup queryGroup, Duration queriedDuration) {
+    String path = String.format("oracle-stats/%s/%s.sql", queryGroup.path(), name);
     return new AutoValue_OracleStatsQuery(queriedDuration, queryGroup, name, loadFile(path));
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -16,14 +16,15 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.MULTI_TENANT;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.AWR;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.STATSPACK;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.AWR;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.NATIVE;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.STATSPACK;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup.MULTI_TENANT;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.io.Resources;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup;
 import java.io.IOException;
 import java.net.URL;
 import java.time.Duration;
@@ -63,17 +64,6 @@ public abstract class OracleStatsQuery {
   static OracleStatsQuery createStatspack(String name, Duration queriedDuration) {
     QueryGroup queryGroup = QueryGroup.create(false, STATSPACK, MULTI_TENANT);
     return create(name, queryGroup, queriedDuration);
-  }
-
-  enum TenantSetup {
-    MULTI_TENANT("cdb"),
-    SINGLE_TENANT("dba");
-
-    final String code;
-
-    TenantSetup(String code) {
-      this.code = code;
-    }
   }
 
   static OracleStatsQuery create(String name, QueryGroup queryGroup, Duration queriedDuration) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -41,6 +41,11 @@ public abstract class OracleStatsQuery {
   abstract Duration queriedDuration();
 
   @Nonnull
+  QueryGroup queryGroup() {
+    return QueryGroup.create(isRequired(), statsSource(), tenantSetup());
+  }
+
+  @Nonnull
   abstract String name();
 
   @Nonnull
@@ -93,7 +98,7 @@ public abstract class OracleStatsQuery {
 
   @Nonnull
   String description() {
-    return String.format("Query{name=%s, statsSource=%s}", name(), statsSource());
+    return String.format("Query{name=%s, statsSource=%s}", name(), queryGroup().statsSource());
   }
 
   private static String loadFile(String path) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQuery.java
@@ -35,27 +35,17 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public abstract class OracleStatsQuery {
 
-  abstract boolean isRequired();
-
   @Nonnull
   abstract Duration queriedDuration();
 
   @Nonnull
-  QueryGroup queryGroup() {
-    return QueryGroup.create(isRequired(), statsSource(), tenantSetup());
-  }
+  abstract QueryGroup queryGroup();
 
   @Nonnull
   abstract String name();
 
   @Nonnull
   abstract String queryText();
-
-  @Nonnull
-  abstract StatsSource statsSource();
-
-  @Nonnull
-  abstract TenantSetup tenantSetup();
 
   @Nonnull
   static OracleStatsQuery createAwr(String name, Duration queriedDuration) {
@@ -90,10 +80,10 @@ public abstract class OracleStatsQuery {
       String name,
       StatsSource statsSource,
       TenantSetup tenantSetup) {
+    QueryGroup queryGroup = QueryGroup.create(isRequired, statsSource, tenantSetup);
     String source = statsSource.value;
     String path = String.format("oracle-stats/%s/%s/%s.sql", tenantSetup.code, source, name);
-    return new AutoValue_OracleStatsQuery(
-        isRequired, queriedDuration, name, loadFile(path), statsSource, tenantSetup);
+    return new AutoValue_OracleStatsQuery(queriedDuration, queryGroup, name, loadFile(path));
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/QueryGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/QueryGroup.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle;
+
+import com.google.auto.value.AutoValue;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@AutoValue
+@ParametersAreNonnullByDefault
+abstract class QueryGroup {
+
+  abstract boolean required();
+
+  @Nonnull
+  abstract StatsSource statsSource();
+
+  @Nonnull
+  abstract TenantSetup tenantSetup();
+
+  @Nonnull
+  static QueryGroup create(boolean required, StatsSource statsSource, TenantSetup tenantSetup) {
+    return new AutoValue_QueryGroup(required, statsSource, tenantSetup);
+  }
+
+  @Nonnull
+  String path() {
+    return tenantSetup().code + "/" + statsSource().value;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/QueryGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/QueryGroup.java
@@ -17,8 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import com.google.auto.value.AutoValue;
-import com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup;
-import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -42,5 +40,29 @@ abstract class QueryGroup {
   @Nonnull
   String path() {
     return tenantSetup().code + "/" + statsSource().value;
+  }
+
+  /** The source of performance statistics. */
+  enum StatsSource {
+    AWR("awr"),
+    NATIVE("native"),
+    STATSPACK("statspack");
+
+    final String value;
+
+    StatsSource(String value) {
+      this.value = value;
+    }
+  }
+
+  enum TenantSetup {
+    MULTI_TENANT("cdb"),
+    SINGLE_TENANT("dba");
+
+    final String code;
+
+    TenantSetup(String code) {
+      this.code = code;
+    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.NATIVE;
 
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -83,7 +83,7 @@ final class StatsJdbcTask extends AbstractJdbcTask<Summary> {
       throws SQLException {
     ResultSetExtractor<Summary> extractor = newCsvResultSetExtractor(sink);
     Summary result;
-    if (query.statsSource() == NATIVE) {
+    if (query.queryGroup().statsSource() == NATIVE) {
       result = doSelect(connection, extractor, query.queryText());
     } else {
       long days = query.queriedDuration().toDays();
@@ -99,7 +99,7 @@ final class StatsJdbcTask extends AbstractJdbcTask<Summary> {
   @Nonnull
   @Override
   public TaskCategory getCategory() {
-    if (query.isRequired()) {
+    if (query.queryGroup().required()) {
       return TaskCategory.REQUIRED;
     } else {
       return TaskCategory.OPTIONAL;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -78,7 +78,7 @@ class StatsTaskListGenerator {
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : nativeNames(/* required= */ true)) {
-      QueryGroup requiredGroup = QueryGroup.create(true, NATIVE, MULTI_TENANT);
+      QueryGroup requiredGroup = QueryGroup.create(/* required= */ true, NATIVE, MULTI_TENANT);
       OracleStatsQuery item = OracleStatsQuery.create(name, requiredGroup, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(item));
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -18,6 +18,9 @@ package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.MULTI_TENANT;
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.SINGLE_TENANT;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.AWR;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.STATSPACK;
 
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -70,23 +73,23 @@ class StatsTaskListGenerator {
     builder.add(new DumpMetadataTask(arguments, scope.formatName()));
     builder.add(new FormatTask(scope.formatName()));
     for (String name : awrNames()) {
-      OracleStatsQuery item = OracleStatsQuery.createAwr(name, queriedDuration);
+      QueryGroup awr = QueryGroup.create(/* required= */ false, AWR, MULTI_TENANT);
+      OracleStatsQuery item = OracleStatsQuery.create(name, awr, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : nativeNames(/* required= */ true)) {
-      OracleStatsQuery item =
-          OracleStatsQuery.createNative(
-              name, /* isRequired= */ true, queriedDuration, MULTI_TENANT);
+      QueryGroup requiredGroup = QueryGroup.create(true, NATIVE, MULTI_TENANT);
+      OracleStatsQuery item = OracleStatsQuery.create(name, requiredGroup, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : nativeNames(/* required= */ false)) {
-      OracleStatsQuery item =
-          OracleStatsQuery.createNative(
-              name, /* isRequired= */ false, queriedDuration, MULTI_TENANT);
+      QueryGroup optionalGroupCdb = QueryGroup.create(/* required= */ false, NATIVE, MULTI_TENANT);
+      OracleStatsQuery item = OracleStatsQuery.create(name, optionalGroupCdb, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(item));
     }
     for (String name : statspackNames()) {
-      OracleStatsQuery query = OracleStatsQuery.createStatspack(name, queriedDuration);
+      QueryGroup statspack = QueryGroup.create(/* required= */ false, STATSPACK, MULTI_TENANT);
+      OracleStatsQuery query = OracleStatsQuery.create(name, statspack, queriedDuration);
       builder.add(StatsJdbcTask.fromQuery(query));
     }
     for (String name : NATIVE_NAMES_OPTIONAL) {
@@ -100,11 +103,11 @@ class StatsTaskListGenerator {
 
   List<Task<?>> createTaskWithAlternative(
       String name, boolean isRequired, Duration queriedDuration) {
-    OracleStatsQuery primary =
-        OracleStatsQuery.createNative(name, /* isRequired= */ false, queriedDuration, MULTI_TENANT);
+    QueryGroup primaryGroup = QueryGroup.create(/* required= */ false, NATIVE, MULTI_TENANT);
+    OracleStatsQuery primary = OracleStatsQuery.create(name, primaryGroup, queriedDuration);
     StatsJdbcTask primaryTask = StatsJdbcTask.fromQuery(primary);
-    OracleStatsQuery alternative =
-        OracleStatsQuery.createNative(name, isRequired, queriedDuration, SINGLE_TENANT);
+    QueryGroup alternativeGroup = QueryGroup.create(isRequired, NATIVE, SINGLE_TENANT);
+    OracleStatsQuery alternative = OracleStatsQuery.create(name, alternativeGroup, queriedDuration);
     StatsJdbcTask alternativeTask = StatsJdbcTask.fromQuery(alternative).onlyIfFailed(primaryTask);
     return ImmutableList.of(primaryTask, alternativeTask);
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -16,11 +16,11 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.MULTI_TENANT;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.SINGLE_TENANT;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.AWR;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.NATIVE;
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsTaskListGenerator.StatsSource.STATSPACK;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.AWR;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.NATIVE;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.STATSPACK;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup.MULTI_TENANT;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup.SINGLE_TENANT;
 
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -110,19 +110,6 @@ class StatsTaskListGenerator {
     OracleStatsQuery alternative = OracleStatsQuery.create(name, alternativeGroup, queriedDuration);
     StatsJdbcTask alternativeTask = StatsJdbcTask.fromQuery(alternative).onlyIfFailed(primaryTask);
     return ImmutableList.of(primaryTask, alternativeTask);
-  }
-
-  /** The source of performance statistics. */
-  enum StatsSource {
-    AWR("awr"),
-    NATIVE("native"),
-    STATSPACK("statspack");
-
-    final String value;
-
-    StatsSource(String value) {
-      this.value = value;
-    }
   }
 
   ImmutableList<String> awrNames() {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsQueryTest.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.MULTI_TENANT;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup.MULTI_TENANT;
 import static java.time.Duration.ofDays;
 import static org.junit.Assert.assertEquals;
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTaskTest.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.MULTI_TENANT;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup.MULTI_TENANT;
 import static java.time.Duration.ofDays;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGeneratorTest.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.oracle.OracleStatsQuery.TenantSetup.MULTI_TENANT;
+import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.TenantSetup.MULTI_TENANT;
 import static java.time.Duration.ofDays;
 
 import com.google.common.collect.ImmutableList;


### PR DESCRIPTION
Unlike the SQL text itself or query parameters, some properties are common for all SQLs in a single subdirectory.
Group these properties into a new class, decreasing the number of properties accessed directly from OracleStatsQuery.

- create QueryGroup as a value-based class
- move stats-source, tenant-setup and required-ness properties to the new class