### PR TITLE
[b/356467392] Remove MIGRATION_METADATA flag

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/AbstractHiveConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/AbstractHiveConnector.java
@@ -253,9 +253,7 @@ public abstract class AbstractHiveConnector extends AbstractConnector {
             + " SASL connection between hadoop and the dumper. Allowed values: '"
             + HadoopRpcProtection.ALLOWED_VALUES
             + "'.",
-        HadoopRpcProtection.PRIVACY.name()),
-    MIGRATION_METADATA(
-        "migration.metadata", "Extraction of the metadata necessary for migration.", "false");
+        HadoopRpcProtection.PRIVACY.name());
 
     private final String name;
     private final String description;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -64,7 +64,6 @@ import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.apache.commons.csv.CSVPrinter;
-import org.apache.commons.lang3.BooleanUtils;
 import org.apache.thrift.TBase;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -693,19 +692,15 @@ public class HiveMetadataConnector extends AbstractHiveConnector
 
     out.add(new SchemataTask(databasePredicate));
     out.add(new FunctionsTask(databasePredicate));
-    if (BooleanUtils.toBoolean(
-        arguments.getDefinitionOrDefault(HiveConnectorProperty.MIGRATION_METADATA))) {
-      out.add(new CatalogsJsonlTask());
-      out.add(new DatabasesJsonlTask());
-      out.add(new MasterKeysTask());
-      out.add(new DelegationTokensTask());
-      out.add(new FunctionsJsonlTask());
-      out.add(new ResourcePlansJsonlTask());
-      out.add(new TablesRawJsonlTask(databasePredicate));
-      out.add(new PartitionsJsonlTask());
-    } else {
-      out.add(new TablesJsonTask(databasePredicate, shouldDumpPartitions));
-    }
+    out.add(new CatalogsJsonlTask());
+    out.add(new DatabasesJsonlTask());
+    out.add(new MasterKeysTask());
+    out.add(new DelegationTokensTask());
+    out.add(new FunctionsJsonlTask());
+    out.add(new ResourcePlansJsonlTask());
+    out.add(new TablesRawJsonlTask(databasePredicate));
+    out.add(new PartitionsJsonlTask());
+    out.add(new TablesJsonTask(databasePredicate, shouldDumpPartitions));
 
     if (arguments.isAssessment()) {
       out.add(new DatabasesTask(databasePredicate));


### PR DESCRIPTION
The flag was added only temporarily for testing the new format of the hive dump. It is no longer needed.