### PR TITLE
[b/390590500] use info log level for not found drivers for Airflow connector

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/AbstractJdbcConnector.java
@@ -31,6 +31,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.BiConsumer;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import org.slf4j.Logger;
@@ -112,17 +113,33 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
       @Nonnull ClassLoader driverClassLoader, @Nonnull String driverClassName)
       throws PrivilegedActionException {
     return AccessController.doPrivileged(
-        new PrivilegedExceptionAction<Class<?>>() {
-          @Override
-          public Class<?> run() throws Exception {
-            return Class.forName(driverClassName, true, driverClassLoader);
-          }
-        });
+        (PrivilegedExceptionAction<Class<?>>)
+            () -> Class.forName(driverClassName, true, driverClassLoader));
   }
 
   @Nonnull
   protected Driver newDriver(
       @CheckForNull List<String> driverPaths, @Nonnull String... driverClassNames)
+      throws SQLException {
+    return newDriver(
+        driverPaths,
+        (driverClassName, e) -> {
+          if (e.getCause() instanceof ClassNotFoundException)
+            LOG.warn(
+                "Cannot load driver class [{}] from path {}: {}",
+                driverClassName,
+                driverPaths,
+                e.getCause());
+          else throw new RuntimeException(e);
+        },
+        driverClassNames);
+  }
+
+  @Nonnull
+  protected Driver newDriver(
+      @CheckForNull List<String> driverPaths,
+      BiConsumer<String, PrivilegedActionException> onClassLoadException,
+      @Nonnull String... driverClassNames)
       throws SQLException {
     Class<?> driverClass = null;
     try {
@@ -136,13 +153,7 @@ public abstract class AbstractJdbcConnector extends AbstractConnector {
             driverClass = newDriverClass(driverClassLoader, driverClassName);
             if (driverClass != null) break CLASS;
           } catch (PrivilegedActionException e) {
-            if (e.getCause() instanceof ClassNotFoundException)
-              LOG.warn(
-                  "Cannot load driver class [{}] from path {}: {}",
-                  driverClassName,
-                  driverPaths,
-                  e.getCause());
-            else throw e;
+            onClassLoadException.accept(driverClassName, e);
           }
         }
         throw new SQLException(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
@@ -187,14 +187,6 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
         driverClasses.stream()
             .map(AirflowDatabaseDriverClasses::getDriverClassName)
             .toArray(String[]::new);
-    return newDriver(
-        driverPaths,
-        (driverClassName, e) -> {
-          LOG.info(
-              "Checking drivers path [{}] for available drivers... Driver [{}] wasn't not available.",
-              driverPaths,
-              driverClassName);
-        },
-        driverClassesNames);
+    return newDriver(driverPaths, driverClassesNames);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
@@ -154,7 +154,6 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
     Driver driver;
 
     if (!arguments.hasUri()) {
-      // todo fix warning logs, because no drivers is expected case
       driver = loadFirstAvailableDriver(arguments.getDriverPaths(), driverClasses);
       String host = arguments.getHost();
       int port = arguments.getPort();
@@ -188,6 +187,14 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
         driverClasses.stream()
             .map(AirflowDatabaseDriverClasses::getDriverClassName)
             .toArray(String[]::new);
-    return newDriver(driverPaths, driverClassesNames);
+    return newDriver(
+        driverPaths,
+        (driverClassName, e) -> {
+          LOG.info(
+              "Checking drivers path [{}] for available drivers... Driver [{}] wasn't not available.",
+              driverPaths,
+              driverClassName);
+        },
+        driverClassesNames);
   }
 }


### PR DESCRIPTION
Airflow may work with different databases, so the airflow connector check different driver classes. Do not find some driver class for example  PostgreSql is expected if the instance of Airflow works with MySql.

Errors and stack traces in the output may be confusing for user, so improve it.

before:
```
10:43:20.610 [main] WARN  com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector - Cannot load driver class [com.mysql.jdbc.Driver] from path [/Users/vsidorovich/jdbc/postgresql-42.7.5.jar]: {}
java.lang.ClassNotFoundException: com.mysql.jdbc.Driver
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:419)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:352)
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:348)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector$3.run(AbstractJdbcConnector.java:118)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector$3.run(AbstractJdbcConnector.java:115)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriverClass(AbstractJdbcConnector.java:114)
	at com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector.newDriver(AbstractJdbcConnector.java:136)
	at com.google.edwmigration.dumper.application.dumper.connector.airflow.AirflowConnector.loadFirstAvailableDriver(AirflowConnector.java:191)
	at com.google.edwmigration.dumper.application.dumper.connector.airflow.AirflowConnector.open(AirflowConnector.java:158)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:180)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:91)
	at com.google.edwmigration.dumper.application.dumper.MetadataDumper.run(MetadataDumper.java:67)
	at com.google.edwmigration.dumper.application.dumper.Main.run(Main.java:40)
	at com.google.edwmigration.dumper.application.dumper.Main.main(Main.java:69)
```

after:
```
10:49:45.704 [main] INFO  com.google.edwmigration.dumper.application.dumper.connector.airflow.AirflowConnector - Checking drivers path [[/Users/vsidorovich/jdbc/postgresql-42.7.5.jar]] for available drivers... Driver [com.mysql.jdbc.Driver] wasn't not available.
10:49:45.875 [main] INFO  com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector - Using JDBC Driver: class org.postgresql.Driver
```

Such case is unique for airflow connector. 