### PR TITLE
Fix: Collect cluster name with YARN application types

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTask.java
@@ -80,7 +80,7 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
               appLoader.load(
                   clusterName,
                   yarnAppType,
-                  yarnAppsPage -> writeYarnAppTypes(writer, yarnAppsPage, yarnAppType));
+                  yarnAppsPage -> writeYarnAppTypes(writer, yarnAppsPage, yarnAppType, clusterName));
           LOG.info(
               "Dumped {} YARN applications with {} type from {} cluster",
               loadedAppsCount,
@@ -92,11 +92,11 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
   }
 
   private void writeYarnAppTypes(
-      Writer writer, List<ApiYARNApplicationDTO> yarnApps, String appType) {
+      Writer writer, List<ApiYARNApplicationDTO> yarnApps, String appType, String clusterName) {
     List<ApplicationTypeToYarnApplication> yarnAppTypeMappings = new ArrayList<>();
     for (ApiYARNApplicationDTO yarnApp : yarnApps) {
       yarnAppTypeMappings.add(
-          new ApplicationTypeToYarnApplication(yarnApp.getApplicationId(), appType));
+          new ApplicationTypeToYarnApplication(yarnApp.getApplicationId(), appType, clusterName));
     }
     try {
       String yarnAppTypeMappingsInJson =
@@ -132,10 +132,12 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
   private static class ApplicationTypeToYarnApplication {
     private final String applicationId;
     private final String applicationType;
+    private final String clusterName;
 
-    public ApplicationTypeToYarnApplication(String applicationId, String applicationType) {
+    public ApplicationTypeToYarnApplication(String applicationId, String applicationType, String clusterName) {
       this.applicationId = applicationId;
       this.applicationType = applicationType;
+      this.clusterName = clusterName;
     }
 
     public String getApplicationId() {
@@ -145,5 +147,7 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
     public String getApplicationType() {
       return applicationType;
     }
+
+    public String getClusterName() {return clusterName;}
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTask.java
@@ -80,7 +80,8 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
               appLoader.load(
                   clusterName,
                   yarnAppType,
-                  yarnAppsPage -> writeYarnAppTypes(writer, yarnAppsPage, yarnAppType, clusterName));
+                  yarnAppsPage ->
+                      writeYarnAppTypes(writer, yarnAppsPage, yarnAppType, clusterName));
           LOG.info(
               "Dumped {} YARN applications with {} type from {} cluster",
               loadedAppsCount,
@@ -134,7 +135,8 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
     private final String applicationType;
     private final String clusterName;
 
-    public ApplicationTypeToYarnApplication(String applicationId, String applicationType, String clusterName) {
+    public ApplicationTypeToYarnApplication(
+        String applicationId, String applicationType, String clusterName) {
       this.applicationId = applicationId;
       this.applicationType = applicationType;
       this.clusterName = clusterName;
@@ -148,6 +150,8 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
       return applicationType;
     }
 
-    public String getClusterName() {return clusterName;}
+    public String getClusterName() {
+      return clusterName;
+    }
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTaskTest.java
@@ -120,13 +120,13 @@ public class ClouderaYarnApplicationTypeTaskTest {
     List<String> fileJsonLines = MockUtils.getWrittenJsonLines(writer, 3);
     assertTrue(
         fileJsonLines.contains(
-            "{\"yarnAppTypes\":[{\"applicationId\":\"spark-app\",\"applicationType\":\"SPARK\"}]}"));
+            "{\"yarnAppTypes\":[{\"applicationId\":\"spark-app\",\"applicationType\":\"SPARK\",\"clusterName\":\"test-cluster\"}]}"));
     assertTrue(
         fileJsonLines.contains(
-            "{\"yarnAppTypes\":[{\"applicationId\":\"mapreduce-app\",\"applicationType\":\"MAPREDUCE\"}]}"));
+            "{\"yarnAppTypes\":[{\"applicationId\":\"mapreduce-app\",\"applicationType\":\"MAPREDUCE\",\"clusterName\":\"test-cluster\"}]}"));
     assertTrue(
         fileJsonLines.contains(
-            "{\"yarnAppTypes\":[{\"applicationId\":\"custom-app\",\"applicationType\":\"CLOUDERA_TYPE\"}]}"));
+            "{\"yarnAppTypes\":[{\"applicationId\":\"custom-app\",\"applicationType\":\"CLOUDERA_TYPE\",\"clusterName\":\"test-cluster\"}]}"));
   }
 
   @Test
@@ -183,7 +183,7 @@ public class ClouderaYarnApplicationTypeTaskTest {
     List<String> fileJsonLines = MockUtils.getWrittenJsonLines(writer, 3);
     assertTrue(
         fileJsonLines.contains(
-            "{\"yarnAppTypes\":[{\"applicationId\":\"custom-app\",\"applicationType\":\"CUSTOM-YARN-APP-TYPE\"}]}"));
+            "{\"yarnAppTypes\":[{\"applicationId\":\"custom-app\",\"applicationType\":\"CUSTOM-YARN-APP-TYPE\",\"clusterName\":\"test-cluster\"}]}"));
   }
 
   @Test
@@ -209,7 +209,7 @@ public class ClouderaYarnApplicationTypeTaskTest {
     List<String> fileJsonLines = MockUtils.getWrittenJsonLines(writer, 3);
     assertTrue(
         fileJsonLines.contains(
-            "{\"yarnAppTypes\":[{\"applicationId\":\"oozie\",\"applicationType\":\"Oozie Launcher\"}]}"));
+            "{\"yarnAppTypes\":[{\"applicationId\":\"oozie\",\"applicationType\":\"Oozie Launcher\",\"clusterName\":\"test-cluster\"}]}"));
   }
 
   private void initClusters(ClouderaClusterDTO... clusters) {


### PR DESCRIPTION
It's possible to have a collision between the same application IDs in context of different clusters.