### PR TITLE
[b360554196] remove log4j implementation

### DIFF
--- a/dumper/lib-ext-hive-metastore/build.gradle
+++ b/dumper/lib-ext-hive-metastore/build.gradle
@@ -22,6 +22,13 @@ plugins {
     alias libs.plugins.shadow
 }
 
+configurations {
+    configureEach {
+        //We use logback, so log4j implementation must be excluded
+        exclude group: 'log4j', module: 'log4j'
+    }
+}
+
 sourceSets {
     hive312 // build a runtime to run Hive 3.1.2 metastore/server
 }

--- a/dumper/lib-ext-hive-metastore/gradle.lockfile
+++ b/dumper/lib-ext-hive-metastore/gradle.lockfile
@@ -112,7 +112,6 @@ jline:jline:2.14.3=hive312RuntimeClasspath
 joda-time:joda-time:2.9.9=hive312RuntimeClasspath
 junit:junit:4.13.1=hive312RuntimeClasspath
 junit:junit:4.13.2=testCompileClasspath,testRuntimeClasspath
-log4j:log4j:1.2.17=hive312RuntimeClasspath
 net.hydromatic:aggdesigner-algorithm:6.0=hive312RuntimeClasspath
 net.minidev:accessors-smart:1.2=hive312RuntimeClasspath
 net.minidev:json-smart:2.3=hive312RuntimeClasspath


### PR DESCRIPTION
Beside security vulnerabilities in `log4j`,  we use `slf4j` with `logback`, so all `log4j` implementation deps must be excluded. 