### PR TITLE
Remove DummyHandle, make AbstractHandle.close final

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/AbstractHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/AbstractHandle.java
@@ -22,5 +22,5 @@ import java.io.IOException;
 public abstract class AbstractHandle implements Handle {
 
   @Override
-  public void close() throws IOException {}
+  public final void close() throws IOException {}
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/AbstractHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/AbstractHandle.java
@@ -22,5 +22,8 @@ import java.io.IOException;
 public abstract class AbstractHandle implements Handle {
 
   @Override
-  public final void close() throws IOException {}
+  public void close() throws IOException {
+    // Intentionally empty to simplify implementation of some Handles.
+    // If your subclass needs to release resources, consider implementing Handle directly.
+  }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
@@ -31,7 +31,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  *
  * @author shevek
  */
-public class JdbcHandle extends AbstractHandle {
+public class JdbcHandle implements Handle {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcHandle.class);
 
@@ -71,6 +71,5 @@ public class JdbcHandle extends AbstractHandle {
         throw new IOException("Failed to close DataSource: " + e, e);
       }
     }
-    super.close();
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
@@ -22,7 +22,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.AbstractConne
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
-import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.util.List;
@@ -30,7 +29,7 @@ import javax.annotation.Nonnull;
 
 @AutoService({Connector.class, MetadataConnector.class})
 public class TestConnector extends AbstractConnector implements MetadataConnector {
-  private static final Handle DUMMY_HANDLE = new AbstractHandle() {};
+  private static final Handle DUMMY_HANDLE = () -> {};
 
   public TestConnector() {
     super("test");

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/task/AbstractTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/task/AbstractTaskTest.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.task;
 
 import com.google.common.io.ByteSink;
-import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,9 +25,7 @@ import java.io.OutputStream;
 /** @author shevek */
 public abstract class AbstractTaskTest {
 
-  protected static class DummyHandle extends AbstractHandle {}
-
-  protected static Handle HANDLE = new DummyHandle();
+  static final Handle HANDLE = () -> {};
 
   public static class MemoryByteSink extends ByteSink {
 


### PR DESCRIPTION
### Make AbstractHandle.close() final
* The interface `Handle` extends `AutoCloseable`, which means subclasses need to be closed.
* `Handle` is implemented by `AbstractHandle`, where `close` is added as an empty method, so subclasses of  `AbstractHandle` don't need to be closed, despite implementing `Handle`.
* In `JdbcHandle` this changes once more: `JdbcHandle` and any potential subclasses do need to be closed (additionally, the empty `AbstractHandle.close()` is called when closing a `JdbcHandle`).

Remove the 3rd point by bypassing `AbstractHandle`. Prevent this pattern in the future by making the empty `close()` in `AbstractHandle` final. If a `Handle` needs to be closed, it has no need to extend `AbstractHandle`, because `AbstractHandle` doesn't provide anything other than the empty `close()` method.

### Remove DummyHandle

The class is used only once, to create an empty handle in a test, which can be replaced with a lambda.