### PR TITLE
[dbsync] Fix open issues in rsync library and make it functional

### DIFF
--- a/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/GcsClientMain.java
+++ b/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/GcsClientMain.java
@@ -80,7 +80,7 @@ public class GcsClientMain {
       return getOptions().valueOf(stagingBucketOptionSpec);
     }
 
-    public Boolean getDeleteStagingFilesOptionSpec() {
+    public Boolean getDeleteStagingFilesOption() {
       return getOptions().valueOf(deleteStagingFilesOptionSpec);
     }
   }
@@ -95,7 +95,7 @@ public class GcsClientMain {
           new URI(arguments.getSourceUri()),
           new URI(UriUtil.ensureTrailingSlash(arguments.getStagingBucket())),
           new URI(arguments.getTargetUri()),
-          arguments.getDeleteStagingFilesOptionSpec());
+          arguments.getDeleteStagingFilesOption());
     } catch (Exception e) {
       Logger.getLogger("rsync").log(Level.INFO, e.getMessage(), e);
     }

--- a/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/RsyncClient.java
+++ b/dbsync/client/src/main/java/com/google/edwmigration/dbsync/client/RsyncClient.java
@@ -5,6 +5,7 @@ import com.google.edwmigration.dbsync.common.InstructionGenerator;
 import com.google.edwmigration.dbsync.common.storage.LocalStorage;
 import com.google.edwmigration.dbsync.proto.Checksum;
 import com.google.edwmigration.dbsync.server.GCSTarget;
+import com.google.edwmigration.dbsync.server.GcsServerMain.Mode;
 import com.google.edwmigration.dbsync.server.RsyncTarget;
 import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
@@ -101,6 +102,7 @@ public class RsyncClient {
     // Reconstruct on GCS
     server.reconstruct();
 
-    // TODO delete the jobs from cloudrun
+    server.deleteJob(Mode.GENERATE);
+    server.deleteJob(Mode.RECEIVE);
   }
 }

--- a/dbsync/common/src/main/java/com/google/edwmigration/dbsync/common/UriUtil.java
+++ b/dbsync/common/src/main/java/com/google/edwmigration/dbsync/common/UriUtil.java
@@ -1,0 +1,20 @@
+package com.google.edwmigration.dbsync.common;
+
+import java.net.URI;
+
+public class UriUtil {
+  public static String ensureTrailingSlash(String uri) {
+    if (uri.endsWith("/")) {
+      return uri;
+    }
+    return uri + "/";
+  }
+
+  public static String getRelativePath(URI uri) {
+    String path = uri.getPath();
+    if (path.startsWith("/")) {
+      return path.substring(1);
+    }
+    return path;
+  }
+}

