### PR TITLE
ParallelTaskGroup fixes

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -43,7 +43,7 @@ public class ParallelTaskGroup extends TaskGroup {
     super.addTask(task);
   }
 
-  private static class TaskRunner<T> implements Callable<T> {
+  private static class TaskRunner<T> {
 
     private final TaskRunContext context;
     private final Task<T> task;
@@ -55,7 +55,6 @@ public class ParallelTaskGroup extends TaskGroup {
       this.printer = printer;
     }
 
-    @Override
     public T call() throws IOException {
       T result = context.runChildTask(task);
       TaskState state = context.getTaskState(task);
@@ -73,7 +72,8 @@ public class ParallelTaskGroup extends TaskGroup {
     // We safely publish the CSVPrinter to the ExecutorManager.
     try (ExecutorManager executorManager = new ExecutorManager(context.getExecutorService())) {
       for (Task<?> task : getTasks()) {
-        executorManager.execute(new TaskRunner<>(context, task, printer));
+        TaskRunner<?> runner = new TaskRunner<>(context, task, printer);
+        executorManager.execute(runner::call);
       }
     }
     // We now, by the t-w-r, safely collect the CSVPrinter from the sub-threads.

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -22,6 +22,8 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.concurrent.ExecutorManager;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.apache.commons.csv.CSVPrinter;
 
 public class ParallelTaskGroup extends TaskGroup {
@@ -45,17 +47,20 @@ public class ParallelTaskGroup extends TaskGroup {
 
   private static class TaskRunner {
 
+    @Nonnull
     private final TaskRunContext context;
+    @Nonnull
     private final Task<?> task;
+    @Nonnull
     private final CSVPrinter printer;
 
-    public TaskRunner(TaskRunContext context, Task<?> task, CSVPrinter printer) {
+    public TaskRunner(@Nonnull TaskRunContext context, @Nonnull Task<?> task, @Nonnull CSVPrinter printer) {
       this.context = context;
       this.task = task;
       this.printer = printer;
     }
 
-    public Object call() throws IOException {
+    public @Nullable Object call() throws IOException {
       Object result = context.runChildTask(task);
       TaskState state = context.getTaskState(task);
       synchronized (printer) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -19,6 +19,8 @@ package com.google.edwmigration.dumper.application.dumper.task;
 import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.plugin.ext.jdk.concurrent.ExecutorManager;
+
+import java.io.IOException;
 import java.util.concurrent.Callable;
 import org.apache.commons.csv.CSVPrinter;
 
@@ -54,7 +56,7 @@ public class ParallelTaskGroup extends TaskGroup {
     }
 
     @Override
-    public T call() throws Exception {
+    public T call() throws IOException {
       T result = context.runChildTask(task);
       TaskState state = context.getTaskState(task);
       synchronized (printer) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -22,7 +22,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.concurrent.ExecutorManager;
 import java.util.concurrent.Callable;
 import org.apache.commons.csv.CSVPrinter;
 
-// Redshift is really slow, and is the only thing that uses this.
 public class ParallelTaskGroup extends TaskGroup {
 
   public ParallelTaskGroup(String name) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -43,20 +43,20 @@ public class ParallelTaskGroup extends TaskGroup {
     super.addTask(task);
   }
 
-  private static class TaskRunner<T> {
+  private static class TaskRunner {
 
     private final TaskRunContext context;
-    private final Task<T> task;
+    private final Task<?> task;
     private final CSVPrinter printer;
 
-    public TaskRunner(TaskRunContext context, Task<T> task, CSVPrinter printer) {
+    public TaskRunner(TaskRunContext context, Task<?> task, CSVPrinter printer) {
       this.context = context;
       this.task = task;
       this.printer = printer;
     }
 
-    public T call() throws IOException {
-      T result = context.runChildTask(task);
+    public Object call() throws IOException {
+      Object result = context.runChildTask(task);
       TaskState state = context.getTaskState(task);
       synchronized (printer) {
         printer.printRecord(task, state);
@@ -72,7 +72,7 @@ public class ParallelTaskGroup extends TaskGroup {
     // We safely publish the CSVPrinter to the ExecutorManager.
     try (ExecutorManager executorManager = new ExecutorManager(context.getExecutorService())) {
       for (Task<?> task : getTasks()) {
-        TaskRunner<?> runner = new TaskRunner<>(context, task, printer);
+        TaskRunner runner = new TaskRunner(context, task, printer);
         executorManager.execute(runner::call);
       }
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.plugin.ext.jdk.concurrent.ExecutorManager;
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
 import org.apache.commons.csv.CSVPrinter;
 
@@ -67,7 +68,7 @@ public class ParallelTaskGroup extends TaskGroup {
   @Override
   protected void doRun(
       @Nonnull TaskRunContext context, @Nonnull CSVPrinter printer, @Nonnull Handle handle)
-      throws Exception {
+      throws ExecutionException, InterruptedException {
     // Throws ExecutionException if any sub-task threw. However, runChildTask() is nothrow, so that
     // never happens.
     // We safely publish the CSVPrinter to the ExecutorManager.

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -19,9 +19,8 @@ package com.google.edwmigration.dumper.application.dumper.task;
 import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.plugin.ext.jdk.concurrent.ExecutorManager;
-
 import java.io.IOException;
-import java.util.concurrent.Callable;
+import javax.annotation.Nonnull;
 import org.apache.commons.csv.CSVPrinter;
 
 public class ParallelTaskGroup extends TaskGroup {
@@ -66,7 +65,9 @@ public class ParallelTaskGroup extends TaskGroup {
   }
 
   @Override
-  protected void doRun(TaskRunContext context, CSVPrinter printer, Handle handle) throws Exception {
+  protected void doRun(
+      @Nonnull TaskRunContext context, @Nonnull CSVPrinter printer, @Nonnull Handle handle)
+      throws Exception {
     // Throws ExecutionException if any sub-task threw. However, runChildTask() is nothrow, so that
     // never happens.
     // We safely publish the CSVPrinter to the ExecutorManager.

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import org.apache.commons.csv.CSVPrinter;
 
 public class ParallelTaskGroup extends TaskGroup {
@@ -47,14 +46,12 @@ public class ParallelTaskGroup extends TaskGroup {
 
   private static class TaskRunner {
 
-    @Nonnull
-    private final TaskRunContext context;
-    @Nonnull
-    private final Task<?> task;
-    @Nonnull
-    private final CSVPrinter printer;
+    @Nonnull private final TaskRunContext context;
+    @Nonnull private final Task<?> task;
+    @Nonnull private final CSVPrinter printer;
 
-    public TaskRunner(@Nonnull TaskRunContext context, @Nonnull Task<?> task, @Nonnull CSVPrinter printer) {
+    public TaskRunner(
+        @Nonnull TaskRunContext context, @Nonnull Task<?> task, @Nonnull CSVPrinter printer) {
       this.context = context;
       this.task = task;
       this.printer = printer;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -66,15 +66,13 @@ public class ParallelTaskGroup extends TaskGroup {
   }
 
   @Override
-  @SuppressWarnings(
-      "FutureReturnValueIgnored") // It's an ExecutorManager, which tracks the Future internally.
   protected void doRun(TaskRunContext context, CSVPrinter printer, Handle handle) throws Exception {
     // Throws ExecutionException if any sub-task threw. However, runChildTask() is nothrow, so that
     // never happens.
     // We safely publish the CSVPrinter to the ExecutorManager.
     try (ExecutorManager executorManager = new ExecutorManager(context.getExecutorService())) {
       for (Task<?> task : getTasks()) {
-        executorManager.submit(new TaskRunner<>(context, task, printer));
+        executorManager.execute(new TaskRunner<>(context, task, printer));
       }
     }
     // We now, by the t-w-r, safely collect the CSVPrinter from the sub-threads.


### PR DESCRIPTION
- use the correct ExecutorManager method, rather than suppressing a warning
- remove a comment with incorrect information about ParallelTaskGroup being used only for Redshift (it is also used for Greenplum)
- (x2) replace `throws Exception` with a more precise declaration
- remove redundant extension of `Callable`
- remove redundant generics
- add missing annotations