### PR TITLE
[b/385081594]: Add more http tests for Cloudera tasks

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaManagerTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaManagerTask.java
@@ -48,7 +48,8 @@ abstract class AbstractClouderaManagerTask extends AbstractTask<Void> {
   }
 
   protected final boolean isStatusCodeOK(int statusCode) {
-    return 200 <= statusCode && statusCode < 300;
+    // Based on HTTP rfc: https://datatracker.ietf.org/doc/html/rfc7231#section-6.3
+    return 200 <= statusCode && statusCode <= 299;
   }
 
   protected abstract void doRun(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaTimeSeriesTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaTimeSeriesTask.java
@@ -62,12 +62,15 @@ abstract class AbstractClouderaTimeSeriesTask extends AbstractClouderaManagerTas
     try (CloseableHttpResponse chart = httpClient.execute(new HttpGet(uriBuilder.build()))) {
       int statusCode = chart.getStatusLine().getStatusCode();
       if (!isStatusCodeOK(statusCode)) {
-        throw new TimeSeriesException(statusCode, "Expected status code is 2xx.");
+        throw new TimeSeriesException(
+            statusCode,
+            String.format(
+                "Cloudera Error: Response status code is %d but 2xx is expected.", statusCode));
       }
       try {
         chartInJson = readJsonTree(chart.getEntity().getContent());
-      } catch (JsonParseException error) {
-        throw new TimeSeriesException(statusCode, error.getMessage());
+      } catch (JsonParseException ex) {
+        throw new TimeSeriesException(statusCode, ex.getMessage());
       }
     }
     return chartInJson;
@@ -87,20 +90,20 @@ abstract class AbstractClouderaTimeSeriesTask extends AbstractClouderaManagerTas
      * - response with invalid JSON format.
      */
     private final int statusCode;
-    private final String errorMessage;
+    private final String message;
 
-    public TimeSeriesException(int statusCode, String errorMessage) {
-      super(errorMessage);
+    public TimeSeriesException(int statusCode, String message) {
+      super(message);
       this.statusCode = statusCode;
-      this.errorMessage = errorMessage;
+      this.message = message;
     }
 
     public int getStatusCode() {
       return statusCode;
     }
 
-    public String getErrorMessage() {
-      return errorMessage;
+    public String getMessage() {
+      return message;
     }
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaTimeSeriesTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaTimeSeriesTask.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
@@ -58,8 +59,15 @@ abstract class AbstractClouderaTimeSeriesTask extends AbstractClouderaManagerTas
 
     CloseableHttpClient httpClient = handle.getHttpClient();
     JsonNode chartInJson;
+    int statusCode = 200;
     try (CloseableHttpResponse chart = httpClient.execute(new HttpGet(uriBuilder.build()))) {
-      chartInJson = objectMapper.readTree(chart.getEntity().getContent());
+      statusCode = chart.getStatusLine().getStatusCode();
+      if (!isStatusCodeOK(statusCode)) {
+        throw new TimeSeriesError(statusCode, "Expected status code is 2xx.");
+      }
+      chartInJson = readJsonTree(chart.getEntity().getContent());
+    } catch (JsonParseException error) {
+      throw new TimeSeriesError(statusCode, error.getMessage());
     }
     return chartInJson;
   }
@@ -68,6 +76,25 @@ abstract class AbstractClouderaTimeSeriesTask extends AbstractClouderaManagerTas
     ZonedDateTime dateTime =
         ZonedDateTime.of(LocalDateTime.now().minusDays(deltaInDays), ZoneId.of("UTC"));
     return dateTime.format(isoDateTimeFormatter);
+  }
+
+  static class TimeSeriesError extends Exception {
+    private final int statusCode;
+    private final String errorMessage;
+
+    public TimeSeriesError(int statusCode, String errorMessage) {
+      super(errorMessage);
+      this.statusCode = statusCode;
+      this.errorMessage = errorMessage;
+    }
+
+    public int getStatusCode() {
+      return statusCode;
+    }
+
+    public String getErrorMessage() {
+      return errorMessage;
+    }
   }
 
   enum TimeSeriesAggregation {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaAPIHostsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaAPIHostsTask.java
@@ -67,7 +67,8 @@ public class ClouderaAPIHostsTask extends AbstractClouderaManagerTask {
           final int statusCode = hostsResponse.getStatusLine().getStatusCode();
           if (!isStatusCodeOK(statusCode)) {
             throw new MetadataDumperUsageException(
-                "Cloudera Error: Response status code is not 2xx.");
+                String.format(
+                    "Cloudera Error: Response status code is %d but 2xx is expected.", statusCode));
           }
           jsonHosts = readJsonTree(hostsResponse.getEntity().getContent());
         } catch (JsonParseException error) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaAPIHostsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaAPIHostsTask.java
@@ -71,8 +71,8 @@ public class ClouderaAPIHostsTask extends AbstractClouderaManagerTask {
                     "Cloudera Error: Response status code is %d but 2xx is expected.", statusCode));
           }
           jsonHosts = readJsonTree(hostsResponse.getEntity().getContent());
