### PR TITLE
[b394751887] add compilerworks_metadata.yaml to Ranger output zip

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/ranger/RangerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/ranger/RangerConnector.java
@@ -27,6 +27,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.ranger.Ranger
 import com.google.edwmigration.dumper.application.dumper.handle.AbstractHandle;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractTask;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
@@ -88,6 +89,7 @@ public class RangerConnector extends AbstractConnector {
   @Override
   public void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments) {
+    out.add(new DumpMetadataTask(arguments, RangerDumpFormat.FORMAT_NAME));
     out.add(new DumpGroupsTask());
     out.add(new DumpPoliciesTask());
     out.add(new DumpRolesTask());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/ranger/RangerConnectorTasksTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/ranger/RangerConnectorTasksTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2022-2024 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.ranger;
+
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.task.Task;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+
+
+@RunWith(JUnit4.class)
+public class RangerConnectorTasksTest {
+  @Mock protected CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+
+    @Test
+    public void isDumpMetadataTaskinConnectorTasks() throws Exception {
+        RangerConnector connector = new RangerConnector();
+
+        List<Task<?>> tasks = new ArrayList<>();
+        ConnectorArguments args =
+        new ConnectorArguments("--connector", "ranger");
+
+        connector.addTasksTo(tasks, args);
+        assertTrue(tasks.stream().filter(task -> 
+            task.toString().contains("compilerworks-metadata.yaml")).findAny().isPresent());
+    }
+}

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RangerDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/RangerDumpFormat.java
@@ -23,6 +23,8 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 public interface RangerDumpFormat {
 
+  String FORMAT_NAME = "ranger.dump.zip";
+
   ObjectMapper MAPPER =
       new ObjectMapper()
           .registerModule(new JavaTimeModule())


### PR DESCRIPTION
HDFS assessment job cannot work without compilerworks_metadata.yaml, so there was a need to add it.

Testing:
There was a problem with automatic testing, for test solution should be create integration/e2e test that checks if HDFS assessment is passing. There is no point of unit testing it - DumpMetadataTask was tested in different place, adding files to folder too. And there is no point of testing logic of totally different component. 

I checked HDFS assessment before and after and fix works as it shows assessment job lszydelko-test-12.
