### PR TITLE
[b/404528097] Remove TaskGroup#getTasks

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -91,15 +91,6 @@ public class MetadataDumper {
     return run(connector, arguments);
   }
 
-  private void print(@Nonnull Task<?> task, int indent) {
-    System.out.println(repeat(' ', indent * 2) + task);
-    if (task instanceof TaskGroup) {
-      for (Task<?> subtask : ((TaskGroup) task).getTasks()) {
-        print(subtask, indent + 1);
-      }
-    }
-  }
-
   private Path prepareOutputPath(
       @Nonnull String fileName, @Nonnull Closer closer, @Nonnull ConnectorArguments arguments)
       throws IOException {
@@ -151,7 +142,7 @@ public class MetadataDumper {
       System.out.println(repeat('=', title.length()));
       System.out.println("Writing to " + outputFileLocation);
       for (Task<?> task : tasks) {
-        print(task, 1);
+        TaskGroup.print(task);
       }
       return true;
     } else {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/TasksRunner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/TasksRunner.java
@@ -65,7 +65,7 @@ public class TasksRunner implements TaskRunContextOps {
     context = createContext(sinkFactory, handle, threadPoolSize, arguments);
     this.state = state;
     this.tasks = tasks;
-    totalNumberOfTasks = countTasks(tasks);
+    totalNumberOfTasks = TaskGroup.count(tasks);
     stopwatch = Stopwatch.createStarted();
     numberOfCompletedTasks = new AtomicInteger();
   }
@@ -170,11 +170,5 @@ public class TasksRunner implements TaskRunContextOps {
       }
     }
     return null;
-  }
-
-  private int countTasks(List<Task<?>> tasks) {
-    return tasks.stream()
-        .mapToInt(task -> task instanceof TaskGroup ? countTasks(((TaskGroup) task).getTasks()) : 1)
-        .sum();
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.task;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
@@ -25,7 +27,6 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import javax.annotation.Nonnull;
@@ -115,20 +116,11 @@ public abstract class TaskGroup extends AbstractTask<Void> implements CoreMetada
     }
   }
 
-  protected final Iterable<Callable<Object>> toCallables(
+  protected final ImmutableList<Callable<Object>> toCallables(
       @Nonnull TaskRunContext context, @Nonnull CSVPrinter printer) {
-    return () ->
-        new Iterator<Callable<Object>>() {
-          int index = 0;
-
-          public boolean hasNext() {
-            return index < size();
-          }
-
-          public Callable<Object> next() {
-            return new TaskRunner(context, tasks.get(index), printer)::call;
-          }
-        };
+    return tasks.stream()
+        .<Callable<Object>>map(item -> new TaskRunner(context, item, printer)::call)
+        .collect(toImmutableList());
   }
 
   private static int doCount(@Nonnull Task<?> task) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
@@ -124,12 +124,10 @@ public abstract class TaskGroup extends AbstractTask<Void> implements CoreMetada
           public boolean hasNext() {
             return index < size();
           }
-          ;
 
           public Callable<Object> next() {
             return new TaskRunner(context, tasks.get(index), printer)::call;
           }
-          ;
         };
   }
 


### PR DESCRIPTION
As the first step of fixing the issue, remove the method `TaskGroup#getTasks`. This method returns the reference to all subtasks as a mutable list, allowing for arbitrary modification.

Since all used instances of `TaskGroup` belong to the subclass `ParallelTaskGroup`, I also made `TaskGroup` abstract.

Two additional optimizations are possible. **They were not included** to avoid unnecessary complexity:
1. Return an `Iterable` from `TaskGroup#toCallables` to avoid the cost of creating the list
2. Use a one-way linked list to avoid the concatenation in `print`