-        } catch (JsonParseException error) {
-          throw new MetadataDumperUsageException("Cloudera Error:" + error.getMessage());
+        } catch (JsonParseException ex) {
+          throw new MetadataDumperUsageException("Cloudera Error:" + ex.getMessage());
         }
         String stringifiedHosts = jsonHosts.toString();
         writer.write(stringifiedHosts);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTask.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
@@ -77,14 +78,18 @@ public class ClouderaCMFHostsTask extends AbstractClouderaManagerTask {
         JsonNode hostsJson;
         try (CloseableHttpResponse hostsResponse =
             httpClient.execute(new HttpGet(hostPerClusterUrl))) {
-          hostsJson = getObjectMapper().readTree(hostsResponse.getEntity().getContent());
+          try {
+            hostsJson = readJsonTree(hostsResponse.getEntity().getContent());
+          } catch (JsonParseException error) {
+            LOG.warn("Cloudera Error: " + error.getMessage());
+            continue;
+          }
         }
         String stringifiedHosts = hostsJson.toString();
         writer.write(stringifiedHosts);
         writer.write('\n');
 
-        CMFHostListDTO apiHosts =
-            getObjectMapper().readValue(stringifiedHosts, CMFHostListDTO.class);
+        CMFHostListDTO apiHosts = parseJsonStringToObject(stringifiedHosts, CMFHostListDTO.class);
         for (CMFHostDTO apiHost : apiHosts.getHosts()) {
           hosts.add(ClouderaHostDTO.create(apiHost.getId(), apiHost.getName()));
         }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTask.java
@@ -80,8 +80,8 @@ public class ClouderaCMFHostsTask extends AbstractClouderaManagerTask {
             httpClient.execute(new HttpGet(hostPerClusterUrl))) {
           try {
             hostsJson = readJsonTree(hostsResponse.getEntity().getContent());
-          } catch (JsonParseException error) {
-            LOG.warn("Cloudera Error: " + error.getMessage());
+          } catch (JsonParseException ex) {
+            LOG.warn("Cloudera Error: " + ex.getMessage());
             continue;
           }
         }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
@@ -64,8 +64,8 @@ public class ClouderaClusterCPUChartTask extends AbstractClouderaTimeSeriesTask 
         JsonNode chartInJson;
         try {
           chartInJson = requestTimeSeriesChart(handle, cpuPerClusterQuery);
-        } catch (TimeSeriesException error) {
-          throw new MetadataDumperUsageException("Cloudera Error: " + error.getMessage());
+        } catch (TimeSeriesException ex) {
+          throw new MetadataDumperUsageException("Cloudera Error: " + ex.getMessage());
         }
         writer.write(chartInJson.toString());
         writer.write('\n');

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
@@ -64,7 +64,7 @@ public class ClouderaClusterCPUChartTask extends AbstractClouderaTimeSeriesTask 
         JsonNode chartInJson;
         try {
           chartInJson = requestTimeSeriesChart(handle, cpuPerClusterQuery);
-        } catch (TimeSeriesError error) {
+        } catch (TimeSeriesException error) {
           throw new MetadataDumperUsageException("Cloudera Error: " + error.getMessage());
         }
         writer.write(chartInJson.toString());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
@@ -61,7 +61,12 @@ public class ClouderaClusterCPUChartTask extends AbstractClouderaTimeSeriesTask 
             cpuPerClusterQuery,
             cluster.getName());
 
-        JsonNode chartInJson = requestTimeSeriesChart(handle, cpuPerClusterQuery);
+        JsonNode chartInJson;
+        try {
+          chartInJson = requestTimeSeriesChart(handle, cpuPerClusterQuery);
+        } catch (TimeSeriesError error) {
+          throw new MetadataDumperUsageException("Cloudera Error: " + error.getMessage());
+        }
         writer.write(chartInJson.toString());
         writer.write('\n');
       }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTask.java
