### PR TITLE
[b/394312229] Dump Snowflake external table metadata without the assessment flag

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -133,8 +133,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
   private void setCurrentDatabase(@Nonnull String databaseName, @Nonnull JdbcTemplate jdbcTemplate)
       throws MetadataDumperUsageException {
     String currentDatabase =
-        jdbcTemplate.queryForObject(
-            String.format("USE DATABASE \"%s\";", databaseName), String.class);
+        jdbcTemplate.queryForObject(String.format("USE DATABASE %s;", databaseName), String.class);
     if (currentDatabase == null) {
       List<String> dbNames =
           jdbcTemplate.query("SHOW DATABASES", (rs, rowNum) -> rs.getString("name"));
@@ -146,8 +145,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
     }
   }
 
-  private String sanitizeDatabaseName(@Nonnull String databaseName)
-      throws MetadataDumperUsageException {
+  String sanitizeDatabaseName(@Nonnull String databaseName) throws MetadataDumperUsageException {
     CharMatcher doubleQuoteMatcher = CharMatcher.is('"');
     String trimmedName = doubleQuoteMatcher.trimFrom(databaseName);
     int charLengthWithQuotes = databaseName.length() + 2;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/HeaderTransformerUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/HeaderTransformerUtil.java
@@ -28,7 +28,7 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 final class HeaderTransformerUtil {
 
-  static ResultSetTransformer<String[]> toCamelCaseFrom(CaseFormat format) {
+  public static ResultSetTransformer<String[]> toCamelCaseFrom(CaseFormat format) {
     return resultSet -> transformToCamelCase(resultSet, format);
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/MetadataView.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/MetadataView.java
@@ -20,6 +20,7 @@ enum MetadataView {
   DATABASES("databases"),
   SCHEMATA("schemata"),
   TABLES("tables"),
+  EXTERNAL_TABLES("externalTables"),
   COLUMNS("columns"),
   VIEWS("views"),
   FUNCTIONS("functions"),

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -42,6 +42,9 @@ import javax.annotation.ParametersAreNonnullByDefault;
 @ParametersAreNonnullByDefault
 final class SnowflakePlanner {
 
+  public static final AssessmentQuery SHOW_EXTERNAL_TABLES =
+      AssessmentQuery.createShow("EXTERNAL TABLES", Format.EXTERNAL_TABLES, LOWER_UNDERSCORE);
+
   private enum Format {
     EXTERNAL_TABLES(ExternalTablesFormat.AU_ZIP_ENTRY_NAME),
     FUNCTION_INFO(FunctionInfoFormat.AU_ZIP_ENTRY_NAME),
@@ -62,7 +65,7 @@ final class SnowflakePlanner {
     return ImmutableList.of(
         AssessmentQuery.createMetricsSelect(Format.TABLE_STORAGE_METRICS, UPPER_UNDERSCORE),
         AssessmentQuery.createShow("WAREHOUSES", Format.WAREHOUSES, LOWER_UNDERSCORE),
-        AssessmentQuery.createShow("EXTERNAL TABLES", Format.EXTERNAL_TABLES, LOWER_UNDERSCORE),
+        SHOW_EXTERNAL_TABLES,
         AssessmentQuery.createShow("FUNCTIONS", Format.FUNCTION_INFO, LOWER_UNDERSCORE));
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeAccountUsageMetadataConnectorTest.java
@@ -56,11 +56,13 @@ public class SnowflakeAccountUsageMetadataConnectorTest
     validator.withEntryValidator(
         SnowflakeMetadataDumpFormat.FunctionsFormat.AU_ZIP_ENTRY_NAME,
         SnowflakeMetadataDumpFormat.FunctionsFormat.Header.class);
+    validator.withEntryValidator(
+        SnowflakeMetadataDumpFormat.ExternalTablesFormat.AU_ZIP_ENTRY_NAME,
+        SnowflakeMetadataDumpFormat.ExternalTablesFormat.Header.class);
 
     validator.withExpectedEntries(
         SnowflakeMetadataDumpFormat.TableStorageMetricsFormat.AU_ZIP_ENTRY_NAME,
         SnowflakeMetadataDumpFormat.FunctionInfoFormat.AU_ZIP_ENTRY_NAME,
-        SnowflakeMetadataDumpFormat.ExternalTablesFormat.AU_ZIP_ENTRY_NAME,
         SnowflakeMetadataDumpFormat.WarehousesFormat.AU_ZIP_ENTRY_NAME);
   }
 }

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeMetadataDumpFormat.java
@@ -139,5 +139,27 @@ public interface SnowflakeMetadataDumpFormat {
 
   interface ExternalTablesFormat {
     String AU_ZIP_ENTRY_NAME = "external_tables.csv";
+
+    enum Header {
+      CreatedOn,
+      Name,
+      DatabaseName,
+      SchemaName,
+      Invalid,
+      InvalidReason,
+      Owner,
+      Comment,
+      Stage,
+      Location,
+      FileFormatName,
+      FileFormatType,
+      Cloud,
+      Region,
+      NotificationChannel,
+      LastRefreshedOn,
+      TableFormat,
+      LastRefreshDetails,
+      OwnerRoleType
+    }
   }
 }


### PR DESCRIPTION
Also fixes some issues with the `USE DATABASE` statement and some qualification issues for the `INFORMATION_SCHEMA` queries.