### PR TITLE
[b/359866106] Add SQLs to discover Oracle exadata and system configuration

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -40,7 +40,8 @@ class StatsTaskListGenerator {
   private final OracleConnectorScope scope = OracleConnectorScope.STATS;
 
   private static final ImmutableList<String> AWR_NAMES =
-      ImmutableList.of("hist-cmd-types-awr", "source-conn-latest", "sql-stats-awr");
+      ImmutableList.of(
+          "hist-cmd-types-awr", "source-conn-latest", "sql-stats-awr", "sys-metric-history");
 
   private static final ImmutableList<String> NATIVE_NAMES_OPTIONAL =
       ImmutableList.of(
@@ -51,7 +52,10 @@ class StatsTaskListGenerator {
           "dtl-source-code",
           "exttab",
           "m-view-types",
-          "pdbs-info");
+          "pdbs-info",
+          "osstat",
+          "cell-config",
+          "data-files");
 
   private static final ImmutableList<String> NATIVE_NAMES_REQUIRED =
       ImmutableList.of(

--- a/dumper/app/src/main/resources/oracle-stats/cdb/awr/sys-metric-history.sql
+++ b/dumper/app/src/main/resources/oracle-stats/cdb/awr/sys-metric-history.sql
@@ -1,0 +1,27 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  SysMetrics.con_id "ConId",
+  SysMetrics.con_dbid "ConDbId",
+  SysMetrics.dbid "DbId",
+  SysMetrics.begin_time "BeginTime",
+  SysMetrics.end_time "EndTime",
+  SysMetrics.metric_id "MetricId",
+  SysMetrics.metric_name "MetricName",
+  SysMetrics.value "Value",
+  SysMetrics.metric_unit "MetricUnit"
+FROM cdb_hist_sysmetric_history SysMetrics
+  -- use a query parameter to get the number of querylog days that should be loaded
+  WHERE SysMetrics.end_time > sysdate - ?

--- a/dumper/app/src/main/resources/oracle-stats/cdb/native/cell-config.sql
+++ b/dumper/app/src/main/resources/oracle-stats/cdb/native/cell-config.sql
@@ -1,0 +1,25 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  Cell.con_id "ConId",
+  Cell.inst_id "InstId",
+  Cell.cell_path "CellPath",
+  Cell.cell_type "CellType",
+  CellConfig.conftype "ConfigType",
+  CellConfig.confval "ConfigValue"
+FROM gv$cell Cell
+LEFT JOIN gv$cell_config CellConfig
+  ON Cell.con_id = CellConfig.con_id
+  AND Cell.cell_hashval = CellConfig.cellhash

--- a/dumper/app/src/main/resources/oracle-stats/cdb/native/data-files.sql
+++ b/dumper/app/src/main/resources/oracle-stats/cdb/native/data-files.sql
@@ -1,0 +1,24 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  DataFiles.con_id "ConId",
+  DataFiles.file_id "FileId",
+  DataFiles.bytes "Bytes",
+  DataFiles.blocks "Blocks",
+  DataFiles.status "Status",
+  DataFiles.tablespace_name "TablespaceName",
+  DataFiles.maxbytes "MaxBytes",
+  DataFiles.maxblocks "MaxBlocks"
+FROM cdb_data_files DataFiles

--- a/dumper/app/src/main/resources/oracle-stats/cdb/native/osstat.sql
+++ b/dumper/app/src/main/resources/oracle-stats/cdb/native/osstat.sql
@@ -1,0 +1,22 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  OsStat.con_id "ConId",
+  OsStat.inst_id "InstId",
+  OsStat.stat_name "StatName",
+  OsStat.value "Value",
+  OsStat.osstat_id "OsstatId",
+  OsStat.cumulative "Cumulative"
+FROM gv$osstat OsStat

--- a/dumper/app/src/main/resources/oracle-stats/dba/awr/sys-metric-history.sql
+++ b/dumper/app/src/main/resources/oracle-stats/dba/awr/sys-metric-history.sql
@@ -1,0 +1,27 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  NULL "ConId",
+  SysMetrics.con_dbid "ConDbId",
+  SysMetrics.dbid "DbId",
+  SysMetrics.begin_time "BeginTime",
+  SysMetrics.end_time "EndTime",
+  SysMetrics.metric_id "MetricId",
+  SysMetrics.metric_name "MetricName",
+  SysMetrics.value "Value",
+  SysMetrics.metric_unit "MetricUnit"
+FROM dba_hist_sysmetric_history SysMetrics
+  -- use a query parameter to get the number of querylog days that should be loaded
+  WHERE SysMetrics.end_time > sysdate - ?

--- a/dumper/app/src/main/resources/oracle-stats/dba/native/cell-config.sql
+++ b/dumper/app/src/main/resources/oracle-stats/dba/native/cell-config.sql
@@ -1,0 +1,25 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  NULL "ConId",
+  Cell.inst_id "InstId",
+  Cell.cell_path "CellPath",
+  Cell.cell_type "CellType",
+  CellConfig.conftype "ConfigType",
+  CellConfig.confval "ConfigValue"
+FROM gv$cell Cell
+LEFT JOIN gv$cell_config CellConfig
+  ON Cell.con_id = CellConfig.con_id
+  AND Cell.cell_hashval = CellConfig.cellhash

--- a/dumper/app/src/main/resources/oracle-stats/dba/native/data-files.sql
+++ b/dumper/app/src/main/resources/oracle-stats/dba/native/data-files.sql
@@ -1,0 +1,24 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  NULL "ConId",
+  DataFiles.file_id "FileId",
+  DataFiles.bytes "Bytes",
+  DataFiles.blocks "Blocks",
+  DataFiles.status "Status",
+  DataFiles.tablespace_name "TablespaceName",
+  DataFiles.maxbytes "MaxBytes",
+  DataFiles.maxblocks "MaxBlocks"
+FROM dba_data_files DataFiles

--- a/dumper/app/src/main/resources/oracle-stats/dba/native/osstat.sql
+++ b/dumper/app/src/main/resources/oracle-stats/dba/native/osstat.sql
@@ -1,0 +1,22 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  NULL "ConId",
+  OsStat.inst_id "InstId",
+  OsStat.stat_name "StatName",
+  OsStat.value "Value",
+  OsStat.osstat_id "OsstatId",
+  OsStat.cumulative "Cumulative"
+FROM gv$osstat OsStat


### PR DESCRIPTION
This PR introduces 4 additional SQL to extract Oracle system configuration:

- osstat - General system statistics. Required to collect CPU configuration.
- cell-config - Information about Exadata storage cells. This view exists for non Exadata systems, but data is missing.
- data-files - Information about Oracle data files that will be used to calculate physical storage size.
- sys-metric-history - History of system metrics like CPU usage.