### PR TITLE
Add a builder for ParallelTaskGroup

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/greenplum/GreenplumLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/greenplum/GreenplumLogsConnector.java
@@ -69,10 +69,7 @@ public class GreenplumLogsConnector extends AbstractGreenplumConnector
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments)
       throws MetadataDumperUsageException {
 
-    ParallelTaskGroup parallelTask = new ParallelTaskGroup(this.getName());
-    out.add(parallelTask);
-
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    ParallelTaskGroup.Builder parallelTask = new ParallelTaskGroup.Builder(this.getName());
 
     // pg_user table is also dumped in the greenplum(metadata) connector, but there is no harm
     // making this zip self-sufficient.
@@ -96,6 +93,10 @@ public class GreenplumLogsConnector extends AbstractGreenplumConnector
         queryQueueHistoryTemplateQuery,
         "tstart",
         parallelTask);
+
+    out.add(parallelTask.build());
+
+    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
   }
 
   // ## in the template to be replaced by the complete WHERE clause.
@@ -105,7 +106,7 @@ public class GreenplumLogsConnector extends AbstractGreenplumConnector
       String filePrefix,
       String queryTemplate,
       String startField,
-      ParallelTaskGroup out)
+      ParallelTaskGroup.Builder out)
       throws MetadataDumperUsageException {
 
     for (ZonedInterval interval : intervals) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftLogsConnector.java
@@ -72,11 +72,7 @@ public class RedshiftLogsConnector extends AbstractRedshiftConnector
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments)
       throws MetadataDumperUsageException {
 
-    ParallelTaskGroup parallelTask = new ParallelTaskGroup(this.getName());
-    out.add(parallelTask);
-
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
-    out.add(new FormatTask(FORMAT_NAME));
+    ParallelTaskGroup.Builder parallelTask = new ParallelTaskGroup.Builder(this.getName());
 
     //  is also be there in the metadata , no harm is making zip self-sufficient
     parallelTask.addTask(
@@ -157,6 +153,11 @@ public class RedshiftLogsConnector extends AbstractRedshiftConnector
           queryTemplateScan,
           "Q.starttime",
           parallelTask);
+
+      out.add(parallelTask.build());
+
+      out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+      out.add(new FormatTask(FORMAT_NAME));
     }
   }
 
@@ -166,7 +167,7 @@ public class RedshiftLogsConnector extends AbstractRedshiftConnector
       String filePrefix,
       String queryTemplate,
       String startField,
-      ParallelTaskGroup out)
+      ParallelTaskGroup.Builder out)
       throws MetadataDumperUsageException {
 
     List<String> whereClauses = new ArrayList<>();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/redshift/RedshiftRawLogsConnector.java
@@ -81,11 +81,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
   public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments)
       throws MetadataDumperUsageException {
 
-    ParallelTaskGroup parallelTask = new ParallelTaskGroup(this.getName());
-    out.add(parallelTask);
-
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
-    out.add(new FormatTask(FORMAT_NAME));
+    ParallelTaskGroup.Builder parallelTask = new ParallelTaskGroup.Builder(this.getName());
 
     //  is also be there in the metadata , no harm is making zip self-sufficient
     parallelTask.addTask(
@@ -198,6 +194,11 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
 
       makeClusterMetricsTasks(arguments, intervals, out);
     }
+
+    out.add(parallelTask.build());
+
+    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(new FormatTask(FORMAT_NAME));
   }
 
   // ##  in the template to be replaced by the complete WHERE clause.
@@ -207,7 +208,7 @@ public class RedshiftRawLogsConnector extends AbstractRedshiftConnector
       String filePrefix,
       String queryTemplate,
       String startField,
-      ParallelTaskGroup out)
+      ParallelTaskGroup.Builder out)
       throws MetadataDumperUsageException {
 
     List<String> whereClauses = new ArrayList<>();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/ParallelTaskGroup.java
@@ -38,19 +38,6 @@ public class ParallelTaskGroup extends TaskGroup {
     super("parallel-task-" + name, tasks);
   }
 
-  @Override
-  public void addTask(Task<?> task) {
-    // Checking for conditions would need some ordering of tasks execution or waiting on {@link
-    // TaskSetState#getTaskResult}
-    Preconditions.checkState(
-        task.getConditions().length == 0, "Tasks in a parallel task should not have conditions");
-    Preconditions.checkState(
-        task instanceof AbstractJdbcTask || task instanceof FormatTask,
-        "Parallel task only supports JdbcSelectTask and FormatTask sub tasks. Trying to add %s.",
-        task.getClass().getSimpleName());
-    super.addTask(task);
-  }
-
   private static class TaskRunner {
 
     @Nonnull private final TaskRunContext context;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
@@ -43,17 +43,6 @@ public class TaskGroup extends AbstractTask<Void> implements CoreMetadataDumpFor
     this.tasks.addAll(tasks);
   }
 
-  public void addTask(Task<?> task) {
-    // Checking for conditions would need some ordering of tasks execution or waiting on {@link
-    // TaskSetState#getTaskResult}
-    // Preconditions.checkState(task.getConditions().length == 0, "Tasks in a parallel task should
-    // not have conditions");
-    // Preconditions.checkState(task instanceof AbstractJdbcSelectTask || task instanceof
-    // FormatTask, "Parallel task only supports JdbcSelectTask and FormatTask sub tasks. Trying to
-    // add %s.", task.getClass().getSimpleName());
-    tasks.add(task);
-  }
-
   @Nonnull
   public List<Task<?>> getTasks() {
     return tasks;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/TaskGroup.java
@@ -38,6 +38,11 @@ public class TaskGroup extends AbstractTask<Void> implements CoreMetadataDumpFor
     Collections.addAll(this.tasks, tasks);
   }
 
+  public TaskGroup(@Nonnull String targetPath, @Nonnull List<Task<?>> tasks) {
+    super(targetPath);
+    this.tasks.addAll(tasks);
+  }
+
   public void addTask(Task<?> task) {
     // Checking for conditions would need some ordering of tasks execution or waiting on {@link
     // TaskSetState#getTaskResult}


### PR DESCRIPTION
Add the builder as discussed in 1:1 and remove the `TaskGroup#addTask` method.

This is step 1 of 2 to make the parallel task list immutable.