### PR TITLE
Add a summary success message for each stats SQL group

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/QueryGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/QueryGroup.java
@@ -24,15 +24,15 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @AutoValue
 @ParametersAreNonnullByDefault
-abstract class QueryGroup {
+public abstract class QueryGroup {
 
   abstract boolean required();
 
   @Nonnull
-  abstract StatsSource statsSource();
+  public abstract StatsSource statsSource();
 
   @Nonnull
-  abstract TenantSetup tenantSetup();
+  public abstract TenantSetup tenantSetup();
 
   @Nonnull
   static QueryGroup create(boolean required, StatsSource statsSource, TenantSetup tenantSetup) {
@@ -51,23 +51,23 @@ abstract class QueryGroup {
   }
 
   /** The source of performance statistics. */
-  enum StatsSource {
+  public enum StatsSource {
     AWR("awr"),
     NATIVE("native"),
     STATSPACK("statspack");
 
-    final String value;
+    public final String value;
 
     StatsSource(String value) {
       this.value = value;
     }
   }
 
-  enum TenantSetup {
+  public enum TenantSetup {
     MULTI_TENANT("cdb"),
     SINGLE_TENANT("dba");
 
-    final String code;
+    public final String code;
 
     TenantSetup(String code) {
       this.code = code;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsJdbcTask.java
@@ -16,8 +16,10 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup.StatsSource.NATIVE;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
@@ -30,6 +32,7 @@ import com.google.edwmigration.dumper.application.dumper.task.TaskState;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.List;
 import javax.annotation.CheckReturnValue;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -39,7 +42,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 @ParametersAreNonnullByDefault
-final class StatsJdbcTask extends AbstractJdbcTask<Summary> {
+public class StatsJdbcTask extends AbstractJdbcTask<Summary> {
 
   private static final Logger LOG = LoggerFactory.getLogger(StatsJdbcTask.class);
   private final Condition condition;
@@ -104,6 +107,19 @@ final class StatsJdbcTask extends AbstractJdbcTask<Summary> {
     } else {
       return TaskCategory.OPTIONAL;
     }
+  }
+
+  @Nonnull
+  public static ImmutableList<StatsJdbcTask> findByGroup(
+      List<StatsJdbcTask> tasks, QueryGroup group) {
+    return tasks.stream()
+        .filter(item -> item.query().queryGroup().equals(group))
+        .collect(toImmutableList());
+  }
+
+  @Nonnull
+  OracleStatsQuery query() {
+    return query;
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -24,6 +24,7 @@ import static com.google.edwmigration.dumper.application.dumper.connector.oracle
 
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.task.ResultMessageTask;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
@@ -75,6 +76,18 @@ class StatsTaskListGenerator {
     builder.add(new FormatTask(scope.formatName()));
     List<StatsJdbcTask> jdbcTasks = createJdbcTasks(queriedDuration);
     builder.addAll(jdbcTasks);
+
+    QueryGroup awrAndCdb = QueryGroup.create(/* required= */ false, AWR, MULTI_TENANT);
+    QueryGroup awrAndNotCdb = QueryGroup.create(/* required= */ false, AWR, SINGLE_TENANT);
+    builder.add(ResultMessageTask.create(awrAndCdb, jdbcTasks));
+    builder.add(ResultMessageTask.create(awrAndNotCdb, jdbcTasks));
+
+    QueryGroup statspackAndCdb = QueryGroup.create(/* required= */ false, STATSPACK, MULTI_TENANT);
+    QueryGroup statspackAndNotCdb =
+        QueryGroup.create(/* required= */ false, STATSPACK, SINGLE_TENANT);
+    builder.add(ResultMessageTask.create(statspackAndCdb, jdbcTasks));
+    builder.add(ResultMessageTask.create(statspackAndNotCdb, jdbcTasks));
+
     return builder.build();
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/NoResultTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/NoResultTask.java
@@ -21,7 +21,7 @@ import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-abstract class VoidTask implements Task<Void> {
+abstract class NoResultTask implements Task<Void> {
 
   @Override
   public final Void run(TaskRunContext context) throws Exception {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
@@ -29,7 +29,9 @@ import com.google.edwmigration.dumper.application.dumper.task.TaskSetState;
 import com.google.edwmigration.dumper.application.dumper.task.TaskState;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
 
+@ParametersAreNonnullByDefault
 public class ResultMessageTask extends VoidTask {
 
   private final Condition condition;
@@ -72,7 +74,7 @@ public class ResultMessageTask extends VoidTask {
   }
 
   @Override
-  void doRun(@Nonnull TaskRunContext context) {}
+  void doRun(TaskRunContext context) {}
 
   private static Condition onAllTasks(List<StatsJdbcTask> tasks, TaskState requiredState) {
     if (tasks.isEmpty()) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
@@ -32,7 +32,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 
 @ParametersAreNonnullByDefault
-public class ResultMessageTask extends VoidTask {
+public class ResultMessageTask extends NoResultTask {
 
   private static final Condition EMPTY_GROUP_FAILED_CONDITION = new EmptyGroupFailedCondition();
 
@@ -44,7 +44,7 @@ public class ResultMessageTask extends VoidTask {
     this.group = group;
   }
 
-  public static VoidTask create(QueryGroup group, List<StatsJdbcTask> tasks) {
+  public static NoResultTask create(QueryGroup group, List<StatsJdbcTask> tasks) {
     List<StatsJdbcTask> matches = StatsJdbcTask.findByGroup(tasks, group);
     Condition condition = onAllTasks(matches, SUCCEEDED);
     return new ResultMessageTask(condition, group);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
@@ -34,6 +34,8 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 public class ResultMessageTask extends VoidTask {
 
+  private static final Condition EMPTY_GROUP_FAILED_CONDITION = new EmptyGroupFailedCondition();
+
   private final Condition condition;
   private final QueryGroup group;
 
@@ -78,7 +80,7 @@ public class ResultMessageTask extends VoidTask {
 
   private static Condition onAllTasks(List<StatsJdbcTask> tasks, TaskState requiredState) {
     if (tasks.isEmpty()) {
-      return emptyGroupFailedCondition();
+      return EMPTY_GROUP_FAILED_CONDITION;
     }
     ImmutableList<Condition> conditions =
         tasks.stream()
@@ -87,18 +89,15 @@ public class ResultMessageTask extends VoidTask {
     return new AndCondition(conditions);
   }
 
-  private static Condition emptyGroupFailedCondition() {
-    return new Condition() {
+  private static final class EmptyGroupFailedCondition implements Condition {
+    @Override
+    public boolean evaluate(@Nonnull TaskSetState state) {
+      return false;
+    }
 
-      @Override
-      public boolean evaluate(@Nonnull TaskSetState state) {
-        return false;
-      }
-
-      @Override
-      public String toString() {
-        return "group is non-empty";
-      }
-    };
+    @Override
+    public String toString() {
+      return "group is non-empty";
+    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/ResultMessageTask.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle.task;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.edwmigration.dumper.application.dumper.task.TaskCategory.OPTIONAL;
+import static com.google.edwmigration.dumper.application.dumper.task.TaskState.SUCCEEDED;
+
+import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.QueryGroup;
+import com.google.edwmigration.dumper.application.dumper.connector.oracle.StatsJdbcTask;
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import com.google.edwmigration.dumper.application.dumper.task.TaskSetState;
+import com.google.edwmigration.dumper.application.dumper.task.TaskState;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+public class ResultMessageTask extends VoidTask {
+
+  private final Condition condition;
+  private final QueryGroup group;
+
+  private ResultMessageTask(Condition condition, QueryGroup group) {
+    this.condition = condition;
+    this.group = group;
+  }
+
+  public static VoidTask create(QueryGroup group, List<StatsJdbcTask> tasks) {
+    List<StatsJdbcTask> matches = StatsJdbcTask.findByGroup(tasks, group);
+    Condition condition = onAllTasks(matches, SUCCEEDED);
+    return new ResultMessageTask(condition, group);
+  }
+
+  @Override
+  @Nonnull
+  public Condition[] getConditions() {
+    return new Condition[] {condition};
+  }
+
+  @Override
+  @Nonnull
+  public String getTargetPath() {
+    return String.format("loading of group %s", group);
+  }
+
+  @Nonnull
+  @Override
+  public String toString() {
+    String tenantSetup = group.tenantSetup().code;
+    return String.format("Load %s data (%s version).", group.statsSource(), tenantSetup);
+  }
+
+  @Override
+  @Nonnull
+  public TaskCategory getCategory() {
+    return OPTIONAL;
+  }
+
+  @Override
+  void doRun(@Nonnull TaskRunContext context) {}
+
+  private static Condition onAllTasks(List<StatsJdbcTask> tasks, TaskState requiredState) {
+    if (tasks.isEmpty()) {
+      return emptyGroupFailedCondition();
+    }
+    ImmutableList<Condition> conditions =
+        tasks.stream()
+            .map(item -> new StateCondition(item, requiredState))
+            .collect(toImmutableList());
+    return new AndCondition(conditions);
+  }
+
+  private static Condition emptyGroupFailedCondition() {
+    return new Condition() {
+
+      @Override
+      public boolean evaluate(@Nonnull TaskSetState state) {
+        return false;
+      }
+
+      @Override
+      public String toString() {
+        return "group is non-empty";
+      }
+    };
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/VoidTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/task/VoidTask.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.oracle.task;
+
+import com.google.edwmigration.dumper.application.dumper.task.Task;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+abstract class VoidTask implements Task<Void> {
+
+  @Override
+  public final Void run(TaskRunContext context) throws Exception {
+    doRun(context);
+    return null;
+  }
+
+  abstract void doRun(TaskRunContext context);
+}


### PR DESCRIPTION
The task of determining if a given SQL group was successful is complicated from the user's perspective.
For example, if they want to determine whether CDBs AWR data will be available in the archive, they need to:
- go through the list of all task statuses
- find the ones which refer to CDBs and have AWR as their statsSource
- ensure that the status is either SUCCEEDED or SKIPPED for each task

Use existing Dumper mechanisms to simplify this process. Provide a summary for each group so that after successful extraction of data from an entire SQL group, an informational message will be printed, e.g:
```
* Task SUCCEEDED (OPTIONAL) Load AWR data (cdb version).
```

This is similar to what's done in OracleMetadataConnector, with two differences: the message is also shown on success and its location is in the task list instead of in the logs.