### PR TITLE
[b/394577286] Disallow the --assessment flag for snowflake-lite

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -78,7 +78,8 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
 
   @Nonnull
   @Override
-  public Handle open(@Nonnull ConnectorArguments arguments) throws MetadataDumperUsageException, SQLException {
+  public Handle open(@Nonnull ConnectorArguments arguments)
+      throws MetadataDumperUsageException, SQLException {
     String url = arguments.getUri();
     if (url == null) {
       StringBuilder buf = new StringBuilder("jdbc:snowflake://");

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -36,6 +36,7 @@ import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import java.sql.Driver;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -77,7 +78,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
 
   @Nonnull
   @Override
-  public Handle open(@Nonnull ConnectorArguments arguments) throws Exception {
+  public Handle open(@Nonnull ConnectorArguments arguments) throws MetadataDumperUsageException, SQLException {
     String url = arguments.getUri();
     if (url == null) {
       StringBuilder buf = new StringBuilder("jdbc:snowflake://");

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -18,11 +18,15 @@ package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
+
+import java.sql.SQLException;
 import java.time.Clock;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -40,6 +44,19 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   public SnowflakeLiteConnector() {
     super(NAME);
+  }
+
+  @Override
+  @Nonnull
+  public Handle open(ConnectorArguments arguments) throws MetadataDumperUsageException, SQLException {
+    if (arguments.isAssessment()) {
+      String message =
+          String.format(
+              "The %s connector supports assessment without using extra flags. Try running again without the '--%s' flag",
+              NAME, ConnectorArguments.OPT_ASSESSMENT);
+      throw new MetadataDumperUsageException(message);
+    }
+    return super.open(arguments);
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -52,7 +52,8 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
     if (arguments.isAssessment()) {
       String message =
           String.format(
-              "The %s connector supports assessment without using extra flags. Try running again without the '--%s' flag",
+              "The %s connector supports assessment without need for extra flags."
+                  + " Try running again without the '--%s' flag",
               NAME, ConnectorArguments.OPT_ASSESSMENT);
       throw new MetadataDumperUsageException(message);
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -25,7 +25,6 @@ import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
-
 import java.sql.SQLException;
 import java.time.Clock;
 import java.util.List;
@@ -48,7 +47,8 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   @Override
   @Nonnull
-  public Handle open(ConnectorArguments arguments) throws MetadataDumperUsageException, SQLException {
+  public Handle open(ConnectorArguments arguments)
+      throws MetadataDumperUsageException, SQLException {
     if (arguments.isAssessment()) {
       String message =
           String.format(


### PR DESCRIPTION
The flag is needed to enable Assessment features for connectors that don't support it by default.

The `snowflake-lite` connector is built for Assessment. In this case the flag is never needed so it shouldn't be supported.