### PR TITLE
More precise .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-build
+/build
+/buildSrc/build
 .svn
 .sw?
 .*.swp

--- a/dumper/app/.gitignore
+++ b/dumper/app/.gitignore
@@ -1,0 +1,2 @@
+/bin
+/build

--- a/dumper/lib-common/.gitignore
+++ b/dumper/lib-common/.gitignore
@@ -1,0 +1,2 @@
+/bin
+/build

--- a/dumper/lib-dumper-spi/.gitignore
+++ b/dumper/lib-dumper-spi/.gitignore
@@ -1,0 +1,2 @@
+/bin
+/build

--- a/dumper/lib-ext-bigquery/.gitignore
+++ b/dumper/lib-ext-bigquery/.gitignore
@@ -1,0 +1,2 @@
+/bin
+/build

--- a/dumper/lib-ext-hive-metastore/.gitignore
+++ b/dumper/lib-ext-hive-metastore/.gitignore
@@ -1,0 +1,2 @@
+/bin
+/build


### PR DESCRIPTION
### Add /bin directories of dumper app and its libs to .gitignore
This prevents them from appearing in git as unstaged changes
### Avoid false positives when the package name contains "build"
New files in e.g. the groovy scripts for license now don't need to be force added.