### PR TITLE
Output first and last query log entries for Teradata with a new task

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -260,6 +260,12 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
 
       addFailFastValidationStepForAssesment(out, arguments, utilityLogsTable);
 
+      out.add(
+          new TeradataQueryLogsJdbcTask(
+              arguments.getQueryLogStart(),
+              arguments.getQueryLogEndOrDefault(),
+              tableNames.queryLogsTableName()));
+
       for (ZonedInterval interval : intervals) {
         String file = createFilename(ZIP_ENTRY_PREFIX, interval);
         List<String> orderBy = Arrays.asList("ST.QueryID", "ST.SQLRowNo");

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -45,7 +45,6 @@ import com.google.edwmigration.dumper.application.dumper.utils.PropertyParser;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.TeradataLogsDumpFormat;
 import java.time.Duration;
-import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -287,8 +286,9 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
       out.add(
           new TeradataQueryLogsJdbcTask(
               "queryLogsFirstAndLastEntry.csv",
-              sqlForQueryLogDates(
-                  tableNames.queryLogsTableName(), intervals.getStart(), intervals.getEnd())));
+              tableNames.queryLogsTableName(),
+              intervals.getStart(),
+              intervals.getEnd()));
     } else {
       for (ZonedInterval interval : intervals) {
         String file = createFilename(ZIP_ENTRY_PREFIX, interval);
@@ -314,17 +314,5 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
     }
 
     out.add(new TeradataTablesValidatorTask(optionalTablesToCheck.toArray(new String[] {})));
-  }
-
-  private String sqlForQueryLogDates(
-      String queryLogsTableName, ZonedDateTime queryLogStartDate, ZonedDateTime queryLogEndDate) {
-    String sql =
-        String.format(
-            "SELECT MIN(StartTime), MAX(StartTime) FROM %s WHERE ErrorCode = 0"
-                + " AND StartTime >= CAST('%s' AS TIMESTAMP) AND StartTime < CAST('%s' AS TIMESTAMP)",
-            queryLogsTableName,
-            SQL_FORMAT.format(queryLogStartDate),
-            SQL_FORMAT.format(queryLogEndDate));
-    return sql;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -320,8 +320,8 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
       String queryLogsTableName, ZonedDateTime queryLogStartDate, ZonedDateTime queryLogEndDate) {
     String sql =
         String.format(
-            "SELECT MIN(StartTime) as queryLogFirstEntry, MAX(StartTime) as queryLogLastEntry FROM '%s' WHERE ErrorCode = 0 AND\n"
-                + "StartTime >= CAST('%s' AS TIMESTAMP) AND L.StartTime < CAST('%s' AS TIMESTAMP)\n",
+            "SELECT MIN(StartTime), MAX(StartTime) FROM %s WHERE ErrorCode = 0"
+                + " AND StartTime >= CAST('%s' AS TIMESTAMP) AND StartTime < CAST('%s' AS TIMESTAMP)",
             queryLogsTableName,
             SQL_FORMAT.format(queryLogStartDate),
             SQL_FORMAT.format(queryLogEndDate));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -288,9 +288,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
           new TeradataQueryLogsJdbcTask(
               "queryLogsFirstAndLastEntry.csv",
               sqlForQueryLogDates(
-                  tableNames.queryLogsTableName(),
-                  arguments.getQueryLogStart(),
-                  arguments.getQueryLogEndOrDefault())));
+                  tableNames.queryLogsTableName(), intervals.getStart(), intervals.getEnd())));
     } else {
       for (ZonedInterval interval : intervals) {
         String file = createFilename(ZIP_ENTRY_PREFIX, interval);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -261,10 +261,6 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
 
       addFailFastValidationStepForAssesment(out, arguments, utilityLogsTable);
 
-      LOG.info(
-          "Extracting query logs first and last entries from tables: '%s'",
-          tableNames.queryLogsTableName());
-
       for (ZonedInterval interval : intervals) {
         String file = createFilename(ZIP_ENTRY_PREFIX, interval);
         List<String> orderBy = Arrays.asList("ST.QueryID", "ST.SQLRowNo");

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
@@ -44,7 +44,7 @@ public class TeradataQueryLogsJdbcTask extends JdbcSelectTask {
       @Nonnull Connection connection)
       throws SQLException {
 
-    LOG.info("Starting getting first and last entry of query logs from");
+    LOG.info("Getting first and last query log entry");
     ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
     Summary summary = doSelect(connection, rse, getSql());
     LOG.info("Result of getting first and last entry is '%s", summary);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
@@ -44,27 +44,9 @@ public class TeradataQueryLogsJdbcTask extends JdbcSelectTask {
       @Nonnull Connection connection)
       throws SQLException {
 
-    LOG.info("Getting first and last query log entry");
+    LOG.info("Getting first and last query log entries");
     ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
     Summary summary = doSelect(connection, rse, getSql());
-    LOG.info("Result of getting first and last entry is '%s", summary);
-    return null;
+    return summary;
   }
-
-  // protected ResultSetExtractor<TeradataQueryLogResults> newResultSetExtractor(
-  //     @Nonnull ByteSink sink) {
-  //   return new ResultSetExtractor<TeradataQueryLogResults>() {
-  //     @Override
-  //     public TeradataQueryLogResults extractData(ResultSet rs)
-  //         throws SQLException, DataAccessException {
-  //       TeradataQueryLogResults out = new TeradataQueryLogResults();
-  //       try (Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
-
-  //         return out;
-  //       } catch (IOException e) {
-  //         throw new SQLException(e);
-  //       }
-  //     }
-  //   };
-  // }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
@@ -16,37 +16,134 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
-import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
-import com.google.edwmigration.dumper.application.dumper.task.Summary;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.sql.Clob;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
-public class TeradataQueryLogsJdbcTask extends JdbcSelectTask {
+public class TeradataQueryLogsJdbcTask extends AbstractJdbcTask<Void> {
 
   private static final Logger LOG = LoggerFactory.getLogger(TeradataQueryLogsJdbcTask.class);
+  private ZonedDateTime queryLogStartDate, queryLogEndDate;
+  private final String tableName;
+  private final DateTimeFormatter SQL_FORMAT =
+      DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
 
-  public TeradataQueryLogsJdbcTask(String targetPath, String sql) {
-    super(targetPath, sql);
+  public TeradataQueryLogsJdbcTask(
+      String targetPath,
+      String tableName,
+      ZonedDateTime queryLogStartDate,
+      ZonedDateTime queryLogEndDate) {
+    super(targetPath);
+    this.tableName = tableName;
+    this.queryLogStartDate = queryLogStartDate;
+    this.queryLogEndDate = queryLogEndDate;
   }
 
+  @CheckForNull
   @Override
-  protected Summary doInConnection(
+  protected Void doInConnection(
       @Nonnull TaskRunContext context,
       @Nonnull JdbcHandle jdbcHandle,
       @Nonnull ByteSink sink,
       @Nonnull Connection connection)
       throws SQLException {
-
     LOG.info("Getting first and last query log entries");
-    ResultSetExtractor<Summary> rse = newCsvResultSetExtractor(sink);
-    Summary summary = doSelect(connection, rse, getSql());
-    return summary;
+
+    String[] queryLogsFirstAndLastEntries = new String[2];
+    String sql = sqlForQueryLogDates(tableName, queryLogStartDate, queryLogEndDate);
+    doSelect(connection, newCsvResultSetExtractor(sink, queryLogsFirstAndLastEntries), sql);
+
+    LOG.info(
+        "The first query log entry is {} UTC and the last query log entry is {} UTC",
+        queryLogsFirstAndLastEntries[0],
+        queryLogsFirstAndLastEntries[1]);
+
+    return null;
+  }
+
+  private ResultSetExtractor<Void> newCsvResultSetExtractor(
+      @Nonnull ByteSink sink, String[] queryLogsFirstAndLastEntries) {
+    return rs -> {
+      try {
+        printAllResults(sink, rs, queryLogsFirstAndLastEntries);
+        return null;
+      } catch (IOException e) {
+        throw new SQLException(e);
+      }
+    };
+  }
+
+  private void printAllResults(
+      ByteSink sink, ResultSet resultSet, String[] queryLogsFirstAndLastEntries)
+      throws IOException, SQLException {
+    try (Writer writer = sink.asCharSink(UTF_8).openBufferedStream()) {
+      int columnCount = resultSet.getMetaData().getColumnCount();
+      int index = 0;
+      while (resultSet.next()) {
+        for (int i = 1; i <= columnCount; i++) {
+          Object resultItem = resultSet.getObject(i);
+          String csvItemCandidate = fromByteBufferOrClob(resultItem);
+          String itemString;
+          if (csvItemCandidate != null || resultItem == null) {
+            // Item was recognized by the helper method or it was null.
+            LOG.info(csvItemCandidate);
+          } else if ((itemString = resultItem.toString()) == null) {
+            // Item violated usual toStringRules
+            Class<?> itemClass = resultItem.getClass();
+            LOG.warn("Unexpected toString result for class {} - null", itemClass);
+          } else {
+            queryLogsFirstAndLastEntries[index++] = itemString;
+          }
+        }
+      }
+    }
+  }
+
+  @Nullable
+  private static String fromByteBufferOrClob(Object object) throws IOException, SQLException {
+    if (object instanceof byte[]) {
+      return Base64.getEncoder().encodeToString((byte[]) object);
+    } else if (object instanceof Clob) {
+      InputStream in = ((Clob) object).getAsciiStream();
+      StringWriter w = new StringWriter();
+      IOUtils.copy(in, w);
+      return w.toString();
+    } else {
+      return null;
+    }
+  }
+
+  private String sqlForQueryLogDates(
+      String queryLogsTableName, ZonedDateTime queryLogStartDate, ZonedDateTime queryLogEndDate) {
+    String sql =
+        String.format(
+            "SELECT MIN(StartTime), MAX(StartTime) FROM %s WHERE ErrorCode = 0"
+                + " AND StartTime >= CAST('%s' AS TIMESTAMP) AND StartTime < CAST('%s' AS TIMESTAMP)",
+            queryLogsTableName,
+            SQL_FORMAT.format(queryLogStartDate),
+            SQL_FORMAT.format(queryLogEndDate));
+    return sql;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
@@ -30,7 +30,6 @@ import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,10 +57,7 @@ public class TeradataQueryLogsJdbcTask extends AbstractJdbcTask<QueryLogEntries>
 
   @Override
   protected QueryLogEntries doInConnection(
-      @Nonnull TaskRunContext context,
-      @Nonnull JdbcHandle jdbcHandle,
-      @Nonnull ByteSink sink,
-      @Nonnull Connection connection)
+      TaskRunContext context, JdbcHandle jdbcHandle, ByteSink sink, Connection connection)
       throws SQLException {
     LOG.info("Getting first and last query log entries");
     String sql = sqlForQueryLogDates(tableName, queryLogStartDate, queryLogEndDate);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.teradata;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteSink;
+import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import javax.annotation.Nonnull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TeradataQueryLogsJdbcTask extends AbstractJdbcTask<TeradataQueryLogResults> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TeradataQueryLogsJdbcTask.class);
+  private static final DateTimeFormatter SQL_FORMAT =
+      DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
+
+  private String queryLogsTableName;
+  private ZonedDateTime queryLogStartDate, queryLogEndDate;
+
+  public TeradataQueryLogsJdbcTask(
+      ZonedDateTime queryLogStartDate, ZonedDateTime queryLogEndDate, String queryLogTableNames) {
+    super(
+        TeradataQueryLogsJdbcTask.class.getSimpleName() + ".txt",
+        TargetInitialization.DO_NOT_CREATE);
+    Preconditions.checkNotNull(queryLogTableNames, "Query log table names are null");
+    this.queryLogsTableName = queryLogTableNames;
+    this.queryLogStartDate = queryLogStartDate;
+    this.queryLogEndDate = queryLogEndDate;
+  }
+
+  @Override
+  protected TeradataQueryLogResults doInConnection(
+      @Nonnull TaskRunContext context,
+      @Nonnull JdbcHandle jdbcHandle,
+      @Nonnull ByteSink sink,
+      @Nonnull Connection connection)
+      throws SQLException {
+
+    LOG.info("Getting first and last entry of query logs from '%s", queryLogsTableName);
+
+    String sql =
+        String.format(
+            "SELECT MIN(StartTime) as queryLogFirstEntry, MAX(StartTime) as queryLogLastEntry FROM '%s' WHERE ErrorCode = 0 AND\n"
+                + "StartTime >= CAST('%s' AS TIMESTAMP) AND L.StartTime < CAST('%s' AS TIMESTAMP)\n",
+            queryLogsTableName,
+            SQL_FORMAT.format(queryLogStartDate),
+            SQL_FORMAT.format(queryLogEndDate));
+
+    return null;
+  }
+}
+
+/** TeradataQueryLogResults */
+class TeradataQueryLogResults {
+  ZonedDateTime queryLogFirstEntry;
+  ZonedDateTime queryLogLastEntry;
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataQueryLogsJdbcTask.java
@@ -45,10 +45,10 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 public class TeradataQueryLogsJdbcTask extends AbstractJdbcTask<Void> {
 
   private static final Logger LOG = LoggerFactory.getLogger(TeradataQueryLogsJdbcTask.class);
-  private ZonedDateTime queryLogStartDate, queryLogEndDate;
-  private final String tableName;
   private final DateTimeFormatter SQL_FORMAT =
       DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneOffset.UTC);
+  private ZonedDateTime queryLogStartDate, queryLogEndDate;
+  private final String tableName;
 
   public TeradataQueryLogsJdbcTask(
       String targetPath,


### PR DESCRIPTION
Logging first and last query log entry for Teradata.

For this purpose created new separate task `TeradataQueryLogsJdbcTask`.

This is output of the task with query log dates:
![Screenshot 2024-10-07 at 14 19 39](https://github.com/user-attachments/assets/04aadc16-1f41-4631-a489-56b920e28504)
