### PR TITLE
Class design cleanup for Snowflake Logs

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -28,6 +28,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 public class SnowflakeAccountUsageLogsConnector extends SnowflakeLogsConnector {
 
   public SnowflakeAccountUsageLogsConnector() {
-    super("snowflake-account-usage-logs", USAGE_ONLY);
+    super("snowflake-account-usage-logs", USAGE_ONLY_SOURCE);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageLogsConnector.java
@@ -16,9 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY;
+
 import com.google.auto.service.AutoService;
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 
@@ -28,12 +28,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 public class SnowflakeAccountUsageLogsConnector extends SnowflakeLogsConnector {
 
   public SnowflakeAccountUsageLogsConnector() {
-    super("snowflake-account-usage-logs");
-  }
-
-  @Override
-  protected String newQueryFormat(ConnectorArguments arguments)
-      throws MetadataDumperUsageException {
-    return createQueryFromAccountUsage(arguments);
+    super("snowflake-account-usage-logs", USAGE_ONLY);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -28,6 +28,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 public class SnowflakeAccountUsageMetadataConnector extends SnowflakeMetadataConnector {
 
   public SnowflakeAccountUsageMetadataConnector() {
-    super("snowflake-account-usage-metadata", USAGE_ONLY);
+    super("snowflake-account-usage-metadata", USAGE_ONLY_SOURCE);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -32,6 +32,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 public class SnowflakeInformationSchemaLogsConnector extends SnowflakeLogsConnector {
 
   public SnowflakeInformationSchemaLogsConnector() {
-    super("snowflake-information-schema-logs", SCHEMA_ONLY);
+    super("snowflake-information-schema-logs", SCHEMA_ONLY_SOURCE);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
@@ -16,12 +16,11 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY;
+
 import com.google.auto.service.AutoService;
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
-import javax.annotation.Nonnull;
 
 /** @author shevek */
 @AutoService(Connector.class)
@@ -29,12 +28,6 @@ import javax.annotation.Nonnull;
 public class SnowflakeInformationSchemaLogsConnector extends SnowflakeLogsConnector {
 
   public SnowflakeInformationSchemaLogsConnector() {
-    super("snowflake-information-schema-logs");
-  }
-
-  @Override
-  protected String newQueryFormat(@Nonnull ConnectorArguments arguments)
-      throws MetadataDumperUsageException {
-    return createQueryFromInformationSchema(arguments);
+    super("snowflake-information-schema-logs", SCHEMA_ONLY);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaLogsConnector.java
@@ -22,7 +22,11 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 
-/** @author shevek */
+/**
+ * This is identical to snowflake-logs, because the SCHEMA_ONLY input setting is the default one.
+ *
+ * @author shevek
+ */
 @AutoService(Connector.class)
 @Description("Dumps logs from Snowflake, using INFORMATION_SCHEMA only.")
 public class SnowflakeInformationSchemaLogsConnector extends SnowflakeLogsConnector {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInformationSchemaMetadataConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -28,6 +28,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 public class SnowflakeInformationSchemaMetadataConnector extends SnowflakeMetadataConnector {
 
   public SnowflakeInformationSchemaMetadataConnector() {
-    super("snowflake-information-schema-metadata", SCHEMA_ONLY);
+    super("snowflake-information-schema-metadata", SCHEMA_ONLY_SOURCE);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInput.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeInput.java
@@ -16,9 +16,12 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+/** Represents a strategy of getting Snowflake data. */
 enum SnowflakeInput {
-  /** Adds the ACCOUNT_USAGE task, with a fallback to the INFORMATION_SCHEMA task. */
-  USAGE_THEN_SCHEMA,
-  SCHEMA_ONLY,
-  USAGE_ONLY;
+  /** Get data from ACCOUNT_USAGE contents, with a fallback to INFORMATION_SCHEMA. */
+  USAGE_THEN_SCHEMA_SOURCE,
+  /** Get data relying only on the contents of INFORMATION_SCHEMA */
+  SCHEMA_ONLY_SOURCE,
+  /** Get data relying only on the contents of ACCOUNT_USAGE */
+  USAGE_ONLY_SOURCE;
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.CaseFormat;
@@ -46,7 +46,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
 
   private static final String NAME = "snowflake-lite";
 
-  private final SnowflakeInput inputSource = USAGE_THEN_SCHEMA;
+  private final SnowflakeInput inputSource = USAGE_THEN_SCHEMA_SOURCE;
 
   public SnowflakeLiteConnector() {
     super(NAME);
@@ -126,7 +126,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
       @Nonnull TaskVariant au_task,
       @Nonnull ConnectorArguments arguments) {
     switch (inputSource) {
-      case USAGE_THEN_SCHEMA:
+      case USAGE_THEN_SCHEMA_SOURCE:
         {
           AbstractJdbcTask<Summary> schemaTask = taskFromVariant(format, is_task, header);
           AbstractJdbcTask<Summary> usageTask = taskFromVariant(format, au_task, header);
@@ -135,9 +135,9 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
           }
           return ImmutableList.of(usageTask, schemaTask.onlyIfFailed(usageTask));
         }
-      case SCHEMA_ONLY:
+      case SCHEMA_ONLY_SOURCE:
         return ImmutableList.of(taskFromVariant(format, is_task, header));
-      case USAGE_ONLY:
+      case USAGE_ONLY_SOURCE:
         return ImmutableList.of(taskFromVariant(format, au_task, header));
     }
     throw new AssertionError();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -40,7 +40,6 @@ import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat;
-import com.google.errorprone.annotations.ForOverride;
 import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -71,7 +70,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
 
   private final SnowflakeInput inputSource;
 
-  protected SnowflakeLogsConnector(@Nonnull String name, @Nonnull SnowflakeInput inputSource) {
+  SnowflakeLogsConnector(@Nonnull String name, @Nonnull SnowflakeInput inputSource) {
     super(name);
     this.inputSource = inputSource;
   }
@@ -167,8 +166,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     return SnowflakeLogConnectorProperties.class;
   }
 
-  @ForOverride
-  protected String newQueryFormat(@Nonnull ConnectorArguments arguments)
+  private String newQueryFormat(@Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     // Docref: https://docs.snowflake.net/manuals/sql-reference/functions/query_history.html
     // Per the docref, Snowflake only retains/returns seven trailing days of logs.
@@ -183,7 +181,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     throw new AssertionError();
   }
 
-  protected String createQueryFromAccountUsage(ConnectorArguments arguments)
+  private String createQueryFromAccountUsage(ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     String overrideQuery = getOverrideQuery(arguments);
     if (overrideQuery != null) return overrideQuery;
@@ -221,7 +219,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     return queryBuilder.toString().replace('\n', ' ');
   }
 
-  protected String createQueryFromInformationSchema(ConnectorArguments arguments)
+  private String createQueryFromInformationSchema(ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     // Docref: https://docs.snowflake.net/manuals/sql-reference/functions/query_history.html
     // Per the docref, Snowflake only retains/returns seven trailing days of logs in
@@ -272,7 +270,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     return queryBuilder.toString().replace('\n', ' ');
   }
 
-  protected String createExtendedQueryFromAccountUsage(ConnectorArguments arguments)
+  private String createExtendedQueryFromAccountUsage(ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     String overrideQuery = getOverrideQuery(arguments);
     if (overrideQuery != null) return overrideQuery;
@@ -339,7 +337,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   }
 
   @CheckForNull
-  protected String getOverrideQuery(@Nonnull ConnectorArguments arguments)
+  private String getOverrideQuery(@Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     String overrideQuery = arguments.getDefinition(SnowflakeLogConnectorProperties.OVERRIDE_QUERY);
     if (overrideQuery != null) {
@@ -353,13 +351,14 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   }
 
   @CheckForNull
-  protected String getOverrideWhere(@Nonnull ConnectorArguments arguments)
+  private String getOverrideWhere(@Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     return arguments.getDefinition(SnowflakeLogConnectorProperties.OVERRIDE_WHERE);
   }
 
   @Override
-  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments)
+  public final void addTasksTo(
+      @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.SCHEMA_ONLY_SOURCE;
 import static com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil.getEntryFileNameWithTimestamp;
 
 import com.google.auto.service.AutoService;
@@ -76,7 +76,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   }
 
   public SnowflakeLogsConnector() {
-    this("snowflake-logs", SCHEMA_ONLY);
+    this("snowflake-logs", SCHEMA_ONLY_SOURCE);
   }
 
   public enum SnowflakeLogConnectorProperties implements ConnectorProperty {
@@ -171,11 +171,11 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     // Docref: https://docs.snowflake.net/manuals/sql-reference/functions/query_history.html
     // Per the docref, Snowflake only retains/returns seven trailing days of logs.
     switch (inputSource) {
-      case USAGE_THEN_SCHEMA:
+      case USAGE_THEN_SCHEMA_SOURCE:
         throw new IllegalArgumentException("Unsupported input source for Snowflake logs.");
-      case USAGE_ONLY:
+      case USAGE_ONLY_SOURCE:
         return createQueryFromAccountUsage(arguments);
-      case SCHEMA_ONLY:
+      case SCHEMA_ONLY_SOURCE:
         return createQueryFromInformationSchema(arguments);
     }
     throw new AssertionError();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.CaseFormat;
@@ -104,7 +104,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   public SnowflakeMetadataConnector() {
-    this("snowflake", USAGE_THEN_SCHEMA);
+    this("snowflake", USAGE_THEN_SCHEMA_SOURCE);
   }
 
   @Nonnull
@@ -147,7 +147,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       @Nonnull TaskVariant au_task,
       @Nonnull ConnectorArguments arguments) {
     switch (inputSource) {
-      case USAGE_THEN_SCHEMA:
+      case USAGE_THEN_SCHEMA_SOURCE:
         {
           AbstractJdbcTask<Summary> schemaTask = taskFromVariant(format, is_task, header);
           AbstractJdbcTask<Summary> usageTask = taskFromVariant(format, au_task, header);
@@ -156,9 +156,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
           }
           return ImmutableList.of(usageTask, schemaTask.onlyIfFailed(usageTask));
         }
-      case SCHEMA_ONLY:
+      case SCHEMA_ONLY_SOURCE:
         return ImmutableList.of(taskFromVariant(format, is_task, header));
-      case USAGE_ONLY:
+      case USAGE_ONLY_SOURCE:
         return ImmutableList.of(taskFromVariant(format, au_task, header));
     }
     throw new AssertionError();


### PR DESCRIPTION
This is a similar change to https://github.com/google/dwh-migration-tools/pull/586 but for the `snowflake-logs` connector.

Limit visibility and overriding of `SnowflakeLogsConnector`, replace unnecessary overrides with constructor parameters.