### PR TITLE
[b/364035944] Prevent a NullPointerException where a result's toString has returned null

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -41,6 +41,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.sql.DataSource;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
@@ -57,7 +58,6 @@ import org.springframework.jdbc.support.JdbcUtils;
 /** @author shevek */
 public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
 
-  @SuppressWarnings("UnusedVariable")
   private static final Logger LOG = LoggerFactory.getLogger(AbstractJdbcTask.class);
 
   @CheckForNull private Class<? extends Enum<?>> headerClass;
@@ -143,15 +143,26 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
       while (resultSet.next()) {
         monitor.count();
         for (int i = 1; i <= columnCount; i++) {
-          Object object = resultSet.getObject(i);
-          printer.print(convertObject(object));
+          Object resultItem = resultSet.getObject(i);
+          String csvCandidate = fromByteBufferOrClob(resultItem);
+          String itemString;
+          if (csvCandidate != null || resultItem == null) {
+            printer.print(csvCandidate);
+          } else if ((itemString = resultItem.toString()) == null) {
+            Class<?> itemClass = resultItem.getClass();
+            LOG.warn("Unexpected toString result for class {} - null", itemClass);
+            printer.print(null);
+          } else {
+            printer.print(itemString);
+          }
         }
         printer.println();
       }
     }
   }
 
-  private static Object convertObject(Object object) throws IOException, SQLException {
+  @Nullable
+  private static String fromByteBufferOrClob(Object object) throws IOException, SQLException {
     if (object instanceof byte[]) {
       return Base64.getEncoder().encodeToString((byte[]) object);
     } else if (object instanceof Clob) {
@@ -159,10 +170,8 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
       StringWriter w = new StringWriter();
       IOUtils.copy(in, w);
       return w.toString();
-    } else if (object != null && object.toString() == null) {
-      return null;
     } else {
-      return object;
+      return null;
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -159,6 +159,8 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
       StringWriter w = new StringWriter();
       IOUtils.copy(in, w);
       return w.toString();
+    } else if (object != null && object.toString() == null) {
+      return null;
     } else {
       return object;
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -144,11 +144,13 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
         monitor.count();
         for (int i = 1; i <= columnCount; i++) {
           Object resultItem = resultSet.getObject(i);
-          String csvCandidate = fromByteBufferOrClob(resultItem);
+          String csvItemCandidate = fromByteBufferOrClob(resultItem);
           String itemString;
-          if (csvCandidate != null || resultItem == null) {
-            printer.print(csvCandidate);
+          if (csvItemCandidate != null || resultItem == null) {
+            // Item was recognized by the helper method or it was null.
+            printer.print(csvItemCandidate);
           } else if ((itemString = resultItem.toString()) == null) {
+            // Item violated usual toStringRules
             Class<?> itemClass = resultItem.getClass();
             LOG.warn("Unexpected toString result for class {} - null", itemClass);
             printer.print(null);


### PR DESCRIPTION
If there is an object in the ResultSet, for which `toString` returns null, the task involving the object may fail, depending on the specific class of this object.

In all cases where a ResultSet element object's `toString` would return null, replace the object with null, which will be written as an empty csv item without error.