### PR TITLE
Remove writeRecordsCsv, refactor the usage metrics task for Redshift

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractAwsApiTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractAwsApiTask.java
@@ -31,7 +31,6 @@ import com.google.edwmigration.dumper.plugin.ext.jdk.progress.RecordProgressMoni
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -77,15 +76,6 @@ public abstract class AbstractAwsApiTask extends AbstractTask<Void> {
   public AmazonCloudWatch cloudWatchApiClient() {
     return cloudWatchClient.orElseGet(
         () -> AmazonCloudWatchClient.builder().withCredentials(credentialsProvider).build());
-  }
-
-  public void writeRecordsCsv(@Nonnull ByteSink sink, List<Object[]> records) throws IOException {
-    CSVFormat format = FORMAT.builder().setHeader(headerEnum).build();
-    try (CsvRecordWriter recordWriter = new CsvRecordWriter(sink, format, getName())) {
-      for (Object[] item : records) {
-        recordWriter.handleRecord(item);
-      }
-    }
   }
 
   static class CsvRecordWriter implements AutoCloseable {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractAwsApiTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractAwsApiTask.java
@@ -16,8 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 
-import static com.google.edwmigration.dumper.application.dumper.utils.OptionalUtils.optionallyWhen;
-
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -36,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 
@@ -82,31 +81,55 @@ public abstract class AbstractAwsApiTask extends AbstractTask<Void> {
 
   public void writeRecordsCsv(@Nonnull ByteSink sink, List<Object[]> records) throws IOException {
     CSVFormat format = FORMAT.builder().setHeader(headerEnum).build();
-    try (RecordProgressMonitor monitor = new RecordProgressMonitor(getName());
-        Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
-      CSVPrinter printer = format.print(writer);
-
-      for (Object[] record : records) {
-        monitor.count();
-        printer.printRecord(record);
+    try (CsvRecordWriter recordWriter = new CsvRecordWriter(sink, format, getName())) {
+      for (Object[] item : records) {
+        recordWriter.handleRecord(item);
       }
+    }
+  }
+
+  static class CsvRecordWriter implements AutoCloseable {
+    private final CSVPrinter printer;
+    private final RecordProgressMonitor monitor;
+    private final Writer writer;
+
+    CsvRecordWriter(ByteSink sink, CSVFormat format, String name) throws IOException {
+      monitor = new RecordProgressMonitor(name);
+      writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream();
+      printer = format.print(writer);
+    }
+
+    void handleRecord(Object[] record) throws IOException {
+      monitor.count();
+      printer.printRecord(record);
+    }
+
+    @Override
+    public void close() throws IOException {
+      // close Monitor first, because closing Writer can throw a checked exception
+      monitor.close();
+      writer.close();
     }
   }
 
   public static Optional<AWSCredentialsProvider> createCredentialsProvider(
       ConnectorArguments arguments) {
+    return Optional.ofNullable(doCreateProvider(arguments));
+  }
+
+  @Nullable
+  private static AWSCredentialsProvider doCreateProvider(ConnectorArguments arguments) {
     String profileName = arguments.getIAMProfile();
     if (profileName != null) {
-      return Optional.of(new ProfileCredentialsProvider(profileName));
+      return new ProfileCredentialsProvider(profileName);
     }
-
-    String iamAccessKey = arguments.getIAMAccessKeyID();
-    String iamSecretAccessKey = arguments.getIAMSecretAccessKey();
-
-    return optionallyWhen(
-        iamAccessKey != null && iamSecretAccessKey != null,
-        () ->
-            new AWSStaticCredentialsProvider(
-                new BasicAWSCredentials(iamAccessKey, iamSecretAccessKey)));
+    String accessKeyId = arguments.getIAMAccessKeyID();
+    String secretAccessKey = arguments.getIAMSecretAccessKey();
+    if (accessKeyId != null && secretAccessKey != null) {
+      BasicAWSCredentials credentials = new BasicAWSCredentials(accessKeyId, secretAccessKey);
+      return new AWSStaticCredentialsProvider(credentials);
+    } else {
+      return null;
+    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractAwsApiTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractAwsApiTask.java
@@ -89,7 +89,7 @@ public abstract class AbstractAwsApiTask extends AbstractTask<Void> {
       printer = format.print(writer);
     }
 
-    void handleRecord(Object[] record) throws IOException {
+    void handleRecord(Object... record) throws IOException {
       monitor.count();
       printer.printRecord(record);
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftClusterNodesTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftClusterNodesTask.java
@@ -49,15 +49,12 @@ public class RedshiftClusterNodesTask extends AbstractAwsApiTask {
     CSVFormat format = FORMAT.builder().setHeader(headerEnum).build();
     try (CsvRecordWriter writer = new CsvRecordWriter(sink, format, getName())) {
       for (Cluster item : result.getClusters()) {
-        Object[] record =
-            new Object[] {
-              item.getClusterIdentifier(),
-              item.getEndpoint() != null ? item.getEndpoint().getAddress() : "",
-              item.getNumberOfNodes(),
-              item.getNodeType(),
-              item.getTotalStorageCapacityInMegaBytes()
-            };
-        writer.handleRecord(record);
+        writer.handleRecord(
+            item.getClusterIdentifier(),
+            item.getEndpoint() != null ? item.getEndpoint().getAddress() : "",
+            item.getNumberOfNodes(),
+            item.getNodeType(),
+            item.getTotalStorageCapacityInMegaBytes());
       }
     }
     return null;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -16,9 +16,6 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricConfig;
-import static com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricName;
-import static com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricType;
 import static com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil.getEntryFileNameWithTimestamp;
 
 import com.google.auto.service.AutoService;
@@ -38,9 +35,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterable;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterableGenerator;
-import com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricConfig;
-import com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricName;
-import com.google.edwmigration.dumper.application.dumper.connector.redshift.RedshiftClusterUsageMetricsTask.MetricType;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectIntervalTask;
@@ -202,13 +196,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
           "service_class_start_time",
           parallelTask);
 
-      makeClusterMetricsTasks(
-          arguments,
-          intervals,
-          ImmutableList.of(
-              MetricConfig.create(MetricName.CPUUtilization, MetricType.Average),
-              MetricConfig.create(MetricName.PercentageDiskSpaceUsed, MetricType.Average)),
-          out);
+      makeClusterMetricsTasks(arguments, intervals, out);
     }
   }
 
@@ -250,10 +238,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
 
   /** Creates tasks to get Redshift cluster metrics from AWS CloudWatch API. */
   private void makeClusterMetricsTasks(
-      ConnectorArguments arguments,
-      ZonedIntervalIterable intervals,
-      ImmutableList<MetricConfig> metrics,
-      List<? super Task<?>> out) {
+      ConnectorArguments arguments, ZonedIntervalIterable intervals, List<? super Task<?>> out) {
     AbstractAwsApiTask.createCredentialsProvider(arguments)
         .ifPresent(
             awsCredentials -> {
@@ -263,7 +248,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
                         RedshiftRawLogsDumpFormat.ClusterUsageMetrics.ZIP_ENTRY_PREFIX, interval);
                 out.add(
                     new RedshiftClusterUsageMetricsTask(
-                        awsCredentials, ZonedDateTime.now(), interval, file, metrics));
+                        awsCredentials, ZonedDateTime.now(), interval, file));
               }
             });
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftClusterUsageMetricsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftClusterUsageMetricsTaskTest.java
@@ -123,7 +123,7 @@ public class RedshiftClusterUsageMetricsTaskTest extends AbstractTaskTest {
 
     RedshiftClusterUsageMetricsTask task =
         new RedshiftClusterUsageMetricsTask(
-            null, CURR_DATE_TIME, TEST_INTERVAL, TEST_ZIP_ENTRY_NAME, testMetrics);
+            null, CURR_DATE_TIME, TEST_INTERVAL, TEST_ZIP_ENTRY_NAME);
     task.withRedshiftApiClient(redshiftClientMock);
     task.withCloudWatchApiClient(cloudWatchClientMock);
 


### PR DESCRIPTION
- remove `writeRecordsCsv` which worked on lists of a file's all records
- create `CsvRecordWriter` for writing records one at a time
- replace `Optional` with `Nullable` to simplify a helper method
- move the list of extracted cluster usage metric types to `RedshiftClusterUsageMetricsTask`
- refactor record formatting in `RedshiftClusterUsageMetricsTask`

We use a list of types of metrics in this connector. The refactor of the usage metrics task relies on that list being a constant. After merging this change, we still can introduce more metric types, but creating custom types of metrics dynamically would require a different approach.

Note that despite working on the same code, this PR does not aim to fix b/382467945.