@@ -65,7 +65,10 @@ public class ClouderaClusterCPUChartTask extends AbstractClouderaTimeSeriesTask 
         try {
           chartInJson = requestTimeSeriesChart(handle, cpuPerClusterQuery);
         } catch (TimeSeriesException ex) {
-          throw new MetadataDumperUsageException("Cloudera Error: " + ex.getMessage());
+          MetadataDumperUsageException dumperException =
+              new MetadataDumperUsageException("Cloudera Error: " + ex.getMessage());
+          dumperException.initCause(ex);
+          throw dumperException;
         }
         writer.write(chartInJson.toString());
         writer.write('\n');

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTask.java
@@ -60,8 +60,8 @@ public class ClouderaClustersTask extends AbstractClouderaManagerTask {
           httpClient.execute(new HttpGet(handle.getApiURI() + "/clusters/" + clusterName))) {
 
         ApiClusterDTO cluster =
-            getObjectMapper()
-                .readValue(EntityUtils.toString(clusterResponse.getEntity()), ApiClusterDTO.class);
+            parseJsonStringToObject(
+                EntityUtils.toString(clusterResponse.getEntity()), ApiClusterDTO.class);
 
         clusterList = new ApiClusterListDTO();
         clusterList.setClusters(ImmutableList.of(cluster));
@@ -72,13 +72,12 @@ public class ClouderaClustersTask extends AbstractClouderaManagerTask {
       try (CloseableHttpResponse clustersResponse =
           httpClient.execute(new HttpGet(handle.getApiURI() + "/clusters"))) {
         String clustersJson = EntityUtils.toString(clustersResponse.getEntity());
-
-        clusterList = getObjectMapper().readValue(clustersJson, ApiClusterListDTO.class);
+        clusterList = parseJsonStringToObject(clustersJson, ApiClusterListDTO.class);
       }
     }
 
     try (Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
-      writer.write(getObjectMapper().writeValueAsString(clusterList));
+      writer.write(parseObjectToJsonString(clusterList));
     }
 
     List<ClouderaClusterDTO> clusters = new ArrayList<>();
@@ -109,7 +108,7 @@ public class ClouderaClustersTask extends AbstractClouderaManagerTask {
 
         return null;
       } else {
-        JsonNode jsonNode = getObjectMapper().readTree(clusterStatus.getEntity().getContent());
+        JsonNode jsonNode = readJsonTree(clusterStatus.getEntity().getContent());
         // https://www.rfc-editor.org/rfc/rfc6901
         return jsonNode.at("/clusterModel/id").asText();
       }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostComponentsTask.java
@@ -57,7 +57,7 @@ public class ClouderaHostComponentsTask extends AbstractClouderaManagerTask {
         String hostsComponentsUrl = handle.getApiURI() + "/hosts/" + host.getId() + "/components";
 
         try (CloseableHttpResponse response = httpClient.execute(new HttpGet(hostsComponentsUrl))) {
-          JsonNode json = getObjectMapper().readTree(response.getEntity().getContent());
+          JsonNode json = readJsonTree(response.getEntity().getContent());
           writer.write(wrapResponseWithHostId(host.getId(), json));
           writer.write('\n');
         }
@@ -66,7 +66,7 @@ public class ClouderaHostComponentsTask extends AbstractClouderaManagerTask {
   }
 
   private String wrapResponseWithHostId(String hostId, JsonNode payload) throws Exception {
-    return getObjectMapper().writeValueAsString(new PayloadEnrichedWithHostId(hostId, payload));
+    return parseObjectToJsonString(new PayloadEnrichedWithHostId(hostId, payload));
   }
 
   private static class PayloadEnrichedWithHostId {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
@@ -66,7 +66,7 @@ public class ClouderaHostRAMChartTask extends AbstractClouderaTimeSeriesTask {
         JsonNode chartInJson;
         try {
           chartInJson = requestTimeSeriesChart(handle, ramPerHostQuery);
-        } catch (TimeSeriesError error) {
+        } catch (TimeSeriesException error) {
           throw new MetadataDumperUsageException("Cloudera Error: " + error.getErrorMessage());
         }
         writer.write(chartInJson.toString());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
@@ -67,7 +67,10 @@ public class ClouderaHostRAMChartTask extends AbstractClouderaTimeSeriesTask {
         try {
           chartInJson = requestTimeSeriesChart(handle, ramPerHostQuery);
         } catch (TimeSeriesException ex) {
-          throw new MetadataDumperUsageException("Cloudera Error: " + ex.getMessage());
+          MetadataDumperUsageException dumperException =
+              new MetadataDumperUsageException("Cloudera Error: " + ex.getMessage());
+          dumperException.initCause(ex);
+          throw dumperException;
         }
         writer.write(chartInJson.toString());
         writer.write('\n');

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
@@ -66,8 +66,8 @@ public class ClouderaHostRAMChartTask extends AbstractClouderaTimeSeriesTask {
         JsonNode chartInJson;
         try {
           chartInJson = requestTimeSeriesChart(handle, ramPerHostQuery);
-        } catch (TimeSeriesException error) {
-          throw new MetadataDumperUsageException("Cloudera Error: " + error.getErrorMessage());
+        } catch (TimeSeriesException ex) {
+          throw new MetadataDumperUsageException("Cloudera Error: " + ex.getMessage());
         }
         writer.write(chartInJson.toString());
         writer.write('\n');

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTask.java
@@ -63,7 +63,12 @@ public class ClouderaHostRAMChartTask extends AbstractClouderaTimeSeriesTask {
         LOG.debug(
             "Execute RAM charts query: [{}] for the host: [{}].", ramPerHostQuery, host.getName());
 
-        JsonNode chartInJson = requestTimeSeriesChart(handle, ramPerHostQuery);
+        JsonNode chartInJson;
+        try {
+          chartInJson = requestTimeSeriesChart(handle, ramPerHostQuery);
+        } catch (TimeSeriesError error) {
+          throw new MetadataDumperUsageException("Cloudera Error: " + error.getErrorMessage());
+        }
         writer.write(chartInJson.toString());
         writer.write('\n');
       }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaServicesTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaServicesTask.java
@@ -52,7 +52,7 @@ public class ClouderaServicesTask extends AbstractClouderaManagerTask {
             handle.getApiURI() + "/clusters/" + cluster.getName() + "/services";
 
         try (CloseableHttpResponse services = httpClient.execute(new HttpGet(servicesPerCluster))) {
-          JsonNode jsonNode = getObjectMapper().readTree(services.getEntity().getContent());
+          JsonNode jsonNode = readJsonTree(services.getEntity().getContent());
           writer.write(jsonNode.toString());
           writer.write('\n');
         }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaManagerTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaManagerTaskTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.io.ByteSink;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nonnull;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class DummyPersonDTO {
+  private final String name;
+
+  @JsonCreator
+  public DummyPersonDTO(@JsonProperty(value = "personName", required = true) String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
+  }
+}
+
+@RunWith(MockitoJUnitRunner.class)
+public class AbstractClouderaManagerTaskTest {
+  AbstractClouderaManagerTask clouderaManagerTask;
+
+  @Before
+  public void setUp() throws Exception {
+    clouderaManagerTask =
+        new AbstractClouderaManagerTask("") {
+          @Override
+          protected void doRun(
+              TaskRunContext context, @Nonnull ByteSink sink, @Nonnull ClouderaManagerHandle handle)
+              throws Exception {}
+        };
+  }
+
+  @Test
+  public void readJsonTree_validJsonLine_success() throws Exception {
+    String jsonLine = "{\"key\": 123}";
+    byte[] byteArray = jsonLine.getBytes(StandardCharsets.UTF_8);
+    InputStream inStream = new ByteArrayInputStream(byteArray);
+
+    JsonNode jsonObj = clouderaManagerTask.readJsonTree(inStream);
+
+    assertEquals(jsonObj.get("key").asInt(), 123);
+  }
+
+  @Test
+  public void readJsonTree_validJsonLineWithTrailingSymbols_throwsException() throws Exception {
+    String jsonLine = "{\"key\": 123} fff";
+    byte[] byteArray = jsonLine.getBytes(StandardCharsets.UTF_8);
+    InputStream inStream = new ByteArrayInputStream(byteArray);
+
+    assertThrows(JsonParseException.class, () -> clouderaManagerTask.readJsonTree(inStream));
+  }
+
+  @Test
+  public void readJsonTree_invalidJsonLine_throwsException() throws Exception {
+    String jsonLine = "{\"key\": 123]";
+    byte[] byteArray = jsonLine.getBytes(StandardCharsets.UTF_8);
+    InputStream inStream = new ByteArrayInputStream(byteArray);
+
+    assertThrows(JsonParseException.class, () -> clouderaManagerTask.readJsonTree(inStream));
+  }
+
+  @Test
+  public void parseJsonStringToObject_validJsonLine_createObject() throws Exception {
+    String jsonLine = "{\"personName\": \"Albus\"}";
+    DummyPersonDTO person =
+        clouderaManagerTask.parseJsonStringToObject(jsonLine, DummyPersonDTO.class);
+    assertEquals(person.getName(), "Albus");
+  }
+
+  @Test
+  public void parseJsonStringToObject_invalidJsonLine_throwsException() throws Exception {
+    String jsonLine = "{\"personName\": \"Albus\"]";
+    assertThrows(
+        JsonParseException.class,
+        () -> clouderaManagerTask.parseJsonStringToObject(jsonLine, DummyPersonDTO.class));
+  }
+
+  @Test
+  public void parseObjectToJsonLine_createJsonLine() throws Exception {
+    DummyPersonDTO albus = new DummyPersonDTO("Albus");
+    String jsonLine = clouderaManagerTask.parseObjectToJsonString(albus);
+    assertEquals(jsonLine, "{\"name\":\"Albus\"}");
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaManagerTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaManagerTaskTest.java
@@ -35,20 +35,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-class DummyPersonDTO {
-  private final String name;
-
-  @JsonCreator
-  public DummyPersonDTO(@JsonProperty(value = "personName", required = true) String name) {
-    this.name = name;
-  }
-
-  public String getName() {
-    return name;
-  }
-}
-
 @RunWith(MockitoJUnitRunner.class)
 public class AbstractClouderaManagerTaskTest {
   AbstractClouderaManagerTask clouderaManagerTask;
@@ -60,7 +46,9 @@ public class AbstractClouderaManagerTaskTest {
           @Override
           protected void doRun(
               TaskRunContext context, @Nonnull ByteSink sink, @Nonnull ClouderaManagerHandle handle)
-              throws Exception {}
+              throws Exception {
+            throw new UnsupportedOperationException("Test implementation");
+          }
         };
   }
 
@@ -114,5 +102,19 @@ public class AbstractClouderaManagerTaskTest {
     DummyPersonDTO albus = new DummyPersonDTO("Albus");
     String jsonLine = clouderaManagerTask.parseObjectToJsonString(albus);
     assertEquals(jsonLine, "{\"name\":\"Albus\"}");
+  }
+}
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class DummyPersonDTO {
+  private final String name;
+
+  @JsonCreator
+  public DummyPersonDTO(@JsonProperty(value = "personName", required = true) String name) {
+    this.name = name;
+  }
+
+  public String getName() {
+    return name;
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaAPIHostsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaAPIHostsTaskTest.java
@@ -134,7 +134,10 @@ public class ClouderaAPIHostsTaskTest {
     MetadataDumperUsageException exception =
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
 
-    assertTrue(exception.getMessage().contains("Cloudera Error:"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Cloudera Error: Response status code is 400 but 2xx is expected."));
   }
 
   @Test
@@ -145,7 +148,10 @@ public class ClouderaAPIHostsTaskTest {
     MetadataDumperUsageException exception =
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
 
-    assertTrue(exception.getMessage().contains("Cloudera Error:"));
+    assertTrue(
+        exception
+            .getMessage()
+            .contains("Cloudera Error: Response status code is 500 but 2xx is expected."));
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTaskTest.java
@@ -101,8 +101,8 @@ public class ClouderaCMFHostsTaskTest {
         ClouderaClusterDTO.create("id1", "first-cluster"),
         ClouderaClusterDTO.create("id34", "next-cluster"));
 
-    mockCMFHostResponse("id1", "first-cluster", "[]");
-    mockCMFHostResponse("id34", "next-cluster", "[]\n\r");
+    stubCMFHostResponse("id1", "first-cluster", "[]");
+    stubCMFHostResponse("id34", "next-cluster", "[]\n\r");
 
     task.doRun(context, sink, handle);
 
@@ -158,7 +158,7 @@ public class ClouderaCMFHostsTaskTest {
   @Test
   public void doRun_clouderaReturnsInvalidJson_continueTaskWithoutWriting() throws Exception {
     initClusters(ClouderaClusterDTO.create("id1", "first-cluster"));
-    mockCMFHostResponse("id1", "first-cluster", "[}");
+    stubCMFHostResponse("id1", "first-cluster", "[}");
     verifyNoWrites();
   }
 
@@ -166,15 +166,15 @@ public class ClouderaCMFHostsTaskTest {
     handle.initClusters(Arrays.asList(clusters));
   }
 
-  private void mockCMFHostResponse(String clusterId, String clusterName, String jsonHosts)
+  private void stubCMFHostResponse(String clusterId, String clusterName, String jsonHosts)
       throws IOException {
-    String mockedResponse =
+    String cmfResponse =
         String.format("{\"clusterName\" :\"%s\", \"hosts\": %s}", clusterName, jsonHosts);
     server.stubFor(
         get(urlMatching(
                 String.format(
                     "/cmf/hardware/hosts/hostsOverview\\.json\\?clusterId=%s.*", clusterId)))
-            .willReturn(okJson(mockedResponse).withStatus(HttpStatus.SC_OK)));
+            .willReturn(okJson(cmfResponse).withStatus(HttpStatus.SC_OK)));
   }
 
   private Set<String> getWrittenJsonLines() throws IOException {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCMFHostsTaskTest.java
@@ -16,6 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
@@ -27,20 +30,20 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.exc.MismatchedInputException;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteSink;
 import com.google.common.io.CharSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.Writer;
 import java.net.URI;
@@ -48,11 +51,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.HttpStatus;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -64,17 +67,29 @@ public class ClouderaCMFHostsTaskTest {
   private final ClouderaCMFHostsTask task = new ClouderaCMFHostsTask();
 
   private ClouderaManagerHandle handle;
+  private static WireMockServer server;
 
   @Mock private TaskRunContext context;
   @Mock private ByteSink sink;
   @Mock private Writer writer;
   @Mock private CharSink charSink;
-  @Mock private CloseableHttpClient httpClient;
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    server = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    server.start();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    server.stop();
+  }
 
   @Before
   public void setUp() throws Exception {
-    URI uri = URI.create("http://localhost/");
-    handle = new ClouderaManagerHandle(uri, httpClient);
+    server.resetAll();
+    URI uri = URI.create(server.baseUrl() + "/api/vTest");
+    handle = new ClouderaManagerHandle(uri, HttpClients.createDefault());
 
     when(sink.asCharSink(eq(StandardCharsets.UTF_8))).thenReturn(charSink);
     when(charSink.openBufferedStream()).thenReturn(writer);
@@ -86,17 +101,10 @@ public class ClouderaCMFHostsTaskTest {
         ClouderaClusterDTO.create("id1", "first-cluster"),
         ClouderaClusterDTO.create("id34", "next-cluster"));
 
-    CloseableHttpResponse resp1 = mockCMFHostResponse("id1", "first-cluster", "[]");
-    CloseableHttpResponse resp2 = mockCMFHostResponse("id34", "next-cluster", "[]\n\r");
+    mockCMFHostResponse("id1", "first-cluster", "[]");
+    mockCMFHostResponse("id34", "next-cluster", "[]\n\r");
 
     task.doRun(context, sink, handle);
-
-    Set<URI> requestedUrls = getRequestedURLs();
-    assertEquals(
-        ImmutableSet.of(
-            URI.create("http://localhost//cmf/hardware/hosts/hostsOverview.json?clusterId=id1"),
-            URI.create("http://localhost//cmf/hardware/hosts/hostsOverview.json?clusterId=id34")),
-        requestedUrls);
 
     // write jsonl. https://jsonlines.org/
     Set<String> fileLines = getWrittenJsonLines();
@@ -106,9 +114,6 @@ public class ClouderaCMFHostsTaskTest {
             "{\"clusterName\":\"first-cluster\",\"hosts\":[]}",
             "{\"clusterName\":\"next-cluster\",\"hosts\":[]}"),
         fileLines);
-
-    verify(resp1).close();
-    verify(resp2).close();
     verify(writer).close();
   }
 
@@ -116,14 +121,10 @@ public class ClouderaCMFHostsTaskTest {
   public void doRun_clouderaReturnsNoHostForCluster_throwsWarningException() throws Exception {
     // GIVEN: The cluster which has no host
     initClusters(ClouderaClusterDTO.create("id1", "first-cluster"));
-    CloseableHttpResponse responseId = mock(CloseableHttpResponse.class);
-    HttpEntity entityId = mock(HttpEntity.class);
-    when(responseId.getEntity()).thenReturn(entityId);
-    when(httpClient.execute(
-            argThat(get -> get != null && get.getURI().toString().endsWith("=id1"))))
-        .thenReturn(responseId);
-    when(entityId.getContent())
-        .thenReturn(new ByteArrayInputStream("{\"clusterName\" :\"first-cluster\"}".getBytes()));
+    String mockedResponse = String.format("{\"clusterName\" :\"%s\"}", "first-cluster");
+    server.stubFor(
+        get(urlMatching("/cmf/hardware/hosts/hostsOverview.json\\?clusterId=id1.*"))
+            .willReturn(okJson(mockedResponse).withStatus(HttpStatus.SC_OK)));
 
     // WHEN: Hosts are requested from the API and no one has been returned
     MismatchedInputException exception =
@@ -139,7 +140,6 @@ public class ClouderaCMFHostsTaskTest {
 
     task.doRun(context, sink, handle);
 
-    verify(httpClient, never()).execute(any());
     verifyNoWrites();
   }
 
@@ -166,34 +166,15 @@ public class ClouderaCMFHostsTaskTest {
     handle.initClusters(Arrays.asList(clusters));
   }
 
-  private CloseableHttpResponse mockCMFHostResponse(
-      String clusterId, String clusterName, String jsonHosts) throws IOException {
-    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
-    HttpEntity entity = mock(HttpEntity.class);
-    when(response.getEntity()).thenReturn(entity);
-
-    when(httpClient.execute(
-            argThat(get -> get != null && get.getURI().toString().endsWith("=" + clusterId))))
-        .thenReturn(response);
-    when(entity.getContent())
-        .thenReturn(
-            new ByteArrayInputStream(
-                String.format("{\"clusterName\" :\"%s\", \"hosts\": %s}", clusterName, jsonHosts)
-                    .getBytes()));
-    return response;
-  }
-
-  private Set<URI> getRequestedURLs() throws IOException {
-    Set<URI> requestedUrls = new HashSet<>();
-    verify(httpClient, times(2))
-        .execute(
-            argThat(
-                request -> {
-                  assertEquals(HttpGet.class, request.getClass());
-                  requestedUrls.add(request.getURI());
-                  return true;
-                }));
-    return requestedUrls;
+  private void mockCMFHostResponse(String clusterId, String clusterName, String jsonHosts)
+      throws IOException {
+    String mockedResponse =
+        String.format("{\"clusterName\" :\"%s\", \"hosts\": %s}", clusterName, jsonHosts);
+    server.stubFor(
+        get(urlMatching(
+                String.format(
+                    "/cmf/hardware/hosts/hostsOverview\\.json\\?clusterId=%s.*", clusterId)))
+            .willReturn(okJson(mockedResponse).withStatus(HttpStatus.SC_OK)));
   }
 
   private Set<String> getWrittenJsonLines() throws IOException {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTaskTest.java
@@ -43,6 +43,7 @@ import com.google.common.io.ByteSink;
 import com.google.common.io.CharSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.AbstractClouderaTimeSeriesTask.TimeSeriesAggregation;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.AbstractClouderaTimeSeriesTask.TimeSeriesException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.IOException;
@@ -189,6 +190,7 @@ public class ClouderaClusterCPUChartTaskTest {
 
     // THEN: There is a relevant exception has been raised
     assertTrue(exception.getMessage().contains("Cloudera Error: "));
+    assertTrue(exception.getCause() instanceof TimeSeriesException);
     verifyNoWrites();
   }
 
@@ -206,6 +208,7 @@ public class ClouderaClusterCPUChartTaskTest {
 
     // THEN: There is a relevant exception has been raised
     assertTrue(exception.getMessage().contains("Cloudera Error: "));
+    assertTrue(exception.getCause() instanceof TimeSeriesException);
     verifyNoWrites();
   }
 
@@ -222,6 +225,7 @@ public class ClouderaClusterCPUChartTaskTest {
 
     // THEN: There is a relevant exception has been raised
     assertTrue(exception.getMessage().contains("Cloudera Error: "));
+    assertTrue(exception.getCause() instanceof TimeSeriesException);
     verifyNoWrites();
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCPUChartTaskTest.java
@@ -131,8 +131,8 @@ public class ClouderaClusterCPUChartTaskTest {
         ClouderaClusterDTO.create("id2", "second-cluster"));
     String firstClusterServicesJson = servicesJson;
     String secondClusterServicesJson = "{\"key\":" + servicesJson + "}";
-    mockHttpRequestToFetchClusterCPUChart("id1", firstClusterServicesJson);
-    mockHttpRequestToFetchClusterCPUChart("id2", secondClusterServicesJson);
+    stubHttpRequestToFetchClusterCPUChart("id1", firstClusterServicesJson);
+    stubHttpRequestToFetchClusterCPUChart("id2", secondClusterServicesJson);
 
     // WHEN:
     task.doRun(context, sink, handle);
@@ -180,7 +180,7 @@ public class ClouderaClusterCPUChartTaskTest {
     // GIVEN: There is a valid cluster
     initClusters(ClouderaClusterDTO.create("id1", "first-cluster"));
     String firstClusterServicesJson = servicesJson;
-    mockHttpRequestToFetchClusterCPUChart(
+    stubHttpRequestToFetchClusterCPUChart(
         "id1", firstClusterServicesJson, HttpStatus.SC_BAD_REQUEST);
 
     // WHEN: Cloudera returns 4xx http status code
@@ -197,7 +197,7 @@ public class ClouderaClusterCPUChartTaskTest {
     // GIVEN: There is a valid cluster
     initClusters(ClouderaClusterDTO.create("id1", "first-cluster"));
     String firstClusterServicesJson = servicesJson;
-    mockHttpRequestToFetchClusterCPUChart(
+    stubHttpRequestToFetchClusterCPUChart(
         "id1", firstClusterServicesJson, HttpStatus.SC_INTERNAL_SERVER_ERROR);
 
     // WHEN: Cloudera returns 4xx http status code
@@ -214,7 +214,7 @@ public class ClouderaClusterCPUChartTaskTest {
     // GIVEN: There is a valid cluster
     initClusters(ClouderaClusterDTO.create("id1", "first-cluster"));
     String firstClusterServicesJson = "{\"key\": []]";
-    mockHttpRequestToFetchClusterCPUChart("id1", firstClusterServicesJson);
+    stubHttpRequestToFetchClusterCPUChart("id1", firstClusterServicesJson);
 
     // WHEN: Cloudera returns 4xx http status code
     MetadataDumperUsageException exception =
@@ -229,12 +229,12 @@ public class ClouderaClusterCPUChartTaskTest {
     handle.initClusters(Arrays.asList(clusters));
   }
 
-  private void mockHttpRequestToFetchClusterCPUChart(String clusterName, String mockedContent)
+  private void stubHttpRequestToFetchClusterCPUChart(String clusterName, String mockedContent)
       throws IOException {
-    mockHttpRequestToFetchClusterCPUChart(clusterName, mockedContent, HttpStatus.SC_OK);
+    stubHttpRequestToFetchClusterCPUChart(clusterName, mockedContent, HttpStatus.SC_OK);
   }
 
-  private void mockHttpRequestToFetchClusterCPUChart(
+  private void stubHttpRequestToFetchClusterCPUChart(
       String clusterName, String mockedContent, int statusCode) throws IOException {
     server.stubFor(
         get(urlMatching(String.format("/api/vTest/timeseries.*%s.*", clusterName)))

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTaskTest.java
@@ -104,7 +104,7 @@ public class ClouderaClustersTaskTest {
   }
 
   @Test
-  public void clusterNotProvided_success() throws Exception {
+  public void doRun_clusterNotProvided_fetchAllClusters() throws Exception {
     when(arguments.getCluster()).thenReturn(null);
     URI apiUrl = URI.create(server.baseUrl() + "/api/vTest/");
     handle = new ClouderaManagerHandle(apiUrl, HttpClients.createDefault());
@@ -148,7 +148,7 @@ public class ClouderaClustersTaskTest {
   }
 
   @Test
-  public void clusterProvided_success() throws Exception {
+  public void doRun_clusterProvided_fetchOnlyProvidedCluster() throws Exception {
     when(arguments.getCluster()).thenReturn("my-cluster");
     URI apiUrl = URI.create(server.baseUrl() + "/api/vTest/");
     handle = new ClouderaManagerHandle(apiUrl, HttpClients.createDefault());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTaskTest.java
@@ -42,6 +42,7 @@ import com.google.common.io.ByteSink;
 import com.google.common.io.CharSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.AbstractClouderaTimeSeriesTask.TimeSeriesAggregation;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.AbstractClouderaTimeSeriesTask.TimeSeriesException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaHostDTO;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.IOException;
@@ -132,6 +133,7 @@ public class ClouderaHostRAMChartTaskTest {
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
 
     assertTrue(exception.getMessage().contains("Cloudera Error:"));
+    assertTrue(exception.getCause() instanceof TimeSeriesException);
     verifyNoWrites();
   }
 
@@ -144,6 +146,7 @@ public class ClouderaHostRAMChartTaskTest {
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
 
     assertTrue(exception.getMessage().contains("Cloudera Error:"));
+    assertTrue(exception.getCause() instanceof TimeSeriesException);
     verifyNoWrites();
   }
 
@@ -156,6 +159,7 @@ public class ClouderaHostRAMChartTaskTest {
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
 
     assertTrue(exception.getMessage().contains("Cloudera Error:"));
+    assertTrue(exception.getCause() instanceof TimeSeriesException);
     verifyNoWrites();
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRAMChartTaskTest.java
@@ -99,8 +99,8 @@ public class ClouderaHostRAMChartTaskTest {
     initHosts(
         ClouderaHostDTO.create("id1", "first-host"),
         ClouderaHostDTO.create("id125", "second-host"));
-    mockHostAPIResponse("id1", HttpStatus.SC_OK, "{\"items\":[\"host1\"]}");
-    mockHostAPIResponse("id125", HttpStatus.SC_OK, "{\n\"items\":[\"host2\"]\n\r}");
+    stubHostAPIResponse("id1", HttpStatus.SC_OK, "{\"items\":[\"host1\"]}");
+    stubHostAPIResponse("id125", HttpStatus.SC_OK, "{\n\"items\":[\"host2\"]\n\r}");
 
     task.doRun(context, sink, handle);
 
@@ -126,7 +126,7 @@ public class ClouderaHostRAMChartTaskTest {
   @Test
   public void doRun_clouderaServerReturnsInvalidJson_throwsCriticalException() throws Exception {
     initHosts(ClouderaHostDTO.create("id1", "first-host"));
-    mockHostAPIResponse("id1", HttpStatus.SC_OK, "\"items\":[\"host1\"]}");
+    stubHostAPIResponse("id1", HttpStatus.SC_OK, "\"items\":[\"host1\"]}");
 
     MetadataDumperUsageException exception =
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
@@ -138,7 +138,7 @@ public class ClouderaHostRAMChartTaskTest {
   @Test
   public void doRun_clouderaServerReturns4xx_throwsCriticalException() throws Exception {
     initHosts(ClouderaHostDTO.create("id1", "first-host"));
-    mockHostAPIResponse("id1", HttpStatus.SC_BAD_REQUEST, "{\"items\":[\"host1\"]}");
+    stubHostAPIResponse("id1", HttpStatus.SC_BAD_REQUEST, "{\"items\":[\"host1\"]}");
 
     MetadataDumperUsageException exception =
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
@@ -150,7 +150,7 @@ public class ClouderaHostRAMChartTaskTest {
   @Test
   public void doRun_clouderaServerReturns5xx_throwsCriticalException() throws Exception {
     initHosts(ClouderaHostDTO.create("id1", "first-host"));
-    mockHostAPIResponse("id1", HttpStatus.SC_INTERNAL_SERVER_ERROR, "{\"items\":[\"host1\"]}");
+    stubHostAPIResponse("id1", HttpStatus.SC_INTERNAL_SERVER_ERROR, "{\"items\":[\"host1\"]}");
 
     MetadataDumperUsageException exception =
         assertThrows(MetadataDumperUsageException.class, () -> task.doRun(context, sink, handle));
@@ -163,7 +163,7 @@ public class ClouderaHostRAMChartTaskTest {
     handle.initHostsIfNull(Arrays.asList(hosts));
   }
 
-  private void mockHostAPIResponse(String hostId, int statusCode, String responseContent)
+  private void stubHostAPIResponse(String hostId, int statusCode, String responseContent)
       throws IOException {
     server.stubFor(
         get(urlMatching(String.format("/api/vTest/timeseries.*%s.*", hostId)))


### PR DESCRIPTION
- Move objectMapper under the API methods of AbstractClouderaManagerTask.
- Add tests to cover different Cloudera http responses during the tasks.