### PR TITLE
[OPS] add source code to distribution

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -211,24 +211,22 @@ tasks.named('distZip') {
 
 tasks.register('generateSourceMirror', Copy) {
     dependsOn 'compileJava'
-    doLast {
-        from {
-            dependencies.createArtifactResolutionQuery()
-                    .forComponents(
-                            configurations.runtimeClasspath.incoming.resolutionResult
-                                    .allDependencies.collect { it.selected.id }
-                    )
-                    .withArtifacts(JvmLibrary, SourcesArtifact)
-                    .execute()
-                    .resolvedComponents
-                    .collectMany {
-                        it.artifactResults
-                                .collect { it.file.path }
-                    }
-        }
-        into layout.buildDirectory.dir('mirror/sources')
-        outputs.dir "mirror/sources"
+    from {
+        dependencies.createArtifactResolutionQuery()
+                .forComponents(
+                        configurations.runtimeClasspath.incoming.resolutionResult
+                                .allDependencies.collect { it.selected.id }
+                )
+                .withArtifacts(JvmLibrary, SourcesArtifact)
+                .execute()
+                .resolvedComponents
+                .collectMany {
+                    it.artifactResults
+                            .collect { it.file.path }
+                }
     }
+    into layout.buildDirectory.dir('mirror/sources')
+    outputs.dir "mirror/sources"
 }
 
 tasks.register('copyGceLauncher', Copy) {


### PR DESCRIPTION
The source code of our dependencies must be included into distributed zip file. It's requirement some licenses of our dependencies. (for example CDDL).