### PR TITLE
[b/361012673] Extract historical metrics from Oracle cdb_hist_seg_stat view

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/StatsTaskListGenerator.java
@@ -41,7 +41,11 @@ class StatsTaskListGenerator {
 
   private static final ImmutableList<String> AWR_NAMES =
       ImmutableList.of(
-          "hist-cmd-types-awr", "source-conn-latest", "sql-stats-awr", "sys-metric-history");
+          "hist-cmd-types-awr",
+          "source-conn-latest",
+          "sql-stats-awr",
+          "sys-metric-history",
+          "segment-stats");
 
   private static final ImmutableList<String> NATIVE_NAMES_OPTIONAL =
       ImmutableList.of(

--- a/dumper/app/src/main/resources/oracle-stats/cdb/awr/segment-stats.sql
+++ b/dumper/app/src/main/resources/oracle-stats/cdb/awr/segment-stats.sql
@@ -1,0 +1,37 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  SegStat.con_id "ConId",
+  SegStat.dbid "DbId",
+  SegStat.instance_number "InstanceNumber",
+  SegStat.ts# "TablespaceNumber",
+  SegStat.obj# "DictionaryObjectNumber",
+  SegStat.dataobj# "DataObjectNumber",
+  Snap.begin_interval_time "BeginIntervalTime",
+  Snap.end_interval_time "EndIntervalTime",
+  SegStat.space_used_total "SpaceUsedTotal",
+  SegStat.space_allocated_total "SpaceAllocatedTotal",
+  SegStat.physical_reads_delta "PhysicalReadsBlocks",
+  SegStat.physical_writes_delta "PhysicalWritesBlocks",
+  SegStat.physical_read_requests_delta "PhysicalReadRequestsBlocks",
+  SegStat.physical_write_requests_delta "PhysicalWriteRequestsBlocks",
+  SegStat.table_scans_delta "TableScans"
+FROM cdb_hist_seg_stat SegStat
+INNER JOIN cdb_hist_snapshot Snap
+  ON SegStat.snap_id = Snap.snap_id
+  AND SegStat.dbid = Snap.dbid
+  AND SegStat.instance_number = Snap.instance_number
+  -- use a query parameter to get the number of querylog days that should be loaded
+  AND Snap.end_interval_time > sysdate - ?

--- a/dumper/app/src/main/resources/oracle-stats/dba/awr/segment-stats.sql
+++ b/dumper/app/src/main/resources/oracle-stats/dba/awr/segment-stats.sql
@@ -1,0 +1,37 @@
+-- Copyright 2022-2024 Google LLC
+-- Copyright 2013-2021 CompilerWorks
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+SELECT
+  NULL "ConId",
+  SegStat.dbid "DbId",
+  SegStat.instance_number "InstanceNumber",
+  SegStat.ts# "TablespaceNumber",
+  SegStat.obj# "DictionaryObjectNumber",
+  SegStat.dataobj# "DataObjectNumber",
+  Snap.begin_interval_time "BeginIntervalTime",
+  Snap.end_interval_time "EndIntervalTime",
+  SegStat.space_used_total "SpaceUsedTotal",
+  SegStat.space_allocated_total "SpaceAllocatedTotal",
+  SegStat.physical_reads_delta "PhysicalReadsBlocks",
+  SegStat.physical_writes_delta "PhysicalWritesBlocks",
+  SegStat.physical_read_requests_delta "PhysicalReadRequestsBlocks",
+  SegStat.physical_write_requests_delta "PhysicalWriteRequestsBlocks",
+  SegStat.table_scans_delta "TableScans"
+FROM dba_hist_seg_stat SegStat
+INNER JOIN dba_hist_snapshot Snap
+  ON SegStat.snap_id = Snap.snap_id
+  AND SegStat.dbid = Snap.dbid
+  AND SegStat.instance_number = Snap.instance_number
+  -- use a query parameter to get the number of querylog days that should be loaded
+  AND Snap.end_interval_time > sysdate - ?


### PR DESCRIPTION
Data extracted from cdb/dba_hist_seg_stat views includes segment level statistics that can be used to better understand database storage trends. 