### PR TITLE
Fix output dir format in metadata yaml

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -915,7 +915,7 @@ public class ConnectorArguments extends DefaultArguments {
             .add(OPT_DATABASE, getDatabases())
             .add(OPT_USER, getUser())
             .add(OPT_CONFIG, getConfiguration())
-            .add(OPT_OUTPUT, getOutputFile())
+            .add(OPT_OUTPUT, getOutputFile().orElse(null))
             .add(OPT_QUERY_LOG_EARLIEST_TIMESTAMP, getQueryLogEarliestTimestamp())
             .add(OPT_QUERY_LOG_DAYS, getQueryLogDays())
             .add(OPT_QUERY_LOG_START, getQueryLogStart())


### PR DESCRIPTION
The `compilerworks-metadata.yaml` contains the command-line options printed in the format that is serialized from Java internal model. For the `--output` option it was:

```
output=Optional[/home/joe/sample-extraction]
```

or if the option was not specified:

```
output=Optional.empty
```

After the change, the value is serialized:

```
output=/home/joe/sample-extraction
```

or

```
output=null
```