### PR TITLE
[b/350521386] Improve Oracle sequence metadata collection

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -204,6 +204,13 @@ public class OracleMetadataConnector extends AbstractOracleConnector
         whereCondOwner);
     buildSelectStarTask(
         out,
+        Sequences.ZIP_ENTRY_NAME_DBA,
+        "DBA_Sequences",
+        Sequences.ZIP_ENTRY_NAME_ALL,
+        "ALL_Sequences",
+        whereCondSequenceOwner);
+    buildSelectStarTask(
+        out,
         Tab_Columns.ZIP_ENTRY_NAME_DBA,
         "DBA_Tab_Columns",
         Tab_Columns.ZIP_ENTRY_NAME_ALL,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnectorTest.java
@@ -68,6 +68,8 @@ public class OracleMetadataConnectorTest {
             "SELECT * FROM DBA_Plsql_Types",
             "SELECT * FROM ALL_Procedures",
             "SELECT * FROM DBA_Procedures",
+            "SELECT * FROM ALL_Sequences",
+            "SELECT * FROM DBA_Sequences",
             "SELECT * FROM ALL_Tab_Columns",
             "SELECT * FROM DBA_Tab_Columns",
             "SELECT * FROM ALL_Tab_Partitions",

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/OracleMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/OracleMetadataDumpFormat.java
@@ -494,6 +494,29 @@ public interface OracleMetadataDumpFormat {
     }
   }
 
+  interface Sequences {
+
+    final String ZIP_ENTRY_NAME_DBA = "DBA.Sequences.csv";
+    final String ZIP_ENTRY_NAME_ALL = "ALL.Sequences.csv";
+
+    enum Header {
+      SEQUENCE_OWNER,
+      SEQUENCE_NAME,
+      MIN_VALUE,
+      MAX_VALUE,
+      INCREMENT_BY,
+      CYCLE_FLAG,
+      ORDER_FLAG,
+      CACHE_SIZE,
+      LAST_NUMBER,
+      SCALE_FLAG,
+      EXTEND_FLAG,
+      SHARDED_FLAG,
+      SESSION_FLAG,
+      KEEP_VALUE
+    }
+  }
+
   interface Types {
 
     final String ZIP_ENTRY_NAME_DBA = "DBA.Types.csv";


### PR DESCRIPTION
Some information is missing when the XML task reads metadata from Oracle sequences using `buildSelectXmlTask` for `ALL_SEQUENCES` and `DBA_SEQUENCES`.

This change adds a new task, `buildSelectStarTask`, for those tables and maps it to new files `DBA.Sequences.csv` and `ALL.Sequences.csv`.

The header for Sequences is defined based on version 23: [https://docs.oracle.com/en/database/oracle/oracle-database/23/refrn/ALL_SEQUENCES.html](https://docs.oracle.com/en/database/oracle/oracle-database/23/refrn/ALL_SEQUENCES.html).