### PR TITLE
[b/355392538] Delete script tmp directory after tests

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScripts.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.hadoop;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Suppliers.memoize;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URL;
@@ -68,5 +69,10 @@ class HadoopScripts {
     Files.write(scriptPath, scriptBody);
     scriptPath.toFile().setExecutable(true);
     return scriptPath;
+  }
+
+  @VisibleForTesting
+  static Path getScriptDir() {
+    return SCRIPT_DIR_SUPPLIER.get();
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnectorTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import org.junit.BeforeClass;
 import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.FromDataPoints;
 import org.junit.experimental.theories.Theories;
@@ -28,6 +29,11 @@ import org.junit.runner.RunWith;
 
 @RunWith(Theories.class)
 public class HadoopMetadataConnectorTest {
+
+  @BeforeClass
+  public static void setUp() {
+    ScriptTmpDirCleanup.cleanupAfterAllTestsAreFinished();
+  }
 
   @DataPoints("scriptNames")
   public static final ImmutableList<String> SCRIPT_NAMES = HadoopMetadataConnector.SCRIPT_NAMES;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,6 +31,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class HadoopScriptsTest {
   Path extractedFile;
+
+  @BeforeClass
+  public static void setUp() {
+    ScriptTmpDirCleanup.cleanupAfterAllTestsAreFinished();
+  }
 
   @After
   public void tearDown() throws IOException {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/ScriptTmpDirCleanup.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/ScriptTmpDirCleanup.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.hadoop;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.io.FileUtils;
+
+public class ScriptTmpDirCleanup {
+
+  private static final AtomicBoolean hookRegistered = new AtomicBoolean();
+
+  public static void cleanupAfterAllTestsAreFinished() {
+    if (hookRegistered.compareAndSet(false, true)) {
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    try {
+                      FileUtils.deleteDirectory(HadoopScripts.getScriptDir().toFile());
+                    } catch (IOException ex) {
+                      ex.printStackTrace();
+                    }
+                  }));
+    }
+  }
+}


### PR DESCRIPTION
The temporary directory is created for bash scripts during test execution. It should be deleted after tests, because otherwise such directories start to pile up, if the tests are executed multiple times during development.