### PR TITLE
[b/352490642] Add child connectors to metadata yaml

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/ClouderaConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/ClouderaConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.cloudera;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.hdfs.HdfsExtractionConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.hive.HiveMetadataConnector;
@@ -26,6 +27,7 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 
 @AutoService(Connector.class)
 @Description("Dumps metadata from the Cloudera (Hadoop on-prem) cluster.")
+@RespectsArgumentAssessment
 public class ClouderaConnector extends AbstractMetaConnector {
 
   public ClouderaConnector() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionConnector.java
@@ -72,7 +72,7 @@ public class HdfsExtractionConnector extends AbstractConnector
   @Override
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments args)
       throws Exception {
-    out.add(new DumpMetadataTask(args, FORMAT_NAME));
+    out.add(new DumpMetadataTask(FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
 
     out.add(new HdfsExtractionTask(args));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/meta/AbstractMetaConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/meta/AbstractMetaConnector.java
@@ -63,7 +63,7 @@ public abstract class AbstractMetaConnector implements Connector {
   @Override
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception {
-    out.add(new DumpMetadataTask(arguments, format, underlyingConnectors));
+    out.add(DumpMetadataTask.create(arguments, format, underlyingConnectors));
     out.add(new FormatTask(format));
     for (String connectorName : underlyingConnectors) {
       ChildConnector childConnector = getChildConnector(connectorName);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/meta/AbstractMetaConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/meta/AbstractMetaConnector.java
@@ -63,7 +63,7 @@ public abstract class AbstractMetaConnector implements Connector {
   @Override
   public void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws Exception {
-    out.add(new DumpMetadataTask(arguments, format));
+    out.add(new DumpMetadataTask(arguments, format, underlyingConnectors));
     out.add(new FormatTask(format));
     for (String connectorName : underlyingConnectors) {
       ChildConnector childConnector = getChildConnector(connectorName);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/DumpMetadataTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/DumpMetadataTask.java
@@ -39,26 +39,28 @@ public class DumpMetadataTask extends AbstractTask<Void>
   @Nullable private final ImmutableList<String> connectors;
 
   public DumpMetadataTask(@Nonnull ConnectorArguments arguments, @Nonnull String format) {
-    this(format, arguments, /* connectors= */ null);
-  }
-
-  public DumpMetadataTask(
-      @Nonnull ConnectorArguments arguments, @Nonnull String format, List<String> connectors) {
-    this(format, arguments, connectors);
+    this(arguments, format, /* connectors= */ null);
   }
 
   public DumpMetadataTask(@Nonnull String format) {
-    this(format, /* arguments= */ null, /* connectors= */ null);
+    this(/* arguments= */ null, format, /* connectors= */ null);
   }
 
   private DumpMetadataTask(
-      @Nonnull String format,
       @Nullable ConnectorArguments arguments,
+      @Nonnull String format,
       @Nullable List<String> connectors) {
     super(ZIP_ENTRY_NAME);
     this.arguments = arguments;
     this.format = Preconditions.checkNotNull(format, "Format was null.");
     this.connectors = connectors != null ? ImmutableList.copyOf(connectors) : null;
+  }
+
+  public static DumpMetadataTask create(
+      @Nonnull ConnectorArguments arguments,
+      @Nonnull String format,
+      @Nonnull List<String> connectors) {
+    return new DumpMetadataTask(arguments, format, connectors);
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/DumpMetadataTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/DumpMetadataTask.java
@@ -17,12 +17,14 @@
 package com.google.edwmigration.dumper.application.dumper.task;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.anarres.jdiagnostics.ProductMetadata;
@@ -34,18 +36,29 @@ public class DumpMetadataTask extends AbstractTask<Void>
   @Nullable private final ConnectorArguments arguments;
   private final String format;
 
+  @Nullable private final ImmutableList<String> connectors;
+
   public DumpMetadataTask(@Nonnull ConnectorArguments arguments, @Nonnull String format) {
-    this(format, arguments);
+    this(format, arguments, /* connectors= */ null);
+  }
+
+  public DumpMetadataTask(
+      @Nonnull ConnectorArguments arguments, @Nonnull String format, List<String> connectors) {
+    this(format, arguments, connectors);
   }
 
   public DumpMetadataTask(@Nonnull String format) {
-    this(format, null);
+    this(format, /* arguments= */ null, /* connectors= */ null);
   }
 
-  private DumpMetadataTask(@Nonnull String format, @Nullable ConnectorArguments arguments) {
+  private DumpMetadataTask(
+      @Nonnull String format,
+      @Nullable ConnectorArguments arguments,
+      @Nullable List<String> connectors) {
     super(ZIP_ENTRY_NAME);
     this.arguments = arguments;
     this.format = Preconditions.checkNotNull(format, "Format was null.");
+    this.connectors = connectors != null ? ImmutableList.copyOf(connectors) : null;
   }
 
   @Override
@@ -58,6 +71,7 @@ public class DumpMetadataTask extends AbstractTask<Void>
       Product product = new Product();
       product.version = String.valueOf(new ProductMetadata());
       product.arguments = String.valueOf(getArguments(context));
+      product.connectors = connectors;
       root.product = product;
     }
 

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/CoreMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/CoreMetadataDumpFormat.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import java.util.List;
 
 /** @author shevek */
 public interface CoreMetadataDumpFormat {
@@ -51,6 +52,7 @@ public interface CoreMetadataDumpFormat {
 
       public String version;
       public String arguments;
+      public List<String> connectors;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
This PR adds the `connectors` attribute in the `compilerworks-metadata.yaml` file:
```
  connectors:
  - "cloudera-metadata"
  - "hiveql"
  - "hdfs"
```

The sample of the whole file with the new `connectors` attribute (irrelevant parts omitted):
```
format: "cloudera.zip"
timestamp: 1724795274133
product:
  version: |
    API Common:2.34.0
    ...
  arguments: "ConnectorArguments{connector=cloudera, ...}"
  connectors:
  - "cloudera-metadata"
  - "hiveql"
  - "hdfs"
```