### PR TITLE
Remove dwh-migration-client

### DIFF
--- a/bin/dwh-migration-client
+++ b/bin/dwh-migration-client
@@ -1,3 +1,0 @@
-#!/bin/sh -ex
-
-exec dwh-migration-client "$@"

--- a/build.gradle
+++ b/build.gradle
@@ -12,9 +12,6 @@ distributions {
                 exclude "**/__pycache__"
                 into "client"
             }
-            from("bin/dwh-migration-client") {
-                into "bin"
-            }
             project(":dumper:app").afterEvaluate {
                 from it.tasks.installPublishedDist
             }


### PR DESCRIPTION
I'm removing the `dwh-migration-client`, because it seems unused.