### PR TITLE
Allow the tool to reuse existing progress resuming from a crash.

### DIFF
--- a/dbsync/README.md
+++ b/dbsync/README.md
@@ -12,7 +12,7 @@ refer to Java vendor documentation.
 
 Before submitting any code changes, please run the formatter
 
-    java -jar dbsync/google-java-format-1.7-all-deps.jar -i $(git ls-files|grep \.java$)
+    java -jar dbsync/google-java-format-1.7-all-deps.jar -i $(git ls-files dbsync | grep '\.java$')
 
 ## Gcysnc
 

--- a/dbsync/common/src/test/java/com/google/edwmigration/dbsync/jdbc/JdbcByteSourceTest.java
+++ b/dbsync/common/src/test/java/com/google/edwmigration/dbsync/jdbc/JdbcByteSourceTest.java
@@ -1,6 +1,5 @@
 package com.google.edwmigration.dbsync.jdbc;
 
-
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteSource;

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/GenerateCheckSumMain.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/GenerateCheckSumMain.java
@@ -1,7 +1,6 @@
 package com.google.edwmigration.dbsync.gcsync;
 
 import static com.google.edwmigration.dbsync.gcsync.Util.getListOfFiles;
-import static com.google.edwmigration.dbsync.gcsync.Util.skipMd5Header;
 import static com.google.edwmigration.dbsync.gcsync.Util.verifyMd5Header;
 
 import com.google.cloud.storage.Blob;
@@ -10,7 +9,6 @@ import com.google.common.io.ByteSource;
 import com.google.edwmigration.dbsync.common.ChecksumGenerator;
 import com.google.edwmigration.dbsync.common.DefaultArguments;
 import com.google.edwmigration.dbsync.storage.gcs.GcsStorage;
