### PR TITLE
Group single-line scripts in a single text file

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/BashTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/BashTask.java
@@ -45,11 +45,12 @@ public class BashTask implements Task<Void> {
   private static final Duration SCRIPT_TIMEOUT = Duration.ofMinutes(1);
 
   private final String scriptName;
-  private final boolean isSingleLineScript;
 
-  public BashTask(String scriptName, boolean isSingleLineScript) {
+  private final Path scriptFile;
+
+  public BashTask(String scriptName, Path scriptFile) {
     this.scriptName = scriptName;
-    this.isSingleLineScript = isSingleLineScript;
+    this.scriptFile = scriptFile;
   }
 
   @Override
@@ -59,13 +60,6 @@ public class BashTask implements Task<Void> {
 
   private void doRun(ByteSink outputSink, ByteSink errorSink, ByteSink exitStatusSink)
       throws IOException, ExecutionException {
-    String scriptFilename = scriptName + ".sh";
-    Path scriptFile;
-    if (isSingleLineScript) {
-      scriptFile = HadoopScripts.extractSingleLineScript(scriptName);
-    } else {
-      scriptFile = HadoopScripts.extract(scriptFilename);
-    }
     Process process =
         new ProcessBuilder("/bin/bash", scriptFile.toAbsolutePath().toString()).start();
     Future<Void> outputStreamPump;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/BashTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/BashTask.java
@@ -45,9 +45,11 @@ public class BashTask implements Task<Void> {
   private static final Duration SCRIPT_TIMEOUT = Duration.ofMinutes(1);
 
   private final String scriptName;
+  private final boolean isSingleLineScript;
 
-  public BashTask(String scriptName) {
+  public BashTask(String scriptName, boolean isSingleLineScript) {
     this.scriptName = scriptName;
+    this.isSingleLineScript = isSingleLineScript;
   }
 
   @Override
@@ -58,7 +60,12 @@ public class BashTask implements Task<Void> {
   private void doRun(ByteSink outputSink, ByteSink errorSink, ByteSink exitStatusSink)
       throws IOException, ExecutionException {
     String scriptFilename = scriptName + ".sh";
-    Path scriptFile = HadoopScripts.extract(scriptFilename);
+    Path scriptFile;
+    if (isSingleLineScript) {
+      scriptFile = HadoopScripts.extractSingleLineScript(scriptName);
+    } else {
+      scriptFile = HadoopScripts.extract(scriptFilename);
+    }
     Process process =
         new ProcessBuilder("/bin/bash", scriptFile.toAbsolutePath().toString()).start();
     Future<Void> outputStreamPump;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnector.java
@@ -66,10 +66,6 @@ public class HadoopMetadataConnector implements MetadataConnector {
           "spark-shell-version",
           "sqoop-version");
 
-  @VisibleForTesting
-  static final ImmutableList<String> SINGLE_LINE_SCRIPT_NAMES =
-      ImmutableList.of("ip-address", "ls-usr-local-lib", "ls-var-log", "os-release");
-
   @Nonnull
   @Override
   public String getName() {
@@ -82,11 +78,14 @@ public class HadoopMetadataConnector implements MetadataConnector {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
     SCRIPT_NAMES.stream()
-        .map(scriptName -> new BashTask(scriptName, /* isSingleLineScript= */ false))
+        .map(scriptName -> new BashTask(scriptName, HadoopScripts.extract(scriptName + ".sh")))
         .forEach(out::add);
-    SINGLE_LINE_SCRIPT_NAMES.stream()
-        .map(scriptName -> new BashTask(scriptName, /* isSingleLineScript= */ true))
-        .forEach(out::add);
+    addTasksForSingleLineScripts(out);
+  }
+
+  private void addTasksForSingleLineScripts(List<? super Task<?>> out) {
+    HadoopScripts.extractSingleLineScripts()
+        .forEach((scriptName, scriptFile) -> out.add(new BashTask(scriptName, scriptFile)));
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnector.java
@@ -50,16 +50,12 @@ public class HadoopMetadataConnector implements MetadataConnector {
           "hbase-shell-version",
           "hbase-version",
           "hive-version",
-          "ip-address",
           "java-version",
-          "ls-usr-local-lib",
-          "ls-var-log",
           "lsb-release",
           "metastore-connection-details",
           "omd-version",
           "oozie-admin-status",
           "oozie-version",
-          "os-release",
           "perl-version",
           "pig-version",
           "python-version",
@@ -69,6 +65,10 @@ public class HadoopMetadataConnector implements MetadataConnector {
           "scala-version",
           "spark-shell-version",
           "sqoop-version");
+
+  @VisibleForTesting
+  static final ImmutableList<String> SINGLE_LINE_SCRIPT_NAMES =
+      ImmutableList.of("ip-address", "ls-usr-local-lib", "ls-var-log", "os-release");
 
   @Nonnull
   @Override
@@ -81,7 +81,12 @@ public class HadoopMetadataConnector implements MetadataConnector {
       throws Exception {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
-    SCRIPT_NAMES.stream().map(BashTask::new).forEach(out::add);
+    SCRIPT_NAMES.stream()
+        .map(scriptName -> new BashTask(scriptName, /* isSingleLineScript= */ false))
+        .forEach(out::add);
+    SINGLE_LINE_SCRIPT_NAMES.stream()
+        .map(scriptName -> new BashTask(scriptName, /* isSingleLineScript= */ true))
+        .forEach(out::add);
   }
 
   @Nonnull

--- a/dumper/app/src/main/resources/hadoop-scripts/ip-address.sh
+++ b/dumper/app/src/main/resources/hadoop-scripts/ip-address.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-ip -o -4 a show

--- a/dumper/app/src/main/resources/hadoop-scripts/ls-usr-local-lib.sh
+++ b/dumper/app/src/main/resources/hadoop-scripts/ls-usr-local-lib.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-ls -l /usr/local/lib

--- a/dumper/app/src/main/resources/hadoop-scripts/ls-var-log.sh
+++ b/dumper/app/src/main/resources/hadoop-scripts/ls-var-log.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-ls -l /var/log

--- a/dumper/app/src/main/resources/hadoop-scripts/os-release.sh
+++ b/dumper/app/src/main/resources/hadoop-scripts/os-release.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-cat /etc/os-release

--- a/dumper/app/src/main/resources/hadoop-scripts/single-line-scripts.json
+++ b/dumper/app/src/main/resources/hadoop-scripts/single-line-scripts.json
@@ -1,0 +1,6 @@
+{
+  "ip-address": "ip -o -4 a show",
+  "ls-usr-local-lib": "ls -l /usr/local/lib",
+  "ls-var-log": "ls -l /var/log",
+  "os-release": "cat /etc/os-release"
+}

--- a/dumper/app/src/main/resources/hadoop-scripts/single-line-scripts.txt
+++ b/dumper/app/src/main/resources/hadoop-scripts/single-line-scripts.txt
@@ -1,4 +1,0 @@
-ip-address: ip -o -4 a show
-ls-usr-local-lib: ls -l /usr/local/lib
-ls-var-log: ls -l /var/log
-os-release: cat /etc/os-release

--- a/dumper/app/src/main/resources/hadoop-scripts/single-line-scripts.txt
+++ b/dumper/app/src/main/resources/hadoop-scripts/single-line-scripts.txt
@@ -1,0 +1,4 @@
+ip-address: ip -o -4 a show
+ls-usr-local-lib: ls -l /usr/local/lib
+ls-var-log: ls -l /var/log
+os-release: cat /etc/os-release

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
@@ -17,8 +17,10 @@
 package com.google.edwmigration.dumper.application.dumper.connector.hadoop;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,5 +61,18 @@ public class HadoopScriptsTest {
 
     // Assert
     assertArrayEquals(HadoopScripts.read(scriptFilename), Files.readAllBytes(extractedFile));
+  }
+
+  @Test
+  public void extractSingleLineScript_success() throws IOException {
+    String scriptName = "os-release";
+
+    // Act
+    extractedFile = HadoopScripts.extractSingleLineScript(scriptName);
+
+    // Assert
+    assertEquals(
+        ImmutableList.of("#!/bin/bash", "", "cat /etc/os-release"),
+        Files.readAllLines(extractedFile));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopScriptsTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -64,15 +66,46 @@ public class HadoopScriptsTest {
   }
 
   @Test
-  public void extractSingleLineScript_success() throws IOException {
-    String scriptName = "os-release";
-
-    // Act
-    extractedFile = HadoopScripts.extractSingleLineScript(scriptName);
-
-    // Assert
+  public void extractSingleLineScripts_allScriptsPresent() {
+    ImmutableMap<String, Path> singleLineScripts = HadoopScripts.extractSingleLineScripts();
     assertEquals(
-        ImmutableList.of("#!/bin/bash", "", "cat /etc/os-release"),
-        Files.readAllLines(extractedFile));
+        ImmutableSet.of("ip-address", "os-release", "ls-var-log", "ls-usr-local-lib"),
+        singleLineScripts.keySet());
+  }
+
+  @Test
+  public void extractSingleLineScripts_allScriptsStartWithShebangAndBlankLine() {
+    HadoopScripts.extractSingleLineScripts()
+        .forEach(
+            (scriptName, scriptFile) -> {
+              ImmutableList<String> lines = readAllLines(scriptFile);
+              assertEquals("#!/bin/bash", lines.get(0));
+              assertTrue(lines.get(1).isEmpty());
+            });
+  }
+
+  @Test
+  public void extractSingleLineScripts_allScriptsHaveThreeLines() {
+    HadoopScripts.extractSingleLineScripts()
+        .forEach(
+            (scriptName, scriptFile) -> {
+              ImmutableList<String> lines = readAllLines(scriptFile);
+              assertEquals(3, lines.size());
+            });
+  }
+
+  @Test
+  public void extractSingleLineScripts_osRelease() {
+    ImmutableList<String> osReleaseScript =
+        readAllLines(HadoopScripts.extractSingleLineScripts().get("os-release"));
+    assertEquals(ImmutableList.of("#!/bin/bash", "", "cat /etc/os-release"), osReleaseScript);
+  }
+
+  private static ImmutableList<String> readAllLines(Path path) {
+    try {
+      return ImmutableList.copyOf(Files.readAllLines(path));
+    } catch (IOException e) {
+      throw new IllegalStateException(String.format("Error reading file '%s'.", path), e);
+    }
   }
 }


### PR DESCRIPTION
Some of the bash scripts are short enough to fit in a single line. It will be easier to add new scripts if they are grouped in a single JSON file. Besides that, they work the same as the other scripts saved in individual files, i.e. they are executed as separate bash scripts and they produce the same format of the output.