### PR TITLE
Remove redundant arguments from AutoService in Snowflake

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
@@ -20,11 +20,10 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 
 /** @author shevek */
-@AutoService({Connector.class, LogsConnector.class})
+@AutoService(Connector.class)
 @Description("Dumps logs from Snowflake, using ACCOUNT_USAGE only.")
 public class SnowflakeAccountUsageLogsConnector extends SnowflakeLogsConnector {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -19,14 +19,13 @@ package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.util.List;
 
 /** @author shevek */
-@AutoService({Connector.class, MetadataConnector.class})
+@AutoService(Connector.class)
 @Description("Dumps metadata from Snowflake, using ACCOUNT_USAGE only.")
 public class SnowflakeAccountUsageMetadataConnector extends SnowflakeMetadataConnector {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
@@ -20,12 +20,11 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import javax.annotation.Nonnull;
 
 /** @author shevek */
-@AutoService({Connector.class, LogsConnector.class})
+@AutoService(Connector.class)
 @Description("Dumps logs from Snowflake, using INFORMATION_SCHEMA only.")
 public class SnowflakeInformationSchemaLogsConnector extends SnowflakeLogsConnector {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -19,14 +19,13 @@ package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.util.List;
 
 /** @author shevek */
-@AutoService({Connector.class, MetadataConnector.class})
+@AutoService(Connector.class)
 @Description("Dumps metadata from Snowflake, using INFORMATION_SCHEMA only.")
 public class SnowflakeInformationSchemaMetadataConnector extends SnowflakeMetadataConnector {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -52,7 +52,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** @author shevek */
-@AutoService({Connector.class, LogsConnector.class})
+@AutoService(Connector.class)
 @Description("Dumps logs from Snowflake.")
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author matt
  */
-@AutoService({Connector.class, MetadataConnector.class})
+@AutoService(Connector.class)
 @Description("Dumps metadata from Snowflake.")
 public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     implements MetadataConnector, SnowflakeMetadataDumpFormat {


### PR DESCRIPTION
The LogsConnector and MetadataConnector classes have no effect when provided to the AutoService annotation. Keep the necessary Connector class and remove others from AutoService annotations for all Snowflake connectors.