-import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
@@ -48,15 +46,14 @@ public class GenerateCheckSumMain {
       // file's md5. Meaning the file has been changes since we generated the checksum file.
       URI checkSumFile = new URI(tmpBucket).resolve(Util.getCheckSumFileName(file));
       Blob blob = gcsStorage.getBlob(checkSumFile);
-      if (blob != null && verifyMd5Header(gcsStorage.newByteSource(checkSumFile),
-          targetFileMd5)) {
-        logger.log(Level.INFO,
+      if (blob != null && verifyMd5Header(gcsStorage.newByteSource(checkSumFile), targetFileMd5)) {
+        logger.log(
+            Level.INFO,
             String.format("Skip generating checksum for file %s which already exists", file));
         continue;
       }
 
-      ByteSink byteSink =
-          gcsStorage.newByteSink(checkSumFile);
+      ByteSink byteSink = gcsStorage.newByteSink(checkSumFile);
       try (OutputStream bufferedOutputStream = byteSink.openBufferedStream()) {
         // We write the md5 of the target file as a header of the checksum file
         Util.writeMd5Header(bufferedOutputStream, targetFileMd5);
@@ -65,8 +62,10 @@ public class GenerateCheckSumMain {
         logger.log(Level.INFO, String.format("Finished generating check sum for: %s", file));
       } catch (Exception e) {
         if (!gcsStorage.delete(checkSumFile)) {
-          logger.log(Level.SEVERE, String.format(
-              "Failed to delete file: %s which is corrupted. Manually delete this file from GCS"));
+          logger.log(
+              Level.SEVERE,
+              String.format(
+                  "Failed to delete file: %s which is corrupted. Manually delete this file from GCS"));
         }
         throw e;
       }

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/GenerateCheckSumMain.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/GenerateCheckSumMain.java
@@ -1,12 +1,15 @@
 package com.google.edwmigration.dbsync.gcsync;
 
 import static com.google.edwmigration.dbsync.gcsync.Util.getListOfFiles;
+import static com.google.edwmigration.dbsync.gcsync.Util.verifyMd5Header;
 
+import com.google.cloud.storage.Blob;
 import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
 import com.google.edwmigration.dbsync.common.ChecksumGenerator;
 import com.google.edwmigration.dbsync.common.DefaultArguments;
 import com.google.edwmigration.dbsync.storage.gcs.GcsStorage;
+import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
 import java.util.List;
@@ -32,18 +35,39 @@ public class GenerateCheckSumMain {
                 new URI(tmpBucket).resolve(Constants.FILES_TO_RSYNC_FILE_NAME)));
 
     for (String file : filesToGenerateCheckSum) {
-      ByteSource byteSource = gcsStorage.newByteSource(new URI(targetBucket).resolve(file));
+      URI targetFile = new URI(targetBucket).resolve(file);
+      ByteSource byteSource = gcsStorage.newByteSource(targetFile);
       if (byteSource.isEmpty()) {
         logger.log(Level.INFO, String.format("File %s has been deleted on target", file));
         continue;
       }
 
+      String targetFileMd5 = gcsStorage.getBlob(targetFile).getMd5();
+      // Check if we already have a checksum file with a header md5 that matches with the target
+      // file's md5. Meaning the file has been changes since we generated the checksum file.
+      URI checkSumFile = new URI(tmpBucket).resolve(Util.getCheckSumFileName(file));
+      Blob blob = gcsStorage.getBlob(checkSumFile);
+      if (blob.exists() && verifyMd5Header(gcsStorage.newByteSource(checkSumFile),
+          targetFileMd5)) {
+        logger.log(Level.INFO,
+            String.format("Skip generating checksum for file %s which already exists", file));
+        continue;
+      }
+
       ByteSink byteSink =
-          gcsStorage.newByteSink(new URI(tmpBucket).resolve(Util.getCheckSumFileName(file)));
+          gcsStorage.newByteSink(checkSumFile);
       try (OutputStream bufferedOutputStream = byteSink.openBufferedStream()) {
+        // We write the md5 of the target file as a header of the checksum file
+        Util.writeMd5Header(bufferedOutputStream, targetFileMd5);
         checksumGenerator.generate(
             checksum -> checksum.writeDelimitedTo(bufferedOutputStream), byteSource);
         logger.log(Level.INFO, String.format("Finished generating check sum for: %s", file));
+      } catch (Exception e) {
+        if (!gcsStorage.delete(checkSumFile)) {
+          logger.log(Level.SEVERE, String.format(
+              "Failed to delete file: %s which is corrupted. Manually delete this file from GCS"));
+        }
+        throw e;
       }
     }
   }

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/GenerateCheckSumMain.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/GenerateCheckSumMain.java
@@ -1,6 +1,7 @@
 package com.google.edwmigration.dbsync.gcsync;
 
 import static com.google.edwmigration.dbsync.gcsync.Util.getListOfFiles;
+import static com.google.edwmigration.dbsync.gcsync.Util.skipMd5Header;
 import static com.google.edwmigration.dbsync.gcsync.Util.verifyMd5Header;
 
 import com.google.cloud.storage.Blob;
@@ -47,7 +48,7 @@ public class GenerateCheckSumMain {
       // file's md5. Meaning the file has been changes since we generated the checksum file.
       URI checkSumFile = new URI(tmpBucket).resolve(Util.getCheckSumFileName(file));
       Blob blob = gcsStorage.getBlob(checkSumFile);
-      if (blob.exists() && verifyMd5Header(gcsStorage.newByteSource(checkSumFile),
+      if (blob != null && verifyMd5Header(gcsStorage.newByteSource(checkSumFile),
           targetFileMd5)) {
         logger.log(Level.INFO,
             String.format("Skip generating checksum for file %s which already exists", file));

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/ReconstructFilesMain.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/ReconstructFilesMain.java
@@ -74,15 +74,17 @@ public class ReconstructFilesMain {
     }
   }
 
-  private static void verifyMd5(String sourceFileMd5, GcsStorage gcsStorage, URI tmpFile,
-      URI fileToBeReconstructed) {
+  private static void verifyMd5(
+      String sourceFileMd5, GcsStorage gcsStorage, URI tmpFile, URI fileToBeReconstructed) {
     if (sourceFileMd5.equals(gcsStorage.getBlob(tmpFile).getMd5())) {
       gcsStorage.copyFile(tmpFile, fileToBeReconstructed);
     } else {
-      logger.log(Level.SEVERE, String.format(
-          "The reconstructed file of %s doesn't match the file on the source file, the file might be corrupted.",
-          fileToBeReconstructed));
-      throw new RuntimeException("Reconstructed file doesn't match source, abort task");
+      logger.log(
+          Level.SEVERE,
+          String.format(
+              "The reconstructed file of %s doesn't match the file on the source file, the file might be"
+                  + " corrupted or the source file might have been changed while the tool is running",
+              fileToBeReconstructed));
     }
   }
 

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/Util.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/Util.java
@@ -1,9 +1,12 @@
 package com.google.edwmigration.dbsync.gcsync;
 
+import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,6 +40,39 @@ public class Util {
 
   public static String getTempFileName(String fileName) {
     return String.format("%s.%s", fileName, Constants.TMP_FILE_SUFFIX);
+  }
+
+  public static void writeMd5Header(OutputStream outputStream, String md5) throws IOException {
+    outputStream.write((md5 + "\n").getBytes());
+  }
+
+  public static boolean verifyMd5Header(ByteSource byteSource, String md5) throws IOException {
+    if (byteSource.isEmpty()) {
+      return false;
+    }
+    try (BufferedReader reader = new BufferedReader(
+        new InputStreamReader(byteSource.openStream()))) {
+      reader.read();
+      String md5Stored = reader.readLine();
+      return md5Stored.equals(md5);
+    }
+  }
+
+  public static String skipMd5Header(InputStream inputStream) throws IOException {
+    String md5 = "";
+    try (InputStreamReader reader = new InputStreamReader(inputStream)) {
+      while (true) {
+        int c = reader.read();
+        if (c == -1) {
+          throw new IOException("Unexpected EOF");
+        }
+        if (c == '\n') {
+          break;
+        }
+        md5 += (char) c;
+      }
+    }
+    return md5;
   }
 
   public static String ensureTrailingSlash(String uri) {

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/Util.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/Util.java
@@ -1,6 +1,5 @@
 package com.google.edwmigration.dbsync.gcsync;
 
-import com.google.common.io.ByteSink;
 import com.google.common.io.ByteSource;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -10,7 +9,6 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
 
 public class Util {
 
@@ -51,8 +49,8 @@ public class Util {
     if (byteSource.isEmpty()) {
       return false;
     }
-    try (BufferedReader reader = new BufferedReader(
-        new InputStreamReader(byteSource.openStream()))) {
+    try (BufferedReader reader =
+        new BufferedReader(new InputStreamReader(byteSource.openStream()))) {
       String md5Stored = reader.readLine();
       return md5Stored.equals(md5);
     }

--- a/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/Util.java
+++ b/dbsync/gcsync/src/main/java/com/google/edwmigration/dbsync/gcsync/Util.java
@@ -10,6 +10,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 
 public class Util {
 
@@ -43,7 +44,7 @@ public class Util {
   }
 
   public static void writeMd5Header(OutputStream outputStream, String md5) throws IOException {
-    outputStream.write((md5 + "\n").getBytes());
+    outputStream.write((md5 + '\n').getBytes());
   }
 
   public static boolean verifyMd5Header(ByteSource byteSource, String md5) throws IOException {
@@ -52,7 +53,6 @@ public class Util {
     }
     try (BufferedReader reader = new BufferedReader(
         new InputStreamReader(byteSource.openStream()))) {
-      reader.read();
       String md5Stored = reader.readLine();
       return md5Stored.equals(md5);
     }
@@ -60,18 +60,18 @@ public class Util {
 
   public static String skipMd5Header(InputStream inputStream) throws IOException {
     String md5 = "";
-    try (InputStreamReader reader = new InputStreamReader(inputStream)) {
-      while (true) {
-        int c = reader.read();
-        if (c == -1) {
-          throw new IOException("Unexpected EOF");
-        }
-        if (c == '\n') {
-          break;
-        }
-        md5 += (char) c;
+
+    while (true) {
+      int c = inputStream.read();
+      if (c == -1) {
+        throw new IOException("Unexpected EOF");
       }
+      if (c == '\n') {
+        break;
+      }
+      md5 += (char) c;
     }
+
     return md5;
   }
 

--- a/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
+++ b/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
@@ -31,7 +31,7 @@ public class GcsStorage {
     return storage.get(BlobId.fromGsUtilUri(new URI(bucket).resolve(objectName).toString()));
   }
 
-  public Blob getBlob(URI uri){
+  public Blob getBlob(URI uri) {
     return storage.get(BlobId.fromGsUtilUri(uri.toString()));
   }
 

--- a/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
+++ b/dbsync/storage-gcs/src/main/java/com/google/edwmigration/dbsync/storage/gcs/GcsStorage.java
@@ -31,6 +31,10 @@ public class GcsStorage {
     return storage.get(BlobId.fromGsUtilUri(new URI(bucket).resolve(objectName).toString()));
   }
 
+  public Blob getBlob(URI uri){
+    return storage.get(BlobId.fromGsUtilUri(uri.toString()));
+  }
+
   public @NonNull ByteSource newByteSource(URI uri) {
     Preconditions.checkArgument(SCHEME.equals(uri.getScheme()));
     return new GcsByteSource(storage, BlobId.fromGsUtilUri(uri.toString()));


### PR DESCRIPTION
This would be helpful if we are syncing a large number of files. The change implement the following feature.

1. Write the md5 of the file on gcs as a header while generating checksums. Skip generating if a checksum file exists and the md5 of the file on gcs hasn't changed.
2.Write the md5 of the file on source as a header while generating instructions,. skip generating it again if the instruction file exists and the md5 hasn't changed.
3. Before replacing the file on gcs with the reconstructed file, make sure that the md5 matches with the source to avoid potential corruption.