### PR TITLE
[b/350521386] Add correct Oracle column name for ALL_SEQUENCES.SEQUENCE_OWNER

### DIFF
--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/OracleMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/OracleMetadataDumpFormat.java
@@ -687,7 +687,9 @@ public interface OracleMetadataDumpFormat {
     final String ZIP_ENTRY_NAME_ALL = "ALL.Sequences-XML.csv";
 
     enum Header {
+      @Deprecated // `OWNER` is not associated with any column. Please use 'SEQUENCE_OWNER' instead.
       OWNER,
+      SEQUENCE_OWNER,
       SEQUENCE_NAME,
       XML
     }


### PR DESCRIPTION
Correct a mistake in the code where the wrong column name (`OWNER`) was used to retrieve sequence information via `XmlSequences` from an Oracle database. The correct column name is `SEQUENCE_OWNER`, as documented in the Oracle reference (https://docs.oracle.com/en/database/oracle/oracle-database/23/refrn/ALL_SEQUENCES.html). A new enum value `SEQUENCE_OWNER` has been added, and the old `OWNER` value is now marked as deprecated.