### PR TITLE
Remove DummyHandle, don't extend AbstractHandle in JdbcHandle

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/handle/JdbcHandle.java
@@ -31,7 +31,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
  *
  * @author shevek
  */
-public class JdbcHandle extends AbstractHandle {
+public class JdbcHandle implements Handle {
 
   private static final Logger LOG = LoggerFactory.getLogger(JdbcHandle.class);
 
@@ -71,6 +71,5 @@ public class JdbcHandle extends AbstractHandle {
         throw new IOException("Failed to close DataSource: " + e, e);
       }
     }
-    super.close();
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
@@ -22,7 +22,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.AbstractConne
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
-import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.util.List;
@@ -30,7 +29,7 @@ import javax.annotation.Nonnull;
 
 @AutoService({Connector.class, MetadataConnector.class})
 public class TestConnector extends AbstractConnector implements MetadataConnector {
-  private static final Handle DUMMY_HANDLE = new AbstractHandle() {};
+  private static final Handle DUMMY_HANDLE = () -> {};
 
   public TestConnector() {
     super("test");

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/task/AbstractTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/task/AbstractTaskTest.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.task;
 
 import com.google.common.io.ByteSink;
-import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,9 +25,7 @@ import java.io.OutputStream;
 /** @author shevek */
 public abstract class AbstractTaskTest {
 
-  protected static class DummyHandle extends AbstractHandle {}
-
-  protected static Handle HANDLE = new DummyHandle();
+  static final Handle HANDLE = () -> {};
 
   public static class MemoryByteSink extends ByteSink {
 


### PR DESCRIPTION
Similar to #680, but no changes to AbstractHandle.
### Implement Handle directly in JdbcHandle
This avoids the need for `super.close()` in JdbcHandle
### Simplify tests by removing DummyHandle
Given that the value represented by DummyHandle isn't important in the tests, a Handle from lambda is simpler, with the same effect and maintainability.