### PR TITLE
[b/374026408] Fix Hive extraction for Iceberg raw tables

### DIFF
--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_Superset.java
@@ -541,9 +541,7 @@ public class HiveMetastoreThriftClient_Superset extends HiveMetastoreThriftClien
       @Override
       public ImmutableList<? extends TBase<?, ?>> getRawTableStatistics() throws Exception {
         ImmutableList columnNames =
-            client.get_fields(databaseName, tableName).stream()
-                .map(FieldSchema::getName)
-                .collect(toImmutableList());
+            getFields().stream().map(Field::getFieldName).collect(toImmutableList());
         return ImmutableList.copyOf(
             client
                 .get_table_statistics_req(

--- a/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
+++ b/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java
@@ -516,10 +516,9 @@ public class HiveMetastoreThriftClient_v2_3_6 extends HiveMetastoreThriftClient 
 
       @Override
       public ImmutableList<? extends TBase<?, ?>> getRawTableStatistics() throws Exception {
+
         ImmutableList columnNames =
-            client.get_fields(databaseName, tableName).stream()
-                .map(FieldSchema::getName)
-                .collect(toImmutableList());
+            getFields().stream().map(Field::getFieldName).collect(toImmutableList());
         return ImmutableList.copyOf(
             client
                 .get_table_statistics_req(


### PR DESCRIPTION
Error caused by an already [known issue when reading Hive columns](https://github.com/google/dwh-migration-tools/blob/409b87cb7c6182afa4180c56cd93e524fc0f84d3/dumper/lib-ext-hive-metastore/src/main/java/com/google/edwmigration/dumper/ext/hive/metastore/HiveMetastoreThriftClient_v2_3_6.java#L306): "Storage schema reading not supported"