### PR TITLE
Remove another connector's configuration from snowflake-lite

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -77,8 +77,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
 
-    boolean INJECT_IS_FAULT = arguments.isTestFlag('A');
-    final String IS = INJECT_IS_FAULT ? "__NONEXISTENT__" : "INFORMATION_SCHEMA";
+    final String IS = "INFORMATION_SCHEMA";
     final String AU = "SNOWFLAKE.ACCOUNT_USAGE";
     final String AU_WHERE = " WHERE DELETED IS NULL";
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -101,8 +101,9 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
 
     if (arguments.isAssessment()) {
       for (AssessmentQuery item : planner.generateAssessmentQueries()) {
-        String AU = "SNOWFLAKE.ACCOUNT_USAGE";
-        String query = String.format(item.formatString, AU, /* an empty WHERE clause */ "");
+        String usageSchema = "SNOWFLAKE.ACCOUNT_USAGE";
+        String query =
+            String.format(item.formatString, usageSchema, /* an empty WHERE clause */ "");
         String zipName = item.zipEntryName;
         Task<?> task = new JdbcSelectTask(zipName, query).withHeaderTransformer(item.transformer());
         out.add(task);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -34,8 +34,11 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDum
 import java.time.Clock;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
 
 @AutoService(Connector.class)
+@ParametersAreNonnullByDefault
 public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
     implements SnowflakeMetadataDumpFormat {
 
@@ -50,16 +53,16 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
 
   @Override
   @Nonnull
-  public String getDefaultFileName(boolean isAssessment, Clock clock) {
+  public String getDefaultFileName(boolean isAssessment, @Nullable Clock clock) {
     return ArchiveNameUtil.getFileName(NAME);
   }
 
   private void addSqlTasksWithInfoSchemaFallback(
-      @Nonnull List<? super Task<?>> out,
-      @Nonnull Class<? extends Enum<?>> header,
-      @Nonnull String format,
-      @Nonnull String schemaZip,
-      @Nonnull String usageZip) {
+      List<? super Task<?>> out,
+      Class<? extends Enum<?>> header,
+      String format,
+      String schemaZip,
+      String usageZip) {
     String usageView = "SNOWFLAKE.ACCOUNT_USAGE";
     String usageFilter = " WHERE DELETED IS NULL";
     String schemaView = "INFORMATION_SCHEMA";
@@ -72,8 +75,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
   }
 
   @Override
-  public final void addTasksTo(
-      @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments) {
+  public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY_SOURCE;
+import static com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.FORMAT_NAME;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -30,7 +31,9 @@ import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.DatabasesFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.SchemataFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.TablesFormat;
 import java.time.Clock;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -39,8 +42,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 
 @AutoService(Connector.class)
 @ParametersAreNonnullByDefault
-public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
-    implements SnowflakeMetadataDumpFormat {
+public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   private static final String NAME = "snowflake-lite";
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_ONLY_SOURCE;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableList;
@@ -41,7 +41,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector
 
   private static final String NAME = "snowflake-lite";
 
-  private final SnowflakeInput inputSource = USAGE_THEN_SCHEMA_SOURCE;
+  private final SnowflakeInput inputSource = USAGE_ONLY_SOURCE;
   private final SnowflakePlanner planner = new SnowflakePlanner();
 
   public SnowflakeLiteConnector() {


### PR DESCRIPTION
The TCO lite connector was based on the metadata connector. Some parts of the old connector are redundant for the new use case and can now be removed.

- Remove redundant inheritance from the metadata dump format
- Simplify a helper method because the parameter list was getting too big (8 arguments)