### PR TITLE
[b/392580006] fix: Missing views in SF Lite extraction

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -80,10 +80,10 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   }
 
   private static Task<?> proceduresTask() {
+    String view = "SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES";
     String query =
-        "SELECT procedure_language, procedure_owner, count(1)"
-            + " FROM SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES"
-            + " GROUP BY procedure_language, procedure_owner";
+        String.format(
+            "SELECT procedure_language, procedure_owner, count(1) FROM %s GROUP BY ALL", view);
     ImmutableList<String> header = ImmutableList.of("Language", "Owner", "Count");
     return new LiteTimeSeriesTask("procedures.csv", query, header);
   }
@@ -91,8 +91,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   private static Task<?> warehouseEventsTask() {
     String query =
         "SELECT event_name, cluster_number, warehouse_id, warehouse_name, count(1)"
-            + " FROM SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_EVENTS_HISTORY"
-            + " GROUP BY event_name, cluster_number, warehouse_id, warehouse_name";
+            + " FROM SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_EVENTS_HISTORY GROUP BY ALL";
     ImmutableList<String> header =
         ImmutableList.of("Name", "Cluster", "WarehouseId", "WarehouseName", "Count");
     return new LiteTimeSeriesTask("warehouse_events.csv", query, header);
@@ -100,10 +99,9 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   private static Task<?> warehouseMeteringTask() {
     String view = "SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_METERING_HISTORY";
-    String sql =
-        String.format("SELECT warehouse_name, count(1) FROM %s GROUP BY warehouse_name", view);
+    String query = String.format("SELECT warehouse_name, count(1) FROM %s GROUP BY ALL", view);
     ImmutableList<String> header = ImmutableList.of("Name", "Count");
-    return new LiteTimeSeriesTask("warehouse_metering.csv", sql, header);
+    return new LiteTimeSeriesTask("warehouse_metering.csv", query, header);
   }
 
   private static final class LiteTimeSeriesTask extends JdbcSelectTask {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -65,6 +65,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
     ImmutableList.Builder<Task<?>> builder = ImmutableList.builder();
 
     builder.addAll(planner.generateLiteSpecificQueries());
+    builder.add(proceduresTask());
     builder.add(warehouseEventsTask());
     builder.add(warehouseMeteringTask());
 
@@ -76,6 +77,15 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
       builder.add(task);
     }
     return builder.build();
+  }
+
+  private static Task<?> proceduresTask() {
+    String query =
+        "SELECT procedure_language, procedure_owner, count(1)"
+            + " FROM SNOWFLAKE.ACCOUNT_USAGE.PROCEDURES"
+            + " GROUP BY procedure_language, procedure_owner";
+    ImmutableList<String> header = ImmutableList.of("Language", "Owner", "Count");
+    return new LiteTimeSeriesTask("procedures.csv", query, header);
   }
 
   private static Task<?> warehouseEventsTask() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -23,16 +23,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakePlanner.AssessmentQuery;
-import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
-import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.DatabasesFormat;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.SchemataFormat;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.TablesFormat;
 import java.sql.ResultSet;
 import java.time.Clock;
 import java.util.List;
@@ -59,10 +54,6 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
     return ArchiveNameUtil.getFileName(NAME);
   }
 
-  private AbstractJdbcTask<Summary> createTask(String sql, String usageZip) {
-    return new JdbcSelectTask(usageZip, sql);
-  }
-
   @Override
   public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
@@ -71,31 +62,9 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   }
 
   private ImmutableList<Task<?>> createTaskList() {
-    String view = "SNOWFLAKE.ACCOUNT_USAGE";
-    String filter = " WHERE DELETED IS NULL";
     ImmutableList.Builder<Task<?>> builder = ImmutableList.builder();
 
-    String databases =
-        String.format("SELECT database_name, database_owner FROM %s.DATABASES%s", view, filter);
-    builder.add(
-        new JdbcSelectTask(DatabasesFormat.AU_ZIP_ENTRY_NAME, databases)
-            .withHeaderClass(DatabasesFormat.Header.class));
-
-    String schemata =
-        String.format("SELECT catalog_name, schema_name FROM %s.SCHEMATA%s", view, filter);
-    builder.add(
-        createTask(schemata, SchemataFormat.AU_ZIP_ENTRY_NAME)
-            .withHeaderClass(SchemataFormat.Header.class));
-
-    String tables =
-        String.format(
-            "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes,"
-                + " clustering_key FROM %s.TABLES%s",
-            view, filter);
-    builder.add(
-        createTask(tables, TablesFormat.AU_ZIP_ENTRY_NAME)
-            .withHeaderClass(TablesFormat.Header.class));
-
+    builder.addAll(planner.generateLiteSpecificQueries());
     builder.add(createWarehouseEvents());
 
     for (AssessmentQuery item : planner.generateAssessmentQueries()) {


### PR DESCRIPTION
- Add missing extraction of `PROCEDURES`
- Add missing extraction of `WAREHOUSE_METERING_HISTORY`
- Move extraction of `DATABASES`, `SCHEMATA`, `TABLES` to another class

[dry-run output with queries](https://github.com/user-attachments/files/18537243/dry-run.txt)
 