### PR TITLE
Allow overriding snowflake authenticator parameter

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -120,8 +120,13 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
     Properties prop = new Properties();
 
     prop.put("user", arguments.getUser());
-    prop.put("password", arguments.getPasswordOrPrompt());
-    prop.put("authenticator", "username_password_mfa");
+    if (arguments.isPasswordFlagProvided()) {
+      prop.put("password", arguments.getPasswordOrPrompt());
+    }
+    // Set default authenticator only if url is not provided to allow user overriding it
+    if (arguments.getUri() == null) {
+      prop.put("authenticator", "username_password_mfa");
+    }
     return new SimpleDriverDataSource(driver, url, prop);
   }
 


### PR DESCRIPTION
Set default `username_password_mfa` authenticator option only if the custom URL is not provided by the user. This allows overriding it with custom value like 'externalbrowser'.

Additionally, we skip asking about the password if `--password` flag is not provided to allow using passwordless auth options.