--- a/dbsync/common/src/test/java/com/google/edwmigration/dbsync/common/UriUtilTest.java
+++ b/dbsync/common/src/test/java/com/google/edwmigration/dbsync/common/UriUtilTest.java
@@ -1,0 +1,39 @@
+package com.google.edwmigration.dbsync.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+
+class UriUtilTest {
+
+  @Test
+  void ensureTrailingSlash_addMissingSlash() {
+    assertEquals("gs://path/to/folder/", UriUtil.ensureTrailingSlash("gs://path/to/folder"));
+    assertEquals("/path/to/folder/", UriUtil.ensureTrailingSlash("/path/to/folder"));
+    assertEquals("path/to/folder/", UriUtil.ensureTrailingSlash("path/to/folder"));
+  }
+
+  @Test
+  void ensureTrailingSlash_retainsExistingSlash() {
+    assertEquals("gs://path/to/folder/", UriUtil.ensureTrailingSlash("gs://path/to/folder/"));
+    assertEquals("/path/to/folder/", UriUtil.ensureTrailingSlash("/path/to/folder/"));
+    assertEquals("path/to/folder/", UriUtil.ensureTrailingSlash("path/to/folder/"));
+  }
+
+  @Test
+  void getRelativePath_extractFilePath() {
+    assertEquals(
+        "path/to/file.txt", UriUtil.getRelativePath(URI.create("gs://bucket/path/to/file.txt")));
+  }
+
+  @Test
+  void getRelativePath_extractFolderPath() {
+    assertEquals("path/to/file/", UriUtil.getRelativePath(URI.create("gs://bucket/path/to/file/")));
+  }
+
+  @Test
+  void getRelativePath_returnEmptyStringWhenNoPathPresent() {
+    assertEquals("", UriUtil.getRelativePath(URI.create("gs://bucket/")));
+  }
+}

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
@@ -22,7 +22,6 @@ public class CloudRunServerAPI {
   private static final String BASE_IMAGE_ENV_VAR = "RSYNC_CLOUD_BASE_IMAGE";
   private static final String SERVER_JAR_ENV_VAR = "RSYNC_SERVER_JAR";
   private static final String RSYNC_BINARY_NAME = "rsync-binary";
-
   private final String project;
   private final String location;
   private final URI stagingBucket;
@@ -133,6 +132,14 @@ public class CloudRunServerAPI {
   public void reconstruct() throws IOException, ExecutionException, InterruptedException {
     try (JobsClient jobsClient = JobsClient.create()) {
       jobsClient.runJobAsync(JobName.of(project, location, getJobId(Mode.RECEIVE))).get();
+    }
+  }
+
+  public void deleteJob(Mode mode)
+      throws IOException, ExecutionException, InterruptedException {
+    try(JobsClient jobsClient = JobsClient.create()) {
+      JobName jobName = JobName.of(project, location, getJobId(mode));
+      jobsClient.deleteJobAsync(jobName).get();
     }
   }
 }

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
@@ -84,10 +84,10 @@ public class CloudRunServerAPI {
   }
 
   public void deployRsyncJobs() throws IOException, ExecutionException, InterruptedException {
-    Path jar_path = Paths.get(this.clientJar);
+    Path jarPath = Paths.get(this.clientJar);
     GcsStorage stagingStorage = new GcsStorage(project);
     URI serverJarUri = stagingBucket.resolve(RSYNC_BINARY_NAME);
-    stagingStorage.uploadFile(jar_path, serverJarUri);
+    stagingStorage.uploadFile(jarPath, serverJarUri);
     String jarDownloadCommand = String.format("gcloud storage cp %s .", serverJarUri);
 
     // TODO: Handle special characters

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
@@ -18,7 +18,6 @@ import com.google.cloud.run.v2.JobsClient;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 
-
 public class CloudRunServerAPI {
   private static final String BASE_IMAGE_ENV_VAR = "RSYNC_CLOUD_BASE_IMAGE";
   private static final String SERVER_JAR_ENV_VAR = "RSYNC_SERVER_JAR";
@@ -31,49 +30,60 @@ public class CloudRunServerAPI {
   private final String baseImage;
   private final String clientJar;
   private final String jobIdSuffix;
+  private final boolean deleteStagingFiles;
 
-  public CloudRunServerAPI(String project, String location, URI stagingBucket, URI targetUri) {
+  public CloudRunServerAPI(
+      String project,
+      String location,
+      URI stagingBucket,
+      URI targetUri,
+      boolean deleteStagingFiles) {
     this.project = project;
     this.location = location;
     this.stagingBucket = stagingBucket;
     this.targetUri = targetUri;
     this.baseImage = System.getenv(BASE_IMAGE_ENV_VAR);
     this.clientJar = System.getenv(SERVER_JAR_ENV_VAR);
-    //TODO a better way to generate unique id for job.
+    // TODO a better way to generate unique id for job.
     this.jobIdSuffix = UUID.randomUUID().toString();
+    this.deleteStagingFiles = deleteStagingFiles;
   }
 
-  private String getJobId(Mode mode){
+  private String getJobId(Mode mode) {
     return String.format("rsync-server-%s-%s", mode.toString().toLowerCase(), this.jobIdSuffix);
   }
 
-  private void deployCloudRunJob(String projectId, String location, Mode mode,
-      String command)
+  private void deployCloudRunJob(String projectId, String location, Mode mode, String command)
       throws IOException, ExecutionException, InterruptedException {
     try (JobsClient jobsClient = JobsClient.create()) {
       String parent = String.format("projects/%s/locations/%s", projectId, location);
-      Job job = Job.newBuilder()
-          .setTemplate(
-              ExecutionTemplate.newBuilder().setTemplate(TaskTemplate.newBuilder().addContainers(
-                  Container.newBuilder()
-                      .setImage(this.baseImage)
-                      .addCommand("/bin/sh")
-                      .addAllArgs(Arrays.asList("-c", command))
-                      .build()
-              ).build()).build()
-          ).build();
-      CreateJobRequest jobRequest = CreateJobRequest.newBuilder()
-          .setParent(parent)
-          .setJobId(getJobId(mode))
-          .setJob(job)
-          .build();
+      Job job =
+          Job.newBuilder()
+              .setTemplate(
+                  ExecutionTemplate.newBuilder()
+                      .setTemplate(
+                          TaskTemplate.newBuilder()
+                              .addContainers(
+                                  Container.newBuilder()
+                                      .setImage(this.baseImage)
+                                      .addCommand("/bin/sh")
+                                      .addAllArgs(Arrays.asList("-c", command))
+                                      .build())
+                              .build())
+                      .build())
+              .build();
+      CreateJobRequest jobRequest =
+          CreateJobRequest.newBuilder()
+              .setParent(parent)
+              .setJobId(getJobId(mode))
+              .setJob(job)
+              .build();
       OperationFuture<Job, Job> client = jobsClient.createJobAsync(jobRequest);
       client.get();
     }
   }
 
-  public void deployRsyncJobs()
-      throws IOException, ExecutionException, InterruptedException {
+  public void deployRsyncJobs() throws IOException, ExecutionException, InterruptedException {
     Path jar_path = Paths.get(this.clientJar);
     GcsStorage stagingStorage = new GcsStorage(project);
     URI serverJarUri = stagingBucket.resolve(RSYNC_BINARY_NAME);
@@ -89,12 +99,12 @@ public class CloudRunServerAPI {
                 + "--project '%s' "
                 + "--staging_bucket '%s' "
                 + "--target_file '%s'",
-            RSYNC_BINARY_NAME, Mode.GENERATE, project, stagingBucket, targetUri
-        );
+            RSYNC_BINARY_NAME, Mode.GENERATE, project, stagingBucket, targetUri);
     deployCloudRunJob(
-        project, location, Mode.GENERATE,
-        String.format("%s && %s", jarDownloadCommand, generateCommand)
-    );
+        project,
+        location,
+        Mode.GENERATE,
+        String.format("%s && %s", jarDownloadCommand, generateCommand));
 
     // TODO: Handle special characters
     String receiveCommand =
@@ -104,13 +114,14 @@ public class CloudRunServerAPI {
                 + "--mode '%s' "
                 + "--project '%s' "
                 + "--staging_bucket '%s' "
-                + "--target_file '%s'",
-            RSYNC_BINARY_NAME, Mode.RECEIVE, project, stagingBucket, targetUri
-        );
+                + "--target_file '%s' "
+                + "--delete_staging_files %s ",
+            RSYNC_BINARY_NAME, Mode.RECEIVE, project, stagingBucket, targetUri, this.deleteStagingFiles);
     deployCloudRunJob(
-        project, location, Mode.RECEIVE,
-        String.format("%s && %s", jarDownloadCommand, receiveCommand)
-    );
+        project,
+        location,
+        Mode.RECEIVE,
+        String.format("%s && %s", jarDownloadCommand, receiveCommand));
   }
 
   public void generate() throws IOException, ExecutionException, InterruptedException {
@@ -121,7 +132,7 @@ public class CloudRunServerAPI {
 
   public void reconstruct() throws IOException, ExecutionException, InterruptedException {
     try (JobsClient jobsClient = JobsClient.create()) {
-      jobsClient.runJobAsync(JobName.of(project, location,getJobId(Mode.RECEIVE))).get();
+      jobsClient.runJobAsync(JobName.of(project, location, getJobId(Mode.RECEIVE))).get();
     }
   }
 }

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/CloudRunServerAPI.java
@@ -115,7 +115,12 @@ public class CloudRunServerAPI {
                 + "--staging_bucket '%s' "
                 + "--target_file '%s' "
                 + "--delete_staging_files %s ",
-            RSYNC_BINARY_NAME, Mode.RECEIVE, project, stagingBucket, targetUri, this.deleteStagingFiles);
+            RSYNC_BINARY_NAME,
+            Mode.RECEIVE,
+            project,
+            stagingBucket,
+            targetUri,
+            this.deleteStagingFiles);
     deployCloudRunJob(
         project,
         location,
@@ -135,9 +140,8 @@ public class CloudRunServerAPI {
     }
   }
 
-  public void deleteJob(Mode mode)
-      throws IOException, ExecutionException, InterruptedException {
-    try(JobsClient jobsClient = JobsClient.create()) {
+  public void deleteJob(Mode mode) throws IOException, ExecutionException, InterruptedException {
+    try (JobsClient jobsClient = JobsClient.create()) {
       JobName jobName = JobName.of(project, location, getJobId(mode));
       jobsClient.deleteJobAsync(jobName).get();
     }

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/GCSTarget.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/GCSTarget.java
@@ -20,8 +20,13 @@ public class GCSTarget implements RsyncTarget {
   public GCSTarget(String project, URI targetUri, URI stagingBucket) {
     this.storage = new GcsStorage(project);
     this.targetUri = targetUri;
+
     // Create a staging folder path for each target file using the target path and file name
     // Then the checksum, instruction and staged files are created in this folder
+    // Example of staging files storage:
+    //  If target files path is gs://target_bucket/dir/target/file.txt
+    //  Staging bucket is gs://target_bucket/
+    //  Then staging files will be stored as gs://target_bucket/dir/target/file.txt/staged
     String targetRelativePath = UriUtil.getRelativePath(targetUri);
     String stagingBasePath = UriUtil.ensureTrailingSlash(targetRelativePath);
     this.instructionUri = stagingBucket.resolve(stagingBasePath + INSTRUCTION_FILE_NAME);

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/RsyncServer.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/RsyncServer.java
@@ -50,9 +50,9 @@ public class RsyncServer {
         receiver.receive(instruction);
       }
     }
-    // Once instructions are applied staged file is created with latest data
-    // Target files needs to be replaces with this file
-    // And other temp files in staging area would be deleted
+    // Once instructions are applied and staging file is created with latest data
+    // Target file needs to be replaces with the staged file
+    // And other temp files in staging folder would be deleted
     target.moveStagedFileToTarget(this.deleteStagingFiles);
   }
 }

--- a/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/RsyncTarget.java
+++ b/dbsync/server/src/main/java/com/google/edwmigration/dbsync/server/RsyncTarget.java
@@ -5,9 +5,16 @@ import com.google.common.io.ByteSource;
 
 public interface RsyncTarget {
   ByteSource getChecksumByteSource();
+
   ByteSink getChecksumByteSink();
+
   ByteSource getInstructionsByteSource();
+
   ByteSink getInstructionsByteSink();
+
   ByteSource getTargetByteSource();
+
   ByteSink getStagingByteSink();
+
+  void moveStagedFileToTarget(boolean deleteStagingFiles);
 }

--- a/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
+++ b/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
@@ -1,15 +1,10 @@
 package com.google.edwmigration.dbsync.storage.gcs;
 
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
-import com.google.auth.Credentials;
-import com.google.auth.oauth2.AccessToken;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
-import com.google.cloud.storage.Bucket;
-import com.google.cloud.storage.BucketInfo;
+import com.google.cloud.storage.CopyWriter;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.CopyRequest;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSink;
@@ -17,35 +12,55 @@ import com.google.common.io.ByteSource;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.util.Date;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 // https://www.baeldung.com/java-google-cloud-storage
 public class GcsStorage {
 
-    public static final String SCHEME = "gs";
+  public static final String SCHEME = "gs";
 
-    private final Storage storage;
+  private final Storage storage;
 
-    public GcsStorage(String projectId) {
-        this.storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+  public GcsStorage(String projectId) {
+    this.storage = StorageOptions.newBuilder().setProjectId(projectId).build().getService();
+  }
+
+  public @NonNull ByteSource newByteSource(URI uri) {
+    Preconditions.checkArgument(SCHEME.equals(uri.getScheme()));
+    return new GcsByteSource(storage, BlobId.fromGsUtilUri(uri.toString()));
+  }
+
+  public @NonNull ByteSink newByteSink(URI uri) {
+    Preconditions.checkArgument(SCHEME.equals(uri.getScheme()));
+    return new GcsByteSink(storage, BlobId.fromGsUtilUri(uri.toString()));
+  }
+
+  public void uploadFile(Path filepath, URI target) throws IOException {
+    storage.createFrom(
+        BlobInfo.newBuilder(BlobId.fromGsUtilUri(target.toString())).build(), filepath);
+  }
+
+  public void copyFile(URI sourceUri, URI targetUri) {
+    CopyWriter copyWriter =
+        storage.copy(
+            CopyRequest.newBuilder()
+                .setSource(BlobId.fromGsUtilUri(sourceUri.toString()))
+                .setTarget(BlobId.fromGsUtilUri(targetUri.toString()))
+                .build());
+    // We want to block until copy is completed
+    copyWriter.getResult();
+  }
+
+  public boolean deleteFile(URI fileUri) {
+    System.out.printf("Deleting path: %s", fileUri);
+    // return if file got deleted or not and let caller decide how to handle this
+    boolean isDeleted = storage.delete(BlobId.fromGsUtilUri(fileUri.toString()));
+    if (!isDeleted) {
+      Logger.getLogger("GcsStorage")
+          .log(Level.WARNING, "File to delete was not found, fileUri: %s", fileUri);
     }
-
-    public @NonNull ByteSource newByteSource(URI uri) {
-        Preconditions.checkArgument(SCHEME.equals(uri.getScheme()));
-        return new GcsByteSource(storage, BlobId.fromGsUtilUri(uri.toString()));
-    }
-
-    public @NonNull ByteSink newByteSink(URI uri) {
-        Preconditions.checkArgument(SCHEME.equals(uri.getScheme()));
-        return new GcsByteSink(storage, BlobId.fromGsUtilUri(uri.toString()));
-    }
-
-    public void uploadFile(Path filepath, URI target) throws IOException {
-        storage.createFrom(BlobInfo.newBuilder(BlobId.fromGsUtilUri(target.toString())).build(), filepath);
-    }
-
+    return isDeleted;
+  }
 }

--- a/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
+++ b/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
@@ -1,5 +1,6 @@
 package com.google.edwmigration.dbsync.storage.gcs;
 
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.CopyWriter;
@@ -54,7 +55,6 @@ public class GcsStorage {
   }
 
   public boolean deleteFile(URI fileUri) {
-    System.out.printf("Deleting path: %s", fileUri);
     // return if file got deleted or not and let caller decide how to handle this
     boolean isDeleted = storage.delete(BlobId.fromGsUtilUri(fileUri.toString()));
     if (!isDeleted) {
@@ -62,5 +62,10 @@ public class GcsStorage {
           .log(Level.WARNING, "File to delete was not found, fileUri: %s", fileUri);
     }
     return isDeleted;
+  }
+
+  public boolean checkFileExists(String fileGsUtilUri) {
+    Blob blob = storage.get(BlobId.fromGsUtilUri(fileGsUtilUri));
+    return blob != null && blob.exists();
   }
 }


### PR DESCRIPTION
This PR fixes all the open issues to get the library functional

**Issues being fixed**
1. First sync  failed when file is not present in target, we have to create and directly copy the file first time 
2. Exception was thrown if file size was less than min file size constant, in this case file can just be copied directly
3. Staging files (checksum, instruction,staged) were not stored in proper directory structure and would cause problems when syncing multiple files
4. once rsycn was done and staged file is created based on instructions it was note being moved/copied to target and target file was left out of data
5. Staging files were not getting cleaned up at the end
6. If trailing slash was not present in staging path invalid staging file paths were getting created. ( need to add if missing)
7. Cloud run job were not deleted at the end

**Other changes**

1. Added a param to decide if staging files should be deleted (its helpful to not delete for debugging and testing)
2. Fixed formatting and naming issues ( lot of the updates are related to this)

Testing:
test manually with following params
```
--project=achuthasourabh-test --location=us-west1 --target_file=gs://rsync_target/data/test.csv --source_file=file:///usr/local/google/home/achuthasourabh/Downloads/annual-enterprise-survey-2023-financial-year-provisional-size-bands.csv --staging_bucket=gs://rsync_staging --delete_staging_files=false
```

Screenshot of staging bucket files
![image](https://github.com/user-attachments/assets/a9a51d7a-3eb4-45bb-a392-e37aebdd09a5)

Screenshot of target file
![image](https://github.com/user-attachments/assets/e431f37d-2f5e-4197-adef-aa0f727e6872)

Note: Need to setup proper integ/e2e tests but for now trying to get it working and unblock dependent work

