### PR TITLE
[b/404819770] Enable snowflake MFA caching

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     runtimeOnly libs.postgresql
     runtimeOnly libs.snowflake.jdbc
     runtimeOnly libs.redshift.jdbc
+    // JNA is required for the Snowflake MFA caching mechanism
     runtimeOnly libs.jna
 
     testFixturesApi testFixtures(project(':dumper:lib-common'))

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -96,6 +96,7 @@ dependencies {
     runtimeOnly libs.postgresql
     runtimeOnly libs.snowflake.jdbc
     runtimeOnly libs.redshift.jdbc
+    runtimeOnly libs.jna
 
     testFixturesApi testFixtures(project(':dumper:lib-common'))
 

--- a/dumper/app/gradle.lockfile
+++ b/dumper/app/gradle.lockfile
@@ -170,6 +170,7 @@ junit:junit-dep:4.11=testCompileClasspath,testRuntimeClasspath
 junit:junit:4.13.2=testCompileClasspath,testRuntimeClasspath
 net.bytebuddy:byte-buddy-agent:1.12.19=testCompileClasspath,testRuntimeClasspath
 net.bytebuddy:byte-buddy:1.12.19=testCompileClasspath,testRuntimeClasspath
+net.java.dev.jna:jna:5.17.0=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 net.sf.jopt-simple:jopt-simple:5.0.4=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 net.snowflake:snowflake-jdbc:3.22.0=runtimeClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 org.anarres.jdiagnostics:jdiagnostics:1.0.7=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -117,8 +117,12 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
       throws SQLException {
     Driver driver =
         newDriver(arguments.getDriverPaths(), "net.snowflake.client.jdbc.SnowflakeDriver");
-    String password = arguments.getPasswordOrPrompt();
-    return new SimpleDriverDataSource(driver, url, arguments.getUser(), password);
+    Properties prop = new Properties();
+
+    prop.put("user", arguments.getUser());
+    prop.put("password", arguments.getPasswordOrPrompt());
+    prop.put("authenticator", "username_password_mfa");
+    return new SimpleDriverDataSource(driver, url, prop);
   }
 
   private DataSource createPrivateKeyDataSource(@Nonnull ConnectorArguments arguments, String url)

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
@@ -105,4 +105,13 @@ public class AbstractSnowflakeConnectorTest extends AbstractConnectorTest {
             .contains(
                 "Private key authentication method can't be used together with user password"));
   }
+
+  @Test
+  public void checkJnaInClasspath_success() {
+    try {
+      Class.forName("com.sun.jna.Library");
+    } catch (ClassNotFoundException e) {
+      Assert.fail("net.java.dev.jna was not found in the classpath.");
+    }
+  }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
@@ -109,9 +109,11 @@ public class AbstractSnowflakeConnectorTest extends AbstractConnectorTest {
   @Test
   public void checkJnaInClasspath_success() {
     try {
+      // JNA is required for the Snowflake MFA caching mechanism
       Class.forName("com.sun.jna.Library");
     } catch (ClassNotFoundException e) {
-      Assert.fail("net.java.dev.jna was not found in the classpath.");
+      Assert.fail(
+          "net.java.dev.jna was not found in the classpath it is required for the Snowflake MFA caching.");
     }
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ google = "2.49.0"
 oozie-client = "5.2.1"
 amazon = "2.31.6"
 cloudrun = "0.60.0"
+jna = "5.17.0"
 
 [libraries]
 apache-avro = { module = "org.apache.avro:avro", version.ref = "apache-avro" }
@@ -139,6 +140,7 @@ h2 = { group = "com.h2database", name = "h2", version.ref = "h2" }
 parquet-generator = { group = "org.apache.parquet", name = "parquet-generator", version.ref = "parquet" }
 parquet = { group = "org.apache.parquet", name = "parquet", version.ref = "parquet" }
 oozie-client = { group = "org.apache.oozie", name = "oozie-client", version.ref = "oozie-client"}
+jna = { group = "net.java.dev.jna", "name" = "jna", version.ref = "jna"}
 
 [plugins]
 ben-manes-versions = { id = "com.github.ben-manes.versions", version.ref = "ben-manes-versions-plugin" }


### PR DESCRIPTION
This PR enables an optional snowflake MFA caching mechanism. This simplifies the usage of the dumper for the users who decide to use the user&password auth flow with the MFA. This allows user to approve MFA request only once instead of receiving the push notification on every single SQL query.

This requires setting the `authenticator` property to `username_password_mfa` and adding JNA classes to the classpath. Changing the `authenticator` property does not affect the authentication if MFA is disabled for the user.