### PR TITLE
Add sizeIfKnown for GCS source and also fix some other issues

### DIFF
--- a/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/GcsClientMain.java
+++ b/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/GcsClientMain.java
@@ -16,6 +16,12 @@ public class GcsClientMain {
             .ofType(String.class)
             .required();
 
+    private final OptionSpec<String> locationOptionSpec =
+        parser.accepts("location", "Specifies the gcp location")
+            .withRequiredArg()
+            .ofType(String.class)
+            .required();
+
     private final OptionSpec<String> targetOptionSpec =
         parser.accepts("target_file", "Specifies the target file")
             .withRequiredArg()
@@ -42,11 +48,17 @@ public class GcsClientMain {
       return getOptions().valueOf(projectOptionSpec);
     }
 
+    public String getLocation() {
+      return getOptions().valueOf(locationOptionSpec);
+    }
+
     public String getTargetUri() {
       return getOptions().valueOf(targetOptionSpec);
     }
 
-    public String getSourceUri() {return getOptions().valueOf(sourceOptionSpec);}
+    public String getSourceUri() {
+      return getOptions().valueOf(sourceOptionSpec);
+    }
 
     public String getStagingBucket() {
       return getOptions().valueOf(stagingBucketOptionSpec);
@@ -56,14 +68,18 @@ public class GcsClientMain {
   public static void main(String[] args) {
     RsyncClient client = new RsyncClient();
     Arguments arguments = new Arguments(args);
+    // This is needed as URI.resolve do not add '/' automatically
+    String stagingBucket = arguments.getStagingBucket().endsWith("/") ? arguments.getStagingBucket()
+        : arguments.getStagingBucket() + "/";
     try {
       client.putRsync(
           arguments.getProject(),
+          arguments.getLocation(),
           new URI(arguments.getSourceUri()),
-          new URI(arguments.getStagingBucket()),
+          new URI(stagingBucket),
           new URI(arguments.getTargetUri())
       );
-    } catch (Exception e){
+    } catch (Exception e) {
       Logger.getLogger("rsync").log(Level.INFO, e.getMessage(), e);
     }
   }

--- a/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/RsyncClient.java
+++ b/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/RsyncClient.java
@@ -27,7 +27,7 @@ public class RsyncClient {
   // GcsClientMain calls this.
   // Validation calls this.
   // TODO support multiple files ?
-  public void putRsync(String projectId, URI sourceUri, URI stagingBucket, URI targetUri)
+  public void putRsync(String projectId, String location, URI sourceUri, URI stagingBucket, URI targetUri)
       throws IOException, ExecutionException, InterruptedException {
     ByteSource byteSource;
     switch (sourceUri.getScheme()) {
@@ -42,7 +42,7 @@ public class RsyncClient {
         throw new IllegalStateException("Unexpected URI Scheme: " + sourceUri.getScheme());
     }
 
-    CloudRunServerAPI server = new CloudRunServerAPI(projectId, "", stagingBucket, targetUri);
+    CloudRunServerAPI server = new CloudRunServerAPI(projectId, location, stagingBucket, targetUri);
 
     if (byteSource.size() < MIN_SIZE_TO_RSYNC) {
       throw new IllegalStateException("dont handle small files");
@@ -84,5 +84,7 @@ public class RsyncClient {
 
     // Reconstruct on GCS
     server.reconstruct();
+
+    //TODO delete the jobs from cloudrun
   }
 }

--- a/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsByteSource.java
+++ b/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsByteSource.java
@@ -1,6 +1,7 @@
 package com.google.edwmigration.dbsync.storage.gcs;
 
 import com.google.cloud.ReadChannel;
+import com.google.common.base.Optional;
 import com.google.edwmigration.dbsync.common.storage.AbstractRemoteByteSource;
 import com.google.edwmigration.dbsync.common.storage.Slice;
 import com.google.cloud.storage.BlobId;
@@ -48,5 +49,10 @@ public class GcsByteSource extends AbstractRemoteByteSource {
     protected MoreObjects.ToStringHelper toStringHelper(ToStringHelper helper) {
         return super.toStringHelper(helper)
             .add("blobId", blobId);
+    }
+
+    @Override
+    public Optional<Long> sizeIfKnown(){
+        return Optional.of(storage.get(blobId).asBlobInfo().getSize());
     }
 }


### PR DESCRIPTION
1. Added sizeIfKnown for GCS byte source 
2. Fixed naming for cloud run jobs
3. Made cloud run job names random to isolate runs. We should make the command parameteraized if possible to create one job and then update different parameters for different instances.