### PR TITLE
Add task to build the license report for the whole dwh-migration-tools repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
     alias libs.plugins.version.catalog.update
 }
 
+apply plugin: 'com.github.jk1.dependency-license-report'
+
 distributions {
     published {
         distributionBaseName = "dwh-migration-tools"
@@ -38,4 +40,16 @@ versionCatalogUpdate {
         keepUnusedLibraries = true
         keepUnusedPlugins = true
     }
+}
+
+licenseReport {
+    filters = [
+        new com.github.jk1.license.filter.LicenseBundleNormalizer(bundlePath: rootProject.file("gradle/license-bundle-normalizer.json"), createDefaultTransformationRules: true)
+    ]
+    renderers = [
+        new com.google.edwmigration.dumper.build.licensereport.CsvReportRenderer(),
+        new com.github.jk1.license.render.JsonReportRenderer('index.json', false),
+        new com.github.jk1.license.render.InventoryHtmlReportRenderer("index.html", "Licenses of Third Party Dependencies")
+    ]
+    allowedLicensesFile = rootProject.file("gradle/license-allowed.json")
 }


### PR DESCRIPTION
This PR adds additional `checkLicense` task in the repository root to generate single licenses.csv file with all the dependencies.

File will be stored in `build/reports/dependency-license/licenses.csv` 