### PR TITLE
Add licenseReport task to dbsync

### DIFF
--- a/dbsync/build.gradle
+++ b/dbsync/build.gradle
@@ -20,7 +20,6 @@ buildscript {
 }
 
 plugins {
-    alias libs.plugins.shadow
     id 'dbsync.java-application-conventions'
 }
 
@@ -36,7 +35,6 @@ dependencies {
 }
 
 licenseReport {
-    // onlyIf { ! gradle.startParameter.offline }
     filters = [
         new com.github.jk1.license.filter.LicenseBundleNormalizer(bundlePath: rootProject.file("gradle/license-bundle-normalizer.json"), createDefaultTransformationRules: true)
     ]

--- a/dbsync/build.gradle
+++ b/dbsync/build.gradle
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+buildscript {
+    dependencies {
+        classpath libs.gradle.license.report
+    }
+}
+
+plugins {
+    alias libs.plugins.shadow
+    id 'dbsync.java-application-conventions'
+}
+
+apply plugin: 'com.github.jk1.dependency-license-report'
+
+dependencies {
+    implementation project(':dbsync:client')
+    implementation project(':dbsync:common')
+    implementation project(':dbsync:server')
+    implementation project(':dbsync:storage-aws')
+    implementation project(':dbsync:storage-gcs')
+    implementation project(':dbsync:storage-hdfs')
+}
+
+licenseReport {
+    // onlyIf { ! gradle.startParameter.offline }
+    filters = [
+        new com.github.jk1.license.filter.LicenseBundleNormalizer(bundlePath: rootProject.file("gradle/license-bundle-normalizer.json"), createDefaultTransformationRules: true)
+    ]
+    renderers = [
+        new com.google.edwmigration.dumper.build.licensereport.CsvReportRenderer(),
+        new com.github.jk1.license.render.JsonReportRenderer('index.json', false),
+        new com.github.jk1.license.render.InventoryHtmlReportRenderer("index.html", "Licenses of Third Party Dependencies")
+    ]
+    allowedLicensesFile = rootProject.file("gradle/license-allowed.json")
+}

--- a/gradle/license-allowed.json
+++ b/gradle/license-allowed.json
@@ -48,6 +48,10 @@
 			"moduleName": ".*"
 		},
 		{
+			"moduleLicense": "MIT-0",
+			"moduleName": ".*"
+		},
+		{
 			"moduleLicense": "ISC",
 			"moduleName": ".*"
 		},


### PR DESCRIPTION
This PR adds a licenseReport task to the dbsync module. As a result `./gradlew checkLicense` command will produce additional licenses file for the `dbsync` module. 

Report path: dbsync/build/reports/dependency-license/licenses.csv