### PR TITLE
[improvement] add test template to verify assessment flag usage

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/annotations/AvoidArgumentAssessment.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/annotations/AvoidArgumentAssessment.java
@@ -16,37 +16,17 @@
  */
 package com.google.edwmigration.dumper.application.dumper.annotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import javax.annotation.Nonnull;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import java.lang.annotation.*;
 
-/** @author shevek */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@Repeatable(RespectsInputs.class)
-public @interface RespectsInput {
+@AvoidInput(
+    arg = ConnectorArguments.OPT_ASSESSMENT,
+    description = AvoidArgumentAssessment.DESCRIPTION)
+public @interface AvoidArgumentAssessment {
 
-  @Nonnull
-  String arg() default "";
-
-  @Nonnull
-  String env() default "";
-
-  @Nonnull
-  String description();
-
-  @Nonnull
-  String defaultValue() default "";
-
-  int order() default Integer.MAX_VALUE;
-
-  @Nonnull
-  String required() default "";
+  String DESCRIPTION = "The argument must not be used with this connector.";
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/annotations/AvoidInput.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/annotations/AvoidInput.java
@@ -16,37 +16,22 @@
  */
 package com.google.edwmigration.dumper.application.dumper.annotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import javax.annotation.Nonnull;
 
-/** @author shevek */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@Repeatable(RespectsInputs.class)
-public @interface RespectsInput {
+@Repeatable(AvoidInputs.class)
+public @interface AvoidInput {
 
   @Nonnull
   String arg() default "";
-
-  @Nonnull
-  String env() default "";
 
   @Nonnull
   String description();
 
   @Nonnull
   String defaultValue() default "";
-
-  int order() default Integer.MAX_VALUE;
-
-  @Nonnull
-  String required() default "";
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/annotations/AvoidInputs.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/annotations/AvoidInputs.java
@@ -16,37 +16,15 @@
  */
 package com.google.edwmigration.dumper.application.dumper.annotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Inherited;
-import java.lang.annotation.Repeatable;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 import javax.annotation.Nonnull;
 
-/** @author shevek */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
-@Repeatable(RespectsInputs.class)
-public @interface RespectsInput {
+public @interface AvoidInputs {
 
   @Nonnull
-  String arg() default "";
-
-  @Nonnull
-  String env() default "";
-
-  @Nonnull
-  String description();
-
-  @Nonnull
-  String defaultValue() default "";
-
-  int order() default Integer.MAX_VALUE;
-
-  @Nonnull
-  String required() default "";
+  AvoidInput[] value();
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryLogsConnector.java
@@ -31,10 +31,7 @@ import com.google.cloud.bigquery.QueryJobConfiguration;
 import com.google.cloud.bigquery.TableId;
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogDays;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogEnd;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogStart;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
+import com.google.edwmigration.dumper.application.dumper.annotations.*;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
@@ -69,6 +66,7 @@ import org.slf4j.LoggerFactory;
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart
 @RespectsArgumentQueryLogEnd
+@AvoidArgumentAssessment
 public class BigQueryLogsConnector extends AbstractBigQueryConnector
     implements LogsConnector, BigQueryLogsDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/bigquery/BigQueryMetadataConnector.java
@@ -37,6 +37,7 @@ import com.google.cloud.bigquery.ViewDefinition;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -77,6 +78,7 @@ import org.slf4j.LoggerFactory;
     order = 2000,
     arg = ConnectorArguments.OPT_SCHEMA,
     description = "The list of datasets to dump, separated by commas.")
+@AvoidArgumentAssessment
 public class BigQueryMetadataConnector extends AbstractBigQueryConnector
     implements BigQueryMetadataDumpFormat, MetadataConnector {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
@@ -23,6 +23,7 @@ import static com.google.edwmigration.dumper.application.dumper.task.TaskCategor
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -64,6 +65,7 @@ import org.apache.http.ssl.SSLContextBuilder;
     arg = ConnectorArguments.OPT_CLUSTER,
     description = "The name of Cloudera's cluster.",
     required = "Only if you need to dump data for a single Cloudera cluster")
+@RespectsArgumentAssessment
 public class ClouderaManagerConnector extends AbstractConnector {
 
   private static final String FORMAT_NAME = "cloudera-manager.dump.zip";

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/generic/GenericConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/generic/GenericConnector.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.generic;
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
@@ -48,6 +49,7 @@ import org.slf4j.LoggerFactory;
  * generates multiple queries and is like 'logs' mode.
  */
 @AutoService({Connector.class, LogsConnector.class})
+@AvoidArgumentAssessment
 public class GenericConnector extends AbstractJdbcConnector implements LogsConnector {
 
   private static final Logger logger = LoggerFactory.getLogger(GenericConnector.class);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/greenplum/GreenplumMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/greenplum/GreenplumMetadataConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.greenplum;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -39,6 +40,7 @@ import java.util.List;
     required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
     defaultValue = "" + GreenplumMetadataConnector.OPT_PORT_DEFAULT)
 @RespectsArgumentDatabaseForConnection
+@AvoidArgumentAssessment
 public class GreenplumMetadataConnector extends AbstractGreenplumConnector
     implements MetadataConnector, GreenplumMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/HadoopMetadataConnector.java
@@ -24,6 +24,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -41,6 +42,7 @@ import javax.annotation.Nonnull;
 
 @AutoService({Connector.class, MetadataConnector.class})
 @Description("Dumps metadata from the Hadoop cluster via bash commands.")
+@RespectsArgumentAssessment
 public class HadoopMetadataConnector implements MetadataConnector {
 
   @VisibleForTesting

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hdfs/HdfsExtractionConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.hdfs;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -48,6 +49,7 @@ import javax.annotation.Nonnull;
     description = "The size of the thread pool to use when extracting hdfs filesystem.")
 @AutoService({Connector.class})
 @Description("Dumps files and directories from the HDFS.")
+@RespectsArgumentAssessment
 public class HdfsExtractionConnector extends AbstractConnector implements HdfsExtractionDumpFormat {
 
   public HdfsExtractionConnector() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hive/HiveMetadataConnector.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSink;
 import com.google.common.net.PercentEscaper;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabasePredicate;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -73,6 +74,7 @@ import org.slf4j.LoggerFactory;
 @RespectsArgumentDatabasePredicate
 @AutoService({Connector.class, MetadataConnector.class})
 @Description("Dumps metadata from the Hive metastore via Thrift.")
+@RespectsArgumentAssessment
 public class HiveMetadataConnector extends AbstractHiveConnector
     implements HiveMetadataDumpFormat, MetadataConnector {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/mysql/MysqlMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/mysql/MysqlMetadataConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.mysql;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
@@ -38,6 +39,7 @@ import java.util.List;
  */
 @AutoService({Connector.class, MetadataConnector.class})
 @Description("Dumps metadata from MySQL.")
+@RespectsArgumentAssessment
 public class MysqlMetadataConnector extends AbstractMysqlConnector
     implements MetadataConnector, MysqlMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/netezza/NetezzaMetadataConnector.java
@@ -21,13 +21,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabasePredicate;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDriverRequired;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentHostUnlessUrl;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentJDBCUri;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentPassword;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentUser;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
+import com.google.edwmigration.dumper.application.dumper.annotations.*;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -85,6 +79,7 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 @RespectsArgumentPassword
 @RespectsArgumentJDBCUri
 @RespectsArgumentDatabasePredicate
+@RespectsArgumentAssessment
 public class NetezzaMetadataConnector extends AbstractJdbcConnector
     implements MetadataConnector, NetezzaMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleLogsConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.oracle;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
@@ -31,6 +32,7 @@ import javax.annotation.Nonnull;
 
 @AutoService({Connector.class, LogsConnector.class})
 @Description("Dumps query logs from Oracle")
+@AvoidArgumentAssessment
 public class OracleLogsConnector extends AbstractOracleConnector
     implements LogsConnector, OracleLogsDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleMetadataConnector.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.auto.service.AutoService;
 import com.google.common.base.Preconditions;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.oracle.task.GroupTask;
@@ -39,6 +40,7 @@ import org.slf4j.LoggerFactory;
 
 @AutoService({Connector.class, MetadataConnector.class})
 @Description("Dumps metadata from Oracle")
+@RespectsArgumentAssessment
 public class OracleMetadataConnector extends AbstractOracleConnector
     implements MetadataConnector, OracleMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/oracle/OracleStatsConnector.java
@@ -22,6 +22,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.Range;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.ext.jdk.annotation.Description;
@@ -32,6 +33,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @AutoService(Connector.class)
 @Description("Dumps aggregated statistics from Oracle")
 @ParametersAreNonnullByDefault
+@RespectsArgumentAssessment
 public class OracleStatsConnector extends AbstractOracleConnector {
 
   static final Duration DEFAULT_DURATION = ofDays(30);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/postgresql/PostgresqlMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/postgresql/PostgresqlMetadataConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.postgresql;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -40,6 +41,7 @@ import java.util.List;
     required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
     defaultValue = "" + PostgresqlMetadataConnector.OPT_PORT_DEFAULT)
 @RespectsArgumentDatabaseForConnection
+@RespectsArgumentAssessment
 public class PostgresqlMetadataConnector extends AbstractPostgresqlConnector
     implements MetadataConnector, PostgresqlMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/ranger/RangerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/ranger/RangerConnector.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
@@ -61,6 +62,7 @@ import org.slf4j.LoggerFactory;
     defaultValue = ConnectorArguments.OPT_RANGER_PORT_DEFAULT)
 @AutoService({Connector.class})
 @Description("Dumps services and policies from Apache Ranger.")
+@AvoidArgumentAssessment
 public class RangerConnector extends AbstractConnector {
 
   @SuppressWarnings("UnusedVariable")

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftLogsConnector.java
@@ -19,10 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogDays;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogEnd;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogStart;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
+import com.google.edwmigration.dumper.application.dumper.annotations.*;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
@@ -59,6 +56,7 @@ import org.slf4j.LoggerFactory;
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart
 @RespectsArgumentQueryLogEnd
+@AvoidArgumentAssessment
 public class RedshiftLogsConnector extends AbstractRedshiftConnector
     implements LogsConnector, RedshiftLogsDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftMetadataConnector.java
@@ -19,6 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.redshift;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -42,6 +43,7 @@ import javax.annotation.Nonnull;
     description = "The port of the server.",
     required = ConnectorArguments.OPT_REQUIRED_IF_NOT_URL,
     defaultValue = RedshiftUrlUtil.OPT_PORT_DEFAULT)
+@RespectsArgumentAssessment
 public class RedshiftMetadataConnector extends AbstractRedshiftConnector
     implements MetadataConnector, RedshiftMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/sqlserver/SqlServerMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/sqlserver/SqlServerMetadataConnector.java
@@ -18,13 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.sqlserver;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDriver;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentHostUnlessUrl;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentJDBCUri;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentPassword;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentUser;
-import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
+import com.google.edwmigration.dumper.application.dumper.annotations.*;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractJdbcConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -67,6 +61,7 @@ import org.springframework.jdbc.datasource.SimpleDriverDataSource;
 @RespectsArgumentDriver
 @RespectsArgumentDatabaseForConnection
 @RespectsArgumentJDBCUri
+@RespectsArgumentAssessment
 public class SqlServerMetadataConnector extends AbstractJdbcConnector
     implements MetadataConnector, SqlServerMetadataDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/Teradata14LogsConnector.java
@@ -23,6 +23,7 @@ import com.google.common.base.Predicates;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogDays;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogEnd;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogStart;
@@ -62,6 +63,7 @@ import org.springframework.jdbc.core.ResultSetExtractor;
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart
 @RespectsArgumentQueryLogEnd
+@RespectsArgumentAssessment
 public class Teradata14LogsConnector extends AbstractTeradataConnector
     implements LogsConnector, TeradataLogsDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/VerticaLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/VerticaLogsConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.vertica;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
@@ -32,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 
 @AutoService({Connector.class, LogsConnector.class})
 @Description("Dumps logs from Vertica.")
+@AvoidArgumentAssessment
 public class VerticaLogsConnector extends AbstractVerticaConnector
     implements LogsConnector, VerticaLogsDumpFormat {
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/VerticaMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/vertica/VerticaMetadataConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.vertica;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
@@ -31,6 +32,7 @@ import java.util.List;
 /** */
 @AutoService({Connector.class, MetadataConnector.class})
 @Description("Dumps metadata from Vertica.")
+@RespectsArgumentAssessment
 public class VerticaMetadataConnector extends AbstractVerticaConnector
     implements MetadataConnector, VerticaMetadataDumpFormat {
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/AssessmentFlagUsageTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/AssessmentFlagUsageTest.java
@@ -1,0 +1,30 @@
+package com.google.edwmigration.dumper.application.dumper;
+
+import static org.junit.Assert.assertThrows;
+
+import com.google.common.collect.ImmutableCollection;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
+import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AssessmentFlagUsageTest {
+  private static final Logger logger = LoggerFactory.getLogger(AssessmentFlagUsageTest.class);
+
+  @Test
+  public void assessmentFlagIsExplicitlySpecified() throws Exception {
+    ImmutableCollection<Connector> connectors = ConnectorRepository.getInstance().getAllConnectors();
+    for (Connector connector : connectors) {
+      RespectsArgumentAssessment assessment = connector.getClass()
+          .getDeclaredAnnotation(RespectsArgumentAssessment.class);
+      if (assessment != null) {
+        assertThrows(
+            Exception.class,
+            () -> connector.validate(new ConnectorArguments()));
+      } else {
+        logger.warn("Should --assessment flag be required for the connector: {} ?", connector.getName());
+      }
+    }
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/AssessmentFlagUsageTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/AssessmentFlagUsageTest.java
@@ -8,6 +8,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.annotation.AnnotationUtils;
 
 public class AssessmentFlagUsageTest {
   private static final Logger logger = LoggerFactory.getLogger(AssessmentFlagUsageTest.class);
@@ -16,8 +17,8 @@ public class AssessmentFlagUsageTest {
   public void assessmentFlagIsExplicitlySpecified() throws Exception {
     ImmutableCollection<Connector> connectors = ConnectorRepository.getInstance().getAllConnectors();
     for (Connector connector : connectors) {
-      RespectsArgumentAssessment assessment = connector.getClass()
-          .getDeclaredAnnotation(RespectsArgumentAssessment.class);
+      RespectsArgumentAssessment assessment = AnnotationUtils.findAnnotation(connector.getClass(),
+          RespectsArgumentAssessment.class);
       if (assessment != null) {
         assertThrows(
             Exception.class,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/AssessmentFlagUsageTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/AssessmentFlagUsageTest.java
@@ -1,31 +1,73 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.google.edwmigration.dumper.application.dumper;
 
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableCollection;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import java.lang.annotation.Annotation;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 
 public class AssessmentFlagUsageTest {
-  private static final Logger logger = LoggerFactory.getLogger(AssessmentFlagUsageTest.class);
 
   @Test
-  public void assessmentFlagIsExplicitlySpecified() throws Exception {
-    ImmutableCollection<Connector> connectors = ConnectorRepository.getInstance().getAllConnectors();
+  public void allTheConnectorsExplicitlyChoseAssessmentFlag() {
+    ImmutableCollection<Connector> connectors = allConnectors();
     for (Connector connector : connectors) {
-      RespectsArgumentAssessment assessment = AnnotationUtils.findAnnotation(connector.getClass(),
-          RespectsArgumentAssessment.class);
-      if (assessment != null) {
-        assertThrows(
-            Exception.class,
-            () -> connector.validate(new ConnectorArguments()));
-      } else {
-        logger.warn("Should --assessment flag be required for the connector: {} ?", connector.getName());
-      }
+      RespectsArgumentAssessment respect =
+          findAnnotation(connector, RespectsArgumentAssessment.class);
+      AvoidArgumentAssessment avoid = findAnnotation(connector, AvoidArgumentAssessment.class);
+
+      String assertMessage =
+          "The connector "
+              + connector
+              + " must use one of "
+              + RespectsArgumentAssessment.class.getSimpleName()
+              + " or "
+              + AvoidArgumentAssessment.class.getSimpleName();
+      assertTrue(assertMessage, respect != null ^ avoid != null);
     }
+  }
+
+  @Test
+  public void assessmentFlagIsExplicitlySpecifiedAndUsed() throws Exception {
+    ImmutableCollection<Connector> connectors = allConnectors();
+    for (Connector connector : connectors) {
+      RespectsArgumentAssessment assessment =
+          findAnnotation(connector, RespectsArgumentAssessment.class);
+      if (assessment == null) {
+        continue;
+      }
+
+      assertThrows(Exception.class, () -> connector.validate(new ConnectorArguments()));
+    }
+  }
+
+  private static <A extends Annotation> A findAnnotation(
+      Connector connector, Class<A> annotationType) {
+    return AnnotationUtils.findAnnotation(connector.getClass(), annotationType);
+  }
+
+  private static ImmutableCollection<Connector> allConnectors() {
+    return ConnectorRepository.getInstance().getAllConnectors();
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/test/TestConnector.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.test;
 
 import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.annotations.AvoidArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.AbstractConnector;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
@@ -28,6 +29,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 @AutoService({Connector.class, MetadataConnector.class})
+@AvoidArgumentAssessment
 public class TestConnector extends AbstractConnector implements MetadataConnector {
   private static final Handle DUMMY_HANDLE = () -> {};
 


### PR DESCRIPTION
It's very simple forget to add '--assessment' flag to connector. The problem is that the mistake will be find only during uploading zip to server.

So, the idea is to explicitly mark each connector if `assessment` flag is required or not for the connector.   In addition to that the test will verify that connectors are aligned with the annotations.

Please help to double check if the connectors marked properly by `RespectsArgumentAssessment` or `AvoidArgumentAssessment`. 

It should be at least align with our public doc: https://cloud.google.com/bigquery/docs/migration-assessment#teradata_1

Note: the test is failed because the validation logic doesn't exist for all the connector. I would prefer first define the list of connectors and add the validation logic later.  