### PR TITLE
[b/380000872] Add hostId to jsonl

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTask.java
@@ -57,10 +57,32 @@ public class ClouderaHostComponentsTask extends AbstractClouderaManagerTask {
 
         try (CloseableHttpResponse response = httpClient.execute(new HttpGet(hostsComponentsUrl))) {
           JsonNode json = getObjectMapper().readTree(response.getEntity().getContent());
-          writer.write(json.toString());
+          writer.write(wrapResponseWithHostId(host.getId(), json));
           writer.write('\n');
         }
       }
+    }
+  }
+
+  private String wrapResponseWithHostId(String hostId, JsonNode payload) throws Exception {
+    return getObjectMapper().writeValueAsString(new PayloadEnrichedWithHostId(hostId, payload));
+  }
+
+  private static class PayloadEnrichedWithHostId {
+    private final String hostId;
+    private final JsonNode payload;
+
+    public PayloadEnrichedWithHostId(String hostId, JsonNode payload) {
+      this.hostId = hostId;
+      this.payload = payload;
+    }
+
+    public String getHostId() {
+      return hostId;
+    }
+
+    public JsonNode getPayload() {
+      return payload;
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTask.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
@@ -69,20 +70,13 @@ public class ClouderaHostComponentsTask extends AbstractClouderaManagerTask {
   }
 
   private static class PayloadEnrichedWithHostId {
-    private final String hostId;
-    private final JsonNode payload;
+
+    @JsonProperty private final String hostId;
+    @JsonProperty private final JsonNode payload;
 
     public PayloadEnrichedWithHostId(String hostId, JsonNode payload) {
       this.hostId = hostId;
       this.payload = payload;
-    }
-
-    public String getHostId() {
-      return hostId;
-    }
-
-    public JsonNode getPayload() {
-      return payload;
     }
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTaskTest.java
@@ -117,7 +117,11 @@ public class ClouderaHostComponentsTaskTest {
                       return true;
                     }));
     verify(writer, times(2)).write('\n');
-    assertEquals(ImmutableSet.of("{\"valid\":\"json1\"}", "{\"valid\":\"json2\"}"), fileLines);
+    assertEquals(
+        ImmutableSet.of(
+            "{\"hostId\":\"id2\",\"payload\":{\"valid\":\"json2\"}}",
+            "{\"hostId\":\"id1\",\"payload\":{\"valid\":\"json1\"}}"),
+        fileLines);
 
     verify(writer).close();
   }


### PR DESCRIPTION
The API response is an array of https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiComponentInfo.html 
For example:
```
[
  {
    "cdhVersion": "CDH7",
    "cdhRelease": "CDH 7.2.18-1.cdh7.2.18.p400.57851273",
    "componentVersion": "3.1.1.7.2.18.400-40",
    "componentRelease": "57851273",
    "componentInfoSource": "PARCEL",
    "isActive": true,
    "componentConfig": null,
    "name": "hadoop-kms"
  },
  {
    "cdhVersion": "CDH7",
    "cdhRelease": "CDH 7.2.18-1.cdh7.2.18.p400.57851273",
    "componentVersion": "3.1.3000.7.2.18.400-40",
    "componentRelease": "57851273",
    "componentInfoSource": "PARCEL",
    "isActive": true,
    "componentConfig": null,
    "name": "hive"
  },
...
]
```

So, we will lose the information about the `host` on server. To avoid it, I wrap the response into custom data structure.