### PR TITLE
Enable Kerberos keytab auth for HdfsConnector

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -389,7 +389,7 @@ public class ConnectorArguments extends DefaultArguments {
               OPT_KERBEROS_PRINCIPAL,
               "Set Kerberos principal. It is usually a Service principal of the form: "
                   + "DUMPER/webserver.example.com@EXAMPLE.COM . (No default value)")
-          .withOptionalArg()
+          .withRequiredArg()
           .ofType(String.class);
 
   // Kerberos keytab path

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -130,7 +130,8 @@ public class ConnectorArguments extends DefaultArguments {
   public static final String OPT_HIVE_KERBEROS_URL = "hive-kerberos-url";
   public static final String OPT_REQUIRED_IF_NOT_URL = "if --url is not specified";
   public static final String OPT_THREAD_POOL_SIZE = "thread-pool-size";
-
+  public static final String OPT_KERBEROS_KEYTAB_PATH = "kerberos-keytab-path";
+  public static final String OPT_KERBEROS_PRINCIPAL = "kerberos-principal";
   // Ranger.
   public static final String OPT_RANGER_PORT_DEFAULT = "6080";
   public static final String OPT_RANGER_PAGE_SIZE = "ranger-page-size";
@@ -380,6 +381,24 @@ public class ConnectorArguments extends DefaultArguments {
           .withRequiredArg()
           .ofType(Integer.class)
           .defaultsTo(OPT_THREAD_POOL_SIZE_DEFAULT);
+
+  // Kerberos principal
+  private final OptionSpec<String> optionKerberosPrincipal =
+      parser
+          .accepts(
+              OPT_KERBEROS_PRINCIPAL,
+              "Set Kerberos principal. It is usually a Service principal of the form: "
+                  + "DUMPER/webserver.example.com@EXAMPLE.COM . (No default value)")
+          .withOptionalArg()
+          .ofType(String.class);
+
+  // Kerberos keytab path
+  private final OptionSpec<String> optionKerberosKeytabPath =
+      parser
+          .accepts(
+              OPT_KERBEROS_KEYTAB_PATH, "Set path to Kerberos .keytab file. (No default value)")
+          .withRequiredArg()
+          .ofType(String.class);
 
   // generic connector
   private final OptionSpec<String> optionGenericQuery =
@@ -848,6 +867,14 @@ public class ConnectorArguments extends DefaultArguments {
 
   public int getThreadPoolSize() {
     return getOptions().valueOf(optionThreadPoolSize);
+  }
+
+  public String getKerberosPrincipal() {
+    return getOptions().valueOf(optionKerberosPrincipal);
+  }
+
+  public String getKerberosKeytabPath() {
+    return getOptions().valueOf(optionKerberosKeytabPath);
   }
 
   @CheckForNull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsHandle.java
@@ -17,6 +17,8 @@
 package com.google.edwmigration.dumper.application.dumper.connector.hdfs;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_KERBEROS_KEYTAB_PATH;
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_KERBEROS_PRINCIPAL;
 
 import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -46,16 +48,19 @@ class HdfsHandle implements Handle {
     LOG.info("port: '{}'", port);
 
     Configuration conf = new Configuration();
-    if (args.getKerberosKeytabPath() != null) {
+    String krbPrincipal = args.getKerberosPrincipal();
+    String krbKeytab = args.getKerberosKeytabPath();
+    if (krbPrincipal != null || krbKeytab != null) {
+      Preconditions.checkNotNull(krbPrincipal, "Missing argument --" + OPT_KERBEROS_PRINCIPAL);
+      Preconditions.checkNotNull(krbKeytab, "Missing argument --" + OPT_KERBEROS_KEYTAB_PATH);
       conf.set("hadoop.security.authentication", "kerberos");
       conf.set("hadoop.security.authorization", "true");
-      conf.set("dfs.namenode.kerberos.principal", args.getKerberosPrincipal());
-      conf.set("dfs.datanode.kerberos.principal", args.getKerberosPrincipal());
+      conf.set("dfs.namenode.kerberos.principal", krbPrincipal);
+      conf.set("dfs.datanode.kerberos.principal", krbPrincipal);
 
       // Login using principal and its keytab:
       UserGroupInformation.setConfiguration(conf);
-      UserGroupInformation.loginUserFromKeytab(
-          args.getKerberosPrincipal(), args.getKerberosKeytabPath());
+      UserGroupInformation.loginUserFromKeytab(krbPrincipal, krbKeytab);
     }
     conf.set("fs.defaultFS", "hdfs://" + clusterHost + ":" + port + "/");
     conf.set("fs.hdfs.impl", DistributedFileSystem.class.getName());


### PR DESCRIPTION
Dumper/HdfsConnector now takes two more (optional) args, that should always go together:
--kerberos-principal _service-principal_
--kerberos-keytab-path _path-to-keytab-file_
