### PR TITLE
remove ignore section for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,14 +7,14 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "UTC"
-    ignore:
-      - dependency-name: "ch.qos.logback:logback-*"
-        # start from 1.4.x JDK 11 is required, but dumper's minimal is JDK 8
-        versions: [">=1.4.x"]
-      - dependency-name: "com.zaxxer:HikariCP"
-        # version 4.x.x is the latest for JDK 8
-        versions: [">=5.x.x"]
-      - dependency-name: "org.springframework:"
-        # Spring Framework 5.3.x is the latest with JDK 8 support
-        # https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range
-        versions: [">5.3.x"]
+#    ignore:
+#      - dependency-name: "ch.qos.logback:logback-*"
+#        # start from 1.4.x JDK 11 is required, but dumper's minimal is JDK 8
+#        versions: [">=1.4.x"]
+#      - dependency-name: "com.zaxxer:HikariCP"
+#        # version 4.x.x is the latest for JDK 8
+#        versions: [">=5.x.x"]
+#      - dependency-name: "org.springframework:"
+#        # Spring Framework 5.3.x is the latest with JDK 8 support
+#        # https://github.com/spring-projects/spring-framework/wiki/Spring-Framework-Versions#jdk-version-range
+#        versions: [">5.3.x"]


### PR DESCRIPTION
Dependabot wasn't run successfully for some period of time https://github.com/google/dwh-migration-tools/network/updates/17324861/jobs

Logs are not available, so checking the latest changes.