### PR TITLE
[b/382467945] Move parts of JdbcHandle logic to a util class

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
@@ -51,7 +51,7 @@ public class HandleUtil {
     }
   }
 
-  public static HikariConfig createConfig(DataSource dataSource, int threadPoolSize) {
+  public static HikariConfig createHikariConfig(DataSource dataSource, int threadPoolSize) {
     HikariConfig config = new HikariConfig();
     // providing "0" sets it to Integer.MAX_VALUE
     config.setConnectionTimeout(0);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
@@ -30,7 +30,7 @@ public class HandleUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(HandleUtil.class);
 
-  public static JdbcTemplate templateFromDataSource(DataSource dataSource) {
+  public static JdbcTemplate createJdbcTemplate(DataSource dataSource) {
     JdbcTemplate template = new JdbcTemplate(dataSource);
     template.setFetchSize(1024);
     return template;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.handle;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import java.sql.Connection;
+import java.sql.SQLException;
+import javax.annotation.ParametersAreNonnullByDefault;
+import javax.sql.DataSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@ParametersAreNonnullByDefault
+public class HandleUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HandleUtil.class);
+
+  public static HikariDataSource withPoolConfig(DataSource dataSource, int threadPoolSize) {
+    HikariConfig config = createConfig(dataSource, threadPoolSize);
+    return new HikariDataSource(config);
+  }
+
+  public static JdbcTemplate templateFromDataSource(DataSource dataSource) {
+    JdbcTemplate template = new JdbcTemplate(dataSource);
+    template.setFetchSize(1024);
+    return template;
+  }
+
+  static void verifyJdbcConnection(DataSource dataSource) throws SQLException {
+    LOG.debug("Testing connection to database using {}...", dataSource);
+    try (Connection connection = dataSource.getConnection()) {
+      LOG.debug("Obtained connection is: {}");
+      if (connection == null) {
+        LOG.error("DataSource failed to provide a connection (usually bad/mismatched JDBC URI).");
+        // This used to be thrown by Preconditions and was kept for compatibility.
+        // TODO: Replace with a better error.
+        throw new NullPointerException();
+      } else {
+        LOG.debug("Connection test succeeded");
+      }
+    }
+  }
+
+  private static HikariConfig createConfig(DataSource dataSource, int threadPoolSize) {
+    HikariConfig config = new HikariConfig();
+    // providing "0" sets it to Integer.MAX_VALUE
+    config.setConnectionTimeout(0);
+    config.setDataSource(dataSource);
+    // Question: If a connection goes out to lunch, causing getConnection() to block for a thread,
+    // can that deadlock the dumper?
+    config.setMaximumPoolSize(threadPoolSize);
+    config.setMinimumIdle(0);
+    return config;
+  }
+
+  private HandleUtil() {}
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtil.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.handle;
 
 import com.zaxxer.hikari.HikariConfig;
-import com.zaxxer.hikari.HikariDataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -30,11 +29,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 public class HandleUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(HandleUtil.class);
-
-  public static HikariDataSource withPoolConfig(DataSource dataSource, int threadPoolSize) {
-    HikariConfig config = createConfig(dataSource, threadPoolSize);
-    return new HikariDataSource(config);
-  }
 
   public static JdbcTemplate templateFromDataSource(DataSource dataSource) {
     JdbcTemplate template = new JdbcTemplate(dataSource);
@@ -57,7 +51,7 @@ public class HandleUtil {
     }
   }
 
-  private static HikariConfig createConfig(DataSource dataSource, int threadPoolSize) {
+  public static HikariConfig createConfig(DataSource dataSource, int threadPoolSize) {
     HikariConfig config = new HikariConfig();
     // providing "0" sets it to Integer.MAX_VALUE
     config.setConnectionTimeout(0);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
@@ -46,7 +46,7 @@ public class JdbcHandle extends AbstractHandle {
 
   public JdbcHandle(@Nonnull DataSource dataSource) throws SQLException {
     HandleUtil.verifyJdbcConnection(dataSource);
-    this.jdbcTemplate = HandleUtil.templateFromDataSource(dataSource);
+    this.jdbcTemplate = HandleUtil.createJdbcTemplate(dataSource);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.handle;
 
+import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.sql.SQLException;
@@ -37,8 +38,8 @@ public class JdbcHandle extends AbstractHandle {
   @Nonnull
   public static JdbcHandle newPooledJdbcHandle(@Nonnull DataSource dataSource, int threadPoolSize)
       throws SQLException {
-    HikariDataSource hikariSource = HandleUtil.withPoolConfig(dataSource, threadPoolSize);
-    return new JdbcHandle(hikariSource);
+    HikariConfig config = HandleUtil.createConfig(dataSource, threadPoolSize);
+    return new JdbcHandle(new HikariDataSource(config));
   }
 
   private final JdbcTemplate jdbcTemplate;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
@@ -38,7 +38,7 @@ public class JdbcHandle extends AbstractHandle {
   @Nonnull
   public static JdbcHandle newPooledJdbcHandle(@Nonnull DataSource dataSource, int threadPoolSize)
       throws SQLException {
-    HikariConfig config = HandleUtil.createConfig(dataSource, threadPoolSize);
+    HikariConfig config = HandleUtil.createHikariConfig(dataSource, threadPoolSize);
     return new JdbcHandle(new HikariDataSource(config));
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtilTest.java
@@ -16,7 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.handle;
 
-import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.createConfig;
+import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.createHikariConfig;
 import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.templateFromDataSource;
 import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.verifyJdbcConnection;
 import static org.junit.Assert.assertEquals;
@@ -56,7 +56,7 @@ public class HandleUtilTest {
   public void withPoolConfig_success_poolSizeMatches() {
     DataSource dataSource = mock(DataSource.class);
 
-    HikariConfig config = createConfig(dataSource, 2);
+    HikariConfig config = createHikariConfig(dataSource, 2);
 
     assertEquals(2, config.getMaximumPoolSize());
   }
@@ -65,7 +65,7 @@ public class HandleUtilTest {
   public void withPoolConfig_success_timeoutEqualsIntMax() {
     DataSource dataSource = mock(DataSource.class);
 
-    HikariConfig config = createConfig(dataSource, 1);
+    HikariConfig config = createHikariConfig(dataSource, 1);
 
     assertEquals(Integer.MAX_VALUE, config.getConnectionTimeout());
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtilTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.handle;
+
+import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.createConfig;
+import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.templateFromDataSource;
+import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.verifyJdbcConnection;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.zaxxer.hikari.HikariConfig;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@RunWith(MockitoJUnitRunner.class)
+public class HandleUtilTest {
+
+  @Test
+  public void templateFromDataSource_success_fetchSizeMatches() {
+    DataSource dataSource = mock(DataSource.class);
+
+    JdbcTemplate template = templateFromDataSource(dataSource);
+
+    assertEquals(1024, template.getFetchSize());
+  }
+
+  @Test
+  public void verifyJdbcConnection_nullConnection_exceptionThrown() throws SQLException {
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getConnection()).thenReturn(null);
+
+    assertThrows(NullPointerException.class, () -> verifyJdbcConnection(dataSource));
+  }
+
+  @Test
+  public void withPoolConfig_success_poolSizeMatches() {
+    DataSource dataSource = mock(DataSource.class);
+
+    HikariConfig config = createConfig(dataSource, 2);
+
+    assertEquals(2, config.getMaximumPoolSize());
+  }
+
+  @Test
+  public void withPoolConfig_success_timeoutEqualsIntMax() {
+    DataSource dataSource = mock(DataSource.class);
+
+    HikariConfig config = createConfig(dataSource, 1);
+
+    assertEquals(Integer.MAX_VALUE, config.getConnectionTimeout());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/handle/HandleUtilTest.java
@@ -17,7 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.handle;
 
 import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.createHikariConfig;
-import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.templateFromDataSource;
+import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.createJdbcTemplate;
 import static com.google.edwmigration.dumper.application.dumper.handle.HandleUtil.verifyJdbcConnection;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -39,7 +39,7 @@ public class HandleUtilTest {
   public void templateFromDataSource_success_fetchSizeMatches() {
     DataSource dataSource = mock(DataSource.class);
 
-    JdbcTemplate template = templateFromDataSource(dataSource);
+    JdbcTemplate template = createJdbcTemplate(dataSource);
 
     assertEquals(1024, template.getFetchSize());
   }


### PR DESCRIPTION
JdbcHandle is a class which provides common Jdbc logic to connectors that choose to use it as their handle.

Redshift extraction needs (and currently uses) the general-purpose logic from JdbcHandle, but it also needs to define its own handle, for aws-specific connection setup (at the moment this setup is done in Tasks).

Make the JdbcHandle methods available as a util class so that a custom handle planned for Redshift will be able to use them.