### PR TITLE
[b/373568138] Change timestamp format used in zip entry files to work on windows

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 import static com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricConfig;
 import static com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricName;
 import static com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricType;
+import static com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil.getEntryFileNameWithTimestamp;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.Joiner;
@@ -46,7 +47,6 @@ import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectInterval
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.ParallelTaskGroup;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
-import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftMetadataDumpFormat;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftRawLogsDumpFormat;
@@ -243,7 +243,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
                       "%s < TIMESTAMP '%s'",
                       startField, SQL_FORMAT.format(interval.getEndExclusive()))));
 
-      String file = ArchiveNameUtil.getEntryFileNameWithTimestamp(filePrefix, interval);
+      String file = getEntryFileNameWithTimestamp(filePrefix, interval);
       out.addTask(new JdbcSelectIntervalTask(file, query, interval));
     }
   }
@@ -259,7 +259,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
             awsCredentials -> {
               for (ZonedInterval interval : intervals) {
                 String file =
-                    ArchiveNameUtil.getEntryFileNameWithTimestamp(
+                    getEntryFileNameWithTimestamp(
                         RedshiftRawLogsDumpFormat.ClusterUsageMetrics.ZIP_ENTRY_PREFIX, interval);
                 out.add(
                     new RedshiftClusterUsageMetricsTask(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -46,13 +46,12 @@ import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectInterval
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.ParallelTaskGroup;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
+import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftMetadataDumpFormat;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.RedshiftRawLogsDumpFormat;
 import java.time.Duration;
-import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -243,10 +242,8 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
                   String.format(
                       "%s < TIMESTAMP '%s'",
                       startField, SQL_FORMAT.format(interval.getEndExclusive()))));
-      String file =
-          filePrefix
-              + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(interval.getStartUTC())
-              + RedshiftRawLogsDumpFormat.ZIP_ENTRY_SUFFIX;
+
+      String file = ArchiveNameUtil.getEntryFileNameWithTimestamp(filePrefix, interval);
       out.addTask(new JdbcSelectIntervalTask(file, query, interval));
     }
   }
@@ -257,17 +254,13 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
       ZonedIntervalIterable intervals,
       ImmutableList<MetricConfig> metrics,
       List<? super Task<?>> out) {
-    DateTimeFormatter dateFormat =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
-
     AbstractAwsApiTask.createCredentialsProvider(arguments)
         .ifPresent(
             awsCredentials -> {
               for (ZonedInterval interval : intervals) {
                 String file =
-                    RedshiftRawLogsDumpFormat.ClusterUsageMetrics.ZIP_ENTRY_PREFIX
-                        + dateFormat.format(interval.getStartUTC())
-                        + RedshiftRawLogsDumpFormat.ZIP_ENTRY_SUFFIX;
+                    ArchiveNameUtil.getEntryFileNameWithTimestamp(
+                        RedshiftRawLogsDumpFormat.ClusterUsageMetrics.ZIP_ENTRY_PREFIX, interval);
                 out.add(
                     new RedshiftClusterUsageMetricsTask(
                         awsCredentials, ZonedDateTime.now(), interval, file, metrics));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -35,6 +35,7 @@ import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
+import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat;
 import com.google.errorprone.annotations.ForOverride;
@@ -389,10 +390,8 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
             task.unformattedQuery,
             SQL_FORMAT.format(interval.getStart()),
             SQL_FORMAT.format(interval.getEndInclusive()));
-    String file =
-        task.zipPrefix
-            + DateTimeFormatter.ISO_OFFSET_DATE_TIME.format(interval.getStartUTC())
-            + ".csv";
+
+    String file = ArchiveNameUtil.getEntryFileNameWithTimestamp(task.zipPrefix, interval);
     out.add(new JdbcSelectTask(file, query, task.taskCategory).withHeaderClass(task.headerClass));
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil.getEntryFileNameWithTimestamp;
+
 import com.google.auto.service.AutoService;
 import com.google.common.base.CaseFormat;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -35,7 +37,6 @@ import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
-import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat;
 import com.google.errorprone.annotations.ForOverride;
@@ -391,7 +392,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
             SQL_FORMAT.format(interval.getStart()),
             SQL_FORMAT.format(interval.getEndInclusive()));
 
-    String file = ArchiveNameUtil.getEntryFileNameWithTimestamp(task.zipPrefix, interval);
+    String file = getEntryFileNameWithTimestamp(task.zipPrefix, interval);
     out.add(new JdbcSelectTask(file, query, task.taskCategory).withHeaderClass(task.headerClass));
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil.getEntryFileNameWithTimestamp;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -41,7 +42,6 @@ import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
-import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import com.google.edwmigration.dumper.application.dumper.utils.PropertyParser;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.TeradataLogsDumpFormat;
@@ -181,7 +181,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
         .map(
             property ->
                 new TeradataJdbcSelectTask(
-                    ArchiveNameUtil.getEntryFileNameWithTimestamp(
+                    getEntryFileNameWithTimestamp(
                         TIME_SERIES_PROPERTY_TO_FILENAME_PREFIX_MAP.get(property), interval),
                     TaskCategory.OPTIONAL,
                     String.format(
@@ -255,7 +255,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
       addFailFastValidationStepForAssesment(out, arguments, utilityLogsTable);
 
       for (ZonedInterval interval : intervals) {
-        String file = ArchiveNameUtil.getEntryFileNameWithTimestamp(ZIP_ENTRY_PREFIX, interval);
+        String file = getEntryFileNameWithTimestamp(ZIP_ENTRY_PREFIX, interval);
         List<String> orderBy = Arrays.asList("ST.QueryID", "ST.SQLRowNo");
         out.add(
             new TeradataAssessmentLogsJdbcTask(
@@ -271,7 +271,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
         out.addAll(createTimeSeriesTasks(interval, arguments));
         out.add(
             new TeradataUtilityLogsJdbcTask(
-                ArchiveNameUtil.getEntryFileNameWithTimestamp("utility_logs_", interval),
+                getEntryFileNameWithTimestamp("utility_logs_", interval),
                 utilityLogsState,
                 utilityLogsTable,
                 interval));
@@ -285,7 +285,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
               intervals.getEnd()));
     } else {
       for (ZonedInterval interval : intervals) {
-        String file = ArchiveNameUtil.getEntryFileNameWithTimestamp(ZIP_ENTRY_PREFIX, interval);
+        String file = getEntryFileNameWithTimestamp(ZIP_ENTRY_PREFIX, interval);
         out.add(
             new TeradataLogsJdbcTask(file, queryLogsState, tableNames, conditions, interval)
                 .withHeaderClass(Header.class));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -23,7 +23,11 @@ import java.time.format.DateTimeFormatter;
 
 public class ArchiveNameUtil {
 
-  public static final String ZIP_ENTRY_SUFFIX = ".csv";
+  private static final String ZIP_ENTRY_SUFFIX = ".csv";
+  private static final DateTimeFormatter ENTRY_FILE_DATE_FORMAT =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HHmmss'Z'");
+  private static final DateTimeFormatter ARCHIVE_FILE_DATE_FORMAT =
+      DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
 
   /**
    * Generate the archive file name that includes creation time. Typically this is used with a logs
@@ -35,8 +39,7 @@ public class ArchiveNameUtil {
    * @return Full name for the .zip archive.
    */
   public static String getFileNameWithTimestamp(String name, Clock clock) {
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
-    String timeSuffix = formatter.withZone(clock.getZone()).format(clock.instant());
+    String timeSuffix = ARCHIVE_FILE_DATE_FORMAT.withZone(clock.getZone()).format(clock.instant());
     return formatFileName(name, timeSuffix);
   }
 
@@ -46,9 +49,11 @@ public class ArchiveNameUtil {
 
   public static String getEntryFileNameWithTimestamp(
       String prefix, ZonedInterval interval, String suffix) {
-    DateTimeFormatter formatter =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
-    return String.join("", prefix, formatter.format(interval.getStartUTC()), suffix);
+    return String.join(
+        "",
+        prefix,
+        ENTRY_FILE_DATE_FORMAT.withZone(ZoneOffset.UTC).format(interval.getStartUTC()),
+        suffix);
   }
 
   /**

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtil.java
@@ -16,10 +16,14 @@
  */
 package com.google.edwmigration.dumper.application.dumper.utils;
 
+import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import java.time.Clock;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 
 public class ArchiveNameUtil {
+
+  public static final String ZIP_ENTRY_SUFFIX = ".csv";
 
   /**
    * Generate the archive file name that includes creation time. Typically this is used with a logs
@@ -34,6 +38,17 @@ public class ArchiveNameUtil {
     DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
     String timeSuffix = formatter.withZone(clock.getZone()).format(clock.instant());
     return formatFileName(name, timeSuffix);
+  }
+
+  public static String getEntryFileNameWithTimestamp(String prefix, ZonedInterval interval) {
+    return getEntryFileNameWithTimestamp(prefix, interval, ZIP_ENTRY_SUFFIX);
+  }
+
+  public static String getEntryFileNameWithTimestamp(
+      String prefix, ZonedInterval interval, String suffix) {
+    DateTimeFormatter formatter =
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HHmmss'Z'").withZone(ZoneOffset.UTC);
+    return String.join("", prefix, formatter.format(interval.getStartUTC()), suffix);
   }
 
   /**

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/utils/ArchiveNameUtilTest.java
@@ -19,8 +19,11 @@ package com.google.edwmigration.dumper.application.dumper.utils;
 import static java.time.ZoneOffset.UTC;
 import static org.junit.Assert.assertEquals;
 
+import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -45,5 +48,22 @@ public class ArchiveNameUtilTest {
     assertEquals(
         "dwh-migration-snowflake-information-schema-logs-20240510T130210.zip",
         ArchiveNameUtil.getFileNameWithTimestamp(name, clock));
+  }
+
+  @Test
+  public void getEntryFileNameWithTimestamp_success() {
+    ZonedInterval interval =
+        new ZonedInterval(
+            ZonedDateTime.of(2023, 3, 4, 16, 0, 0, 0, ZoneOffset.UTC),
+            ZonedDateTime.of(2023, 3, 4, 17, 0, 0, 0, ZoneOffset.UTC));
+    String prefix = "wlm_query_";
+
+    /*
+     * The expected result should be a valid filename for Linux and Windows filesystems.
+     * Invalid characters: NUL, \, /, :, *, ?, ", <, >, |
+     */
+    assertEquals(
+        "wlm_query_2023-03-04T160000Z.csv",
+        ArchiveNameUtil.getEntryFileNameWithTimestamp(prefix, interval));
   }
 }


### PR DESCRIPTION
Update `redshift-raw-logs`, `teradata-logs` and `snowflake-logs` connectors to use "yyyy-MM-dd'T'HHmmss'Z'" pattern instead of default `ISO_OFFSET_DATE_TIME`. This format was already used for Redshift `cluster_usage_metrics_`, but not applied for all the other files.

The timestamp suffix is added to each time based file generated by the dumper. Currently we use the `ISO_OFFSET_DATE_TIME` format that includes colon characters. Windows file system does not accept colons in the file names what results in following exception:

```
java.nio.file.InvalidPathException: Illegal char <:> at index 21: ddltext_2024-10-09T14:00:00Z.csv
```