### PR TITLE
Cleanup loggers in HDFS connector

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionConnector.java
@@ -34,8 +34,6 @@ import java.time.Clock;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RespectsInput(
     order = 100,
@@ -55,7 +53,6 @@ import org.slf4j.LoggerFactory;
 @Description("Dumps files and directories from the HDFS.")
 public class HdfsExtractionConnector extends AbstractConnector
     implements HdfsExtractionDumpFormat, ChildConnector {
-  static final Logger LOG = LoggerFactory.getLogger(HdfsExtractionConnector.class);
 
   public static final String CONNECTOR_NAME = "hdfs";
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionTask.java
@@ -16,7 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.hdfs;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.hdfs.HdfsExtractionConnector.LOG;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -39,8 +38,12 @@ import javax.annotation.Nonnull;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class HdfsExtractionTask extends AbstractTask<Void> implements HdfsExtractionDumpFormat {
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsExtractionTask.class);
+
   private final int poolSize;
 
   HdfsExtractionTask(@Nonnull ConnectorArguments args) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsHandle.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.connector.hdfs;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.edwmigration.dumper.application.dumper.connector.hdfs.HdfsExtractionConnector.LOG;
 
 import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -27,8 +26,12 @@ import javax.annotation.Nonnull;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class HdfsHandle implements Handle {
+  private static final Logger LOG = LoggerFactory.getLogger(HdfsHandle.class);
+
   private final String clusterHost;
   private final int port;
   private final DistributedFileSystem dfs;
@@ -38,8 +41,8 @@ class HdfsHandle implements Handle {
     clusterHost = args.getHostOrDefault();
     port = args.getPort(/* defaultPort= */ 8020);
 
-    LOG.info("clusterHost: {}", clusterHost);
-    LOG.info("port: {}", port);
+    LOG.info("clusterHost: '{}'", clusterHost);
+    LOG.info("port: '{}'", port);
 
     Configuration conf = new Configuration();
     conf.set("fs.defaultFS", "hdfs://" + clusterHost + ":" + port + "/");

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/SingleDirScanJob.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/SingleDirScanJob.java
@@ -55,10 +55,11 @@ class SingleDirScanJob implements Callable<Void> {
         }
       }
       scanCtx.endWalkDir(dir, numFiles, numDirs, accumFileSize);
-    } catch (Exception exn) {
+    } catch (Exception e) {
       LOG.error(
-          "Unexpected exception while scanning HDFS folder " + dir.getPath().toUri().getPath(),
-          exn);
+          "Unexpected exception while scanning HDFS folder '{}'",
+          dir.getPath().toUri().getPath(),
+          e);
     }
     return null;
   }


### PR DESCRIPTION
As per convention, the logger is instantiated in the class it is used in (with rare exceptions like progress logger).

Also, use placeholder instead of string concatenation in logger.