### PR TITLE
Remove redundant recursion for TaskGroup

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -91,11 +91,12 @@ public class MetadataDumper {
     return run(connector, arguments);
   }
 
-  private void print(@Nonnull Task<?> task, int indent) {
-    System.out.println(repeat(' ', indent * 2) + task);
+  private void print(@Nonnull Task<?> task) {
+    String indent = "  ";
+    System.out.println(indent + task);
     if (task instanceof TaskGroup) {
       for (Task<?> subtask : ((TaskGroup) task).getTasks()) {
-        print(subtask, indent + 1);
+        System.out.println(indent + indent + subtask);
       }
     }
   }
@@ -151,7 +152,7 @@ public class MetadataDumper {
       System.out.println(repeat('=', title.length()));
       System.out.println("Writing to " + outputFileLocation);
       for (Task<?> task : tasks) {
-        print(task, 1);
+        print(task);
       }
       return true;
     } else {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/TasksRunner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/TasksRunner.java
@@ -174,7 +174,7 @@ public class TasksRunner implements TaskRunContextOps {
 
   private int countTasks(List<Task<?>> tasks) {
     return tasks.stream()
-        .mapToInt(task -> task instanceof TaskGroup ? countTasks(((TaskGroup) task).getTasks()) : 1)
+        .mapToInt(task -> task instanceof TaskGroup ? ((TaskGroup) task).getTasks().size() : 1)
         .sum();
   }
 }


### PR DESCRIPTION
The methods `countTasks` and `print` are recursive, but the preconditions checks in `ParallelTaskGroup::addTask` mean that they never reach depth >1, making the recursion not that useful.

Since the same effect can be accomplished using just `if` or `:?`, I removed the recursion.

