### PR TITLE
[b/387249832] Move Redshift URL utilities to a Util class

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -193,7 +193,8 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
   }
 
   @Override
-  public Handle open(ConnectorArguments arguments) throws Exception {
+  @Nonnull
+  public Handle open(@Nonnull ConnectorArguments arguments) throws Exception {
 
     Driver driver =
         newDriver(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -70,7 +70,6 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 @RespectsArgumentJDBCUri
 public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
 
-  @SuppressWarnings("UnusedVariable")
   private static final Logger LOG = LoggerFactory.getLogger(AbstractRedshiftConnector.class);
 
   protected static final DateTimeFormatter SQL_FORMAT =

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -31,6 +31,7 @@ import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import java.io.UnsupportedEncodingException;
 import java.sql.Driver;
+import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -205,10 +206,6 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
         newDriver(
             arguments.getDriverPaths(), "com.amazon.redshift.jdbc.Driver", "org.postgresql.Driver");
 
-    //        LOG.debug("DRIVER IS " + driver.getClass().getCanonicalName());
-    //        LOG.debug("DRIVER CAN RS " + driver.acceptsURL("jdbc:redshift://host/db"));
-    //        LOG.debug("DRIVER CAN IAM " + driver.acceptsURL("jdbc:redshift:iam://host/db"));
-    //        LOG.debug("DRIVER CAN PG " + driver.acceptsURL("jdbc:postgresql://host/db"));
     String url = arguments.getUri();
     Optional<String> password = arguments.getPasswordIfFlagProvided();
     if (url == null) {
@@ -242,5 +239,12 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
         new SimpleDriverDataSource(driver, url, arguments.getUser(), password.orElse(null));
 
     return JdbcHandle.newPooledJdbcHandle(dataSource, arguments.getThreadPoolSize());
+  }
+
+  private static void logDriverInfo(@Nonnull Driver driver) throws SQLException {
+    LOG.debug("DRIVER IS " + driver.getClass().getCanonicalName());
+    LOG.debug("DRIVER CAN RS " + driver.acceptsURL("jdbc:redshift://host/db"));
+    LOG.debug("DRIVER CAN IAM " + driver.acceptsURL("jdbc:redshift:iam://host/db"));
+    LOG.debug("DRIVER CAN PG " + driver.acceptsURL("jdbc:postgresql://host/db"));
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/AbstractRedshiftConnector.java
@@ -130,12 +130,6 @@ public abstract class AbstractRedshiftConnector extends AbstractJdbcConnector {
    *
    * https://s3.amazonaws.com/redshift-downloads/drivers/jdbc/1.2.43.1067/Amazon+Redshift+JDBC+Driver+Install+Guide.pdf
    */
-  // this SHOuLD LAND UP IN THE ARGUMENT CLASS ...
-  @Nonnull
-  private static String requireNonNull(String val, String msg) throws MetadataDumperUsageException {
-    if (val != null) return val;
-    throw new MetadataDumperUsageException(msg);
-  }
 
   @Nonnull
   private String makeJdbcUrlPostgresql(ConnectorArguments arguments)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftLogsConnector.java
@@ -55,7 +55,7 @@ import org.slf4j.LoggerFactory;
     arg = ConnectorArguments.OPT_PORT,
     description = "The port of the server.",
     required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
-    defaultValue = "" + RedshiftMetadataConnector.OPT_PORT_DEFAULT)
+    defaultValue = RedshiftUrlUtil.OPT_PORT_DEFAULT)
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart
 @RespectsArgumentQueryLogEnd

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -41,7 +41,7 @@ import javax.annotation.Nonnull;
     arg = ConnectorArguments.OPT_PORT,
     description = "The port of the server.",
     required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
-    defaultValue = "" + RedshiftMetadataConnector.OPT_PORT_DEFAULT)
+    defaultValue = RedshiftUrlUtil.OPT_PORT_DEFAULT)
 public class RedshiftMetadataConnector extends AbstractRedshiftConnector
     implements MetadataConnector, RedshiftMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -63,7 +63,7 @@ import org.slf4j.LoggerFactory;
     arg = ConnectorArguments.OPT_PORT,
     description = "The port of the server.",
     required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
-    defaultValue = "" + RedshiftMetadataConnector.OPT_PORT_DEFAULT)
+    defaultValue = RedshiftUrlUtil.OPT_PORT_DEFAULT)
 @RespectsArgumentAssessment
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
@@ -34,7 +34,7 @@ class RedshiftUrlUtil {
   static String makeJdbcUrlPostgresql(ConnectorArguments arguments)
       throws MetadataDumperUsageException, UnsupportedEncodingException {
     String password = arguments.getPasswordIfFlagProvided().orElse(null);
-    return "jdbc:postgresql://"
+    return makeScheme("postgresql")
         + arguments.getHostOrDefault()
         + ":"
         + arguments.getPort(DEFAULT_PORT)
@@ -51,7 +51,7 @@ class RedshiftUrlUtil {
   static String makeJdbcUrlRedshiftSimple(ConnectorArguments arguments)
       throws MetadataDumperUsageException, UnsupportedEncodingException {
     String password = arguments.getPasswordIfFlagProvided().orElse(null);
-    return "jdbc:redshift://"
+    return makeScheme("redshift")
         + arguments.getHostOrDefault()
         + ":"
         + arguments.getPort(DEFAULT_PORT)
@@ -68,13 +68,17 @@ class RedshiftUrlUtil {
   @Nonnull
   static String makeJdbcUrlRedshiftIAM(ConnectorArguments arguments)
       throws UnsupportedEncodingException {
-    return "jdbc:redshift:iam://"
+    return makeScheme("redshift:iam")
         + arguments.getHostOrDefault()
         + ":"
         + arguments.getPort(DEFAULT_PORT)
         + "/"
         + Iterables.getFirst(arguments.getDatabases(), "")
         + toIamProperties(arguments);
+  }
+
+  private static String makeScheme(String urlType) {
+    return String.format("jdbc:%s://", urlType);
   }
 
   private static String toIamProperties(ConnectorArguments arguments)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
@@ -74,14 +74,14 @@ class RedshiftUrlUtil {
         + arguments.getPort(DEFAULT_PORT)
         + "/"
         + Iterables.getFirst(arguments.getDatabases(), "")
-        + toIamProperties(arguments);
+        + makeIamProperties(arguments);
   }
 
   private static String makeScheme(String urlType) {
     return String.format("jdbc:%s://", urlType);
   }
 
-  private static String toIamProperties(ConnectorArguments arguments)
+  private static String makeIamProperties(ConnectorArguments arguments)
       throws UnsupportedEncodingException {
     String profile = arguments.getIAMProfile();
     if (profile != null) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.redshift;
+
+import com.google.common.collect.Iterables;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import java.io.UnsupportedEncodingException;
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+
+@ParametersAreNonnullByDefault
+class RedshiftUrlUtil {
+
+  static final int DEFAULT_PORT = 5439;
+  // for annotations
+  static final String OPT_PORT_DEFAULT = "5439";
+
+  @Nonnull
+  static String makeJdbcUrlPostgresql(ConnectorArguments arguments)
+      throws MetadataDumperUsageException, UnsupportedEncodingException {
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
+    return "jdbc:postgresql://"
+        + arguments.getHostOrDefault()
+        + ":"
+        + arguments.getPort(DEFAULT_PORT)
+        + "/"
+        + Iterables.getFirst(arguments.getDatabases(), "") //
+        + new JdbcPropBuilder("?=&")
+            .propOrWarn("user", arguments.getUser(), "--user must be specified")
+            .propOrWarn("password", password, "--password must be specified")
+            .prop("ssl", "true")
+            .toJdbcPart();
+  }
+
+  @Nonnull
+  static String makeJdbcUrlRedshiftSimple(ConnectorArguments arguments)
+      throws MetadataDumperUsageException, UnsupportedEncodingException {
+    String password = arguments.getPasswordIfFlagProvided().orElse(null);
+    return "jdbc:redshift://"
+        + arguments.getHostOrDefault()
+        + ":"
+        + arguments.getPort(DEFAULT_PORT)
+        + "/"
+        + Iterables.getFirst(arguments.getDatabases(), "") //
+        + new JdbcPropBuilder("?=&")
+            .propOrWarn("UID", arguments.getUser(), "--user must be specified")
+            .propOrWarn("PWD", password, "--password must be specified")
+            .toJdbcPart();
+  }
+
+  // TODO:  [cluster-id]:[region] syntax.
+  // either profile, or key+ secret
+  @Nonnull
+  static String makeJdbcUrlRedshiftIAM(ConnectorArguments arguments)
+      throws UnsupportedEncodingException {
+    String url =
+        "jdbc:redshift:iam://"
+            + arguments.getHostOrDefault()
+            + ":"
+            + arguments.getPort(DEFAULT_PORT)
+            + "/"
+            + Iterables.getFirst(arguments.getDatabases(), "");
+
+    if (arguments.getIAMProfile() != null)
+      url += new JdbcPropBuilder("?=&").prop("Profile", arguments.getIAMProfile()).toJdbcPart();
+    else if (arguments.getIAMAccessKeyID() != null && arguments.getIAMSecretAccessKey() != null)
+      url +=
+          new JdbcPropBuilder("?=&")
+              .prop("AccessKeyID", arguments.getIAMAccessKeyID())
+              .prop("SecretAccessKey", arguments.getIAMSecretAccessKey())
+              .propOrError("DbUser", arguments.getUser(), "--user must be specified")
+              .toJdbcPart();
+    // Will use the default IAM from ~/.aws/credentials/
+    // throw new MetadataDumperUsageException("Either --iam-profile or
+    // --iam-accesskeyid/--iam-secretaccesskey should be given");
+    return url;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftUrlUtil.java
@@ -39,7 +39,7 @@ class RedshiftUrlUtil {
         + ":"
         + arguments.getPort(DEFAULT_PORT)
         + "/"
-        + Iterables.getFirst(arguments.getDatabases(), "") //
+        + Iterables.getFirst(arguments.getDatabases(), "")
         + new JdbcPropBuilder("?=&")
             .propOrWarn("user", arguments.getUser(), "--user must be specified")
             .propOrWarn("password", password, "--password must be specified")
@@ -56,7 +56,7 @@ class RedshiftUrlUtil {
         + ":"
         + arguments.getPort(DEFAULT_PORT)
         + "/"
-        + Iterables.getFirst(arguments.getDatabases(), "") //
+        + Iterables.getFirst(arguments.getDatabases(), "")
         + new JdbcPropBuilder("?=&")
             .propOrWarn("UID", arguments.getUser(), "--user must be specified")
             .propOrWarn("PWD", password, "--password must be specified")
@@ -86,8 +86,6 @@ class RedshiftUrlUtil {
               .propOrError("DbUser", arguments.getUser(), "--user must be specified")
               .toJdbcPart();
     // Will use the default IAM from ~/.aws/credentials/
-    // throw new MetadataDumperUsageException("Either --iam-profile or
-    // --iam-accesskeyid/--iam-secretaccesskey should be given");
     return url;
   }
 }


### PR DESCRIPTION
### Extract URL logic:
- Postgres URL builder
- Simple RS URL builder
- Redshift IAM URL builder
- default port constant

### Fixes in Connector:
- move commented-out code to a method
- remove redundant comments
- remove an unused method
- remove redundant `SuppressWarnings`

### Purpose of change

The moved code represented an additional responsibility of the Redshift connector besides managing the handle in `open` and building the task list in `addTasksTo`. Simplify the class to make working on its main features easier.