### PR TITLE
Fixing predice for tables_storage_metrics csv in SF Lite

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -233,7 +233,7 @@ final class SnowflakePlanner {
             "deleted");
     String view = "SNOWFLAKE.ACCOUNT_USAGE.TABLE_STORAGE_METRICS";
     String predicate =
-        "deleted IS NULL" + " AND " + "schema_dropped IS NULL" + " AND " + "table_dropped IS NULL";
+        "deleted IS FALSE" + " AND " + "schema_dropped IS NULL" + " AND " + "table_dropped IS NULL";
     String query = String.format("SELECT %s FROM %s WHERE %s", selectList, view, predicate);
     ImmutableList<String> header =
         ImmutableList.of(


### PR DESCRIPTION
Currently `deleted` column is filtering by checking if it is `null` or not.
This is not correct, as `deleted` column has `boolean` type, should be checked by comparing with `false`.

Doc: https://docs.snowflake.com/en/sql-reference/account-usage/table_storage_metrics