### PR TITLE
[improve] Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,4 @@ updates:
     ignore:
       - dependency-name: " ch.qos.logback:logback-*"
         # start from 1.4.x JDK 11 is required, but dumper's minimal is JDK 8
-        versions: ["1.4.x", "1.5.x"]
+        versions: [">=1.4.x"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,11 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "UTC"
+    ignore:
+      - dependency-name: " ch.qos.logback:logback-*"
+        # start from 1.4.x JDK 11 is required, but dumper's minimal is JDK 8
+        versions: ["1.4.x", "1.5.x"]


### PR DESCRIPTION
Run once a week on Monday morning to reduce `noise`.

Upadte logback only `1.3.x` for JDK 8 compatibility. 