### PR TITLE
[b/377253441] Add a task to get aggregate events in snowflake-lite

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -121,14 +121,14 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
             + " GROUP BY event_name, cluster_number, warehouse_id, warehouse_name";
     ImmutableList<String> header =
         ImmutableList.of("Name", "Cluster", "WarehouseId", "WarehouseName", "Count");
-    return new LiteLogsTask("warehouse_events.csv", query, header);
+    return new LiteTimeSeriesTask("warehouse_events.csv", query, header);
   }
 
-  private static final class LiteLogsTask extends JdbcSelectTask {
+  private static final class LiteTimeSeriesTask extends JdbcSelectTask {
 
     private final ImmutableList<String> header;
 
-    LiteLogsTask(String csvName, String sql, ImmutableList<String> header) {
+    LiteTimeSeriesTask(String csvName, String sql, ImmutableList<String> header) {
       super(csvName, sql);
       this.header = header;
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -35,7 +35,6 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDum
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.SchemataFormat;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.TablesFormat;
 import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.time.Clock;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -136,7 +135,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
     @Override
     @Nonnull
-    protected CSVFormat newCsvFormat(ResultSet rs) throws SQLException {
+    protected CSVFormat newCsvFormat(ResultSet rs) {
       return FORMAT.builder().setHeader(header.toArray(new String[0])).build();
     }
   }


### PR DESCRIPTION
Add a new task and query to the Snowflake (TCO) Lite connector that accesses the `WAREHOUSE_EVENTS_HISTORY` view in the `ACCOUNT_USAGE_SCHEMA` and lists the columns:
- event_name
- cluster_number
-  warehouse_id
- warehouse_name
counting the occurences of each combination.