### PR TITLE
Clean up class design for Snowflake Metadata

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -16,10 +16,11 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY;
+
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.util.List;
@@ -41,11 +42,6 @@ public class SnowflakeAccountUsageMetadataConnector extends SnowflakeMetadataCon
       TaskVariant is_task,
       TaskVariant au_task,
       ConnectorArguments arguments) {
-    Task<?> t0 =
-        new JdbcSelectTask(
-                au_task.zipEntryName,
-                String.format(format, au_task.schemaName, au_task.whereClause))
-            .withHeaderClass(header);
-    out.add(t0);
+    doAddSqlTasks(out, header, format, is_task, au_task, arguments, USAGE_ONLY);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -19,11 +19,8 @@ package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY;
 
 import com.google.auto.service.AutoService;
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
-import java.util.List;
 
 /** @author shevek */
 @AutoService(Connector.class)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -31,17 +31,6 @@ import java.util.List;
 public class SnowflakeAccountUsageMetadataConnector extends SnowflakeMetadataConnector {
 
   public SnowflakeAccountUsageMetadataConnector() {
-    super("snowflake-account-usage-metadata");
-  }
-
-  @Override
-  protected void addSqlTasksWithInfoSchemaFallback(
-      List<? super Task<?>> out,
-      Class<? extends Enum<?>> header,
-      String format,
-      TaskVariant is_task,
-      TaskVariant au_task,
-      ConnectorArguments arguments) {
-    doAddSqlTasks(out, header, format, is_task, au_task, arguments, USAGE_ONLY);
+    super("snowflake-account-usage-metadata", USAGE_ONLY);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -31,17 +31,6 @@ import java.util.List;
 public class SnowflakeInformationSchemaMetadataConnector extends SnowflakeMetadataConnector {
 
   public SnowflakeInformationSchemaMetadataConnector() {
-    super("snowflake-information-schema-metadata");
-  }
-
-  @Override
-  protected void addSqlTasksWithInfoSchemaFallback(
-      List<? super Task<?>> out,
-      Class<? extends Enum<?>> header,
-      String format,
-      TaskVariant is_task,
-      TaskVariant au_task,
-      ConnectorArguments arguments) {
-    doAddSqlTasks(out, header, format, is_task, au_task, arguments, SCHEMA_ONLY);
+    super("snowflake-information-schema-metadata", SCHEMA_ONLY);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -19,11 +19,8 @@ package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY;
 
 import com.google.auto.service.AutoService;
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
-import java.util.List;
 
 /** @author shevek */
 @AutoService(Connector.class)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -16,10 +16,11 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY;
+
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import java.util.List;
@@ -41,11 +42,6 @@ public class SnowflakeInformationSchemaMetadataConnector extends SnowflakeMetada
       TaskVariant is_task,
       TaskVariant au_task,
       ConnectorArguments arguments) {
-    Task<?> t0 =
-        new JdbcSelectTask(
-                is_task.zipEntryName,
-                String.format(format, is_task.schemaName, is_task.whereClause))
-            .withHeaderClass(header);
-    out.add(t0);
+    doAddSqlTasks(out, header, format, is_task, au_task, arguments, SCHEMA_ONLY);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInput.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInput.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 enum SnowflakeInput {
+  /** Adds the ACCOUNT_USAGE task, with a fallback to the INFORMATION_SCHEMA task. */
   USAGE_THEN_SCHEMA,
   SCHEMA_ONLY,
   USAGE_ONLY;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInput.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInput.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
+
+enum SnowflakeInput {
+  USAGE_THEN_SCHEMA,
+  SCHEMA_ONLY,
+  USAGE_ONLY;
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -98,7 +98,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
 
   private final SnowflakeInput inputSource;
 
-  protected SnowflakeMetadataConnector(@Nonnull String name, @Nonnull SnowflakeInput inputSource) {
+  SnowflakeMetadataConnector(@Nonnull String name, @Nonnull SnowflakeInput inputSource) {
     super(name);
     this.inputSource = inputSource;
   }
@@ -113,7 +113,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     return SnowflakeMetadataConnectorProperties.class;
   }
 
-  protected static class TaskVariant {
+  private static class TaskVariant {
 
     public final String zipEntryName;
     public final String schemaName;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -131,7 +131,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
   }
 
-  final void addSqlTasksWithInfoSchemaFallback(
+  private void addSqlTasksWithInfoSchemaFallback(
       @Nonnull List<? super Task<?>> out,
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -161,6 +161,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       case USAGE_ONLY:
         return ImmutableList.of(taskFromVariant(format, au_task, header));
     }
+    throw new AssertionError();
   }
 
   private static AbstractJdbcTask<Summary> taskFromVariant(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -97,12 +97,15 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
   }
 
-  protected SnowflakeMetadataConnector(@Nonnull String name) {
+  private final SnowflakeInput inputSource;
+
+  protected SnowflakeMetadataConnector(@Nonnull String name, @Nonnull SnowflakeInput inputSource) {
     super(name);
+    this.inputSource = inputSource;
   }
 
   public SnowflakeMetadataConnector() {
-    this("snowflake");
+    this("snowflake", USAGE_THEN_SCHEMA);
   }
 
   @Nonnull
@@ -128,19 +131,17 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
   }
 
-  /** Adds the ACCOUNT_USAGE task, with a fallback to the INFORMATION_SCHEMA task. */
-  @ForOverride
-  protected void addSqlTasksWithInfoSchemaFallback(
+  final void addSqlTasksWithInfoSchemaFallback(
       @Nonnull List<? super Task<?>> out,
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,
       @Nonnull TaskVariant is_task,
       @Nonnull TaskVariant au_task,
       ConnectorArguments arguments) {
-    doAddSqlTasks(out, header, format, is_task, au_task, arguments, USAGE_THEN_SCHEMA);
+    doAddSqlTasks(out, header, format, is_task, au_task, arguments, inputSource);
   }
 
-  protected final void doAddSqlTasks(
+  private void doAddSqlTasks(
       @Nonnull List<? super Task<?>> out,
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,
@@ -216,7 +217,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   @Override
-  public void addTasksTo(
+  public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));


### PR DESCRIPTION
- Replace method overrides with an enum parameter
- Remove misused `ForOverride` annotation
- Reduce visibility of class members
- Subclasses shouldn't override `addTasksTo` - prevent this with `final`