### PR TITLE
[OPS] add plugin to log test execution time into console

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,11 @@ plugins {
     id 'java-library-distribution'
     alias libs.plugins.ben.manes.versions
     alias libs.plugins.version.catalog.update
+    alias libs.plugins.test.logger
 }
 
 apply plugin: 'com.github.jk1.dependency-license-report'
+apply plugin: 'com.adarshr.test-logger'
 
 distributions {
     published {

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -29,6 +29,7 @@ plugins {
 
 apply plugin: 'com.github.jk1.dependency-license-report'
 apply plugin: "jacoco"
+apply plugin: 'com.adarshr.test-logger'
 
 configurations {
     sources {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,3 +145,4 @@ version-catalog-update = { id = "nl.littlerobots.version-catalog-update", versio
 jmh = { id = "me.champeau.jmh", version = "0.7.2" }
 jmh-report = { id = "io.morethan.jmhreport", version = "0.9.6" }
 protobuf = { id = "com.google.protobuf", version = "0.9.4" }
+test-logger = {id = "com.adarshr.test-logger", version="4.0.0"}


### PR DESCRIPTION
All tests slower than `2` (configurable) seconds will print execution time to console. So, we will continuously observer test performance.

For example it was obvious that `connector.hive.HiveMetadataConnectorTest` test is very slow. Now we can see that it spend `2+` minutes and ~`30` seconds for all the rest tests.

```
  Test testLoadedHive312 PASSED (2m 14s)

...
SUCCESS: Executed 354 tests in 2m 25s (9 skipped)
```