### PR TITLE
[issue 114] improve error messages for JDBC driver

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
@@ -95,7 +95,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
     File result = new File(driverPath);
     String absolutePath = result.getAbsolutePath();
     if (!result.exists()) {
-      String message = String.format("File does not exist: '%s'", absolutePath);
+      String message = String.format("Jdbc driver does not exist: '%s'", absolutePath);
       throw new IllegalArgumentException(message);
     } else if (!result.isFile()) {
       String message =
@@ -138,22 +138,33 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
           } catch (PrivilegedActionException e) {
             if (e.getCause() instanceof ClassNotFoundException)
               LOG.warn(
-                  "Cannot load " + driverClassName + " from " + driverPaths + ": " + e.getCause());
+                  "Cannot load driver class [{}] from path {}: {}",
+                  driverClassName,
+                  driverPaths,
+                  e.getCause());
             else throw e;
           }
         }
         throw new SQLException(
-            "Failed to load any of " + Arrays.toString(driverClassNames) + " from " + driverPaths);
+            "Failed to load any driver of "
+                + Arrays.toString(driverClassNames)
+                + " from path "
+                + driverPaths);
       }
 
-      LOG.info("Using JDBC Driver " + driverClass);
+      LOG.info("Using JDBC Driver: {}", driverClass);
       return driverClass.asSubclass(Driver.class).getConstructor().newInstance();
     } catch (ReflectiveOperationException
         | PrivilegedActionException
         | MalformedURLException
         | RuntimeException e) {
       throw new SQLException(
-          "Failed to load or instantiate " + driverClass + " from " + driverPaths + ": " + e, e);
+          "Failed to load or instantiate jdbc driver: ["
+              + driverClass
+              + "] from path: "
+              + driverPaths
+              + "",
+          e);
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
@@ -95,7 +95,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
     File result = new File(driverPath);
     String absolutePath = result.getAbsolutePath();
     if (!result.exists()) {
-      String message = String.format("Jdbc driver does not exist: '%s'", absolutePath);
+      String message = String.format("Jdbc driver does not exist at : '%s'", absolutePath);
       throw new IllegalArgumentException(message);
     } else if (!result.isFile()) {
       String message =
@@ -162,8 +162,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
           "Failed to load or instantiate jdbc driver: ["
               + driverClass
               + "] from path: "
-              + driverPaths
-              + "",
+              + driverPaths,
           e);
     }
   }


### PR DESCRIPTION
The error message before:
```
java.sql.SQLException: Failed to load or instantiate null from []: java.lang.IllegalArgumentException: File does not exist: '/Users/vsidorovich/github/dwh-migration-tools/dwh-runs'
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriver(AbstractJdbcConnector.java:155)
	at com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.open(AbstractTeradataConnector.java:204)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:179)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:90)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:67)
	at com.google.edwmigration.dumper.application.dumper.Main.run(Main.java:40)
	at com.google.edwmigration.dumper.application.dumper.Main.main(Main.java:69)
Caused by: java.lang.IllegalArgumentException: File does not exist: '/Users/vsidorovich/github/dwh-migration-tools/dwh-runs'
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.getDriverUri(AbstractJdbcConnector.java:99)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriverClassLoader(AbstractJdbcConnector.java:80)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriver(AbstractJdbcConnector.java:130)
	... 6 more
********************************************************************
* ERROR
* Failed to load or instantiate null from []: java.lang.IllegalArgumentException: File does not exist: '/Users/vsidorovich/github/dwh-migration-tools/dwh-runs'
* Caused by: File does not exist: '/Users/vsidorovich/github/dwh-migration-tools/dwh-runs'
********************************************************************
```

Current error message:
```
java.sql.SQLException: Failed to load or instantiate jdbc driver: [null] from path: []
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriver(AbstractJdbcConnector.java:161)
	at com.google.edwmigration.dumper.application.dumper.connector.teradata.AbstractTeradataConnector.open(AbstractTeradataConnector.java:204)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:179)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:90)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:67)
	at com.google.edwmigration.dumper.application.dumper.Main.run(Main.java:40)
	at com.google.edwmigration.dumper.application.dumper.Main.main(Main.java:69)
Caused by: java.lang.IllegalArgumentException: Jdbc driver does not exist: '/Users/vsidorovich/github/dwh-migration-tools/dwh-runs'
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.getDriverUri(AbstractJdbcConnector.java:99)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriverClassLoader(AbstractJdbcConnector.java:80)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriver(AbstractJdbcConnector.java:130)
	... 6 more
********************************************************************
* ERROR
* Failed to load or instantiate jdbc driver: [null] from path: []
* Caused by: Jdbc driver does not exist: '/Users/vsidorovich/github/dwh-migration-tools/dwh-runs'
********************************************************************
```