### PR TITLE
Clean unused csv in SF Lite

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -97,8 +97,6 @@ final class SnowflakePlanner {
     builder.add(proceduresTask());
     builder.add(reportDateRangeTask());
     builder.add(eventStateTask());
-    builder.add(operationEndsTask());
-    builder.add(operationStartsTask());
     builder.add(warehouseEventsHistoryTask());
     builder.add(warehouseMeteringTask());
     builder.add(storageMetricsLiteTask());
@@ -158,36 +156,6 @@ final class SnowflakePlanner {
             + " WHERE event_name LIKE '%CLUSTER%' GROUP BY ALL";
     ImmutableList<String> header = ImmutableList.of("EventState", "Count");
     return new LiteTimeSeriesTask("event_state.csv", query, header);
-  }
-
-  Task<?> operationEndsTask() {
-    String selectList = "warehouse_name, cluster_number, event_state, timestamp";
-    String view = "SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_EVENTS_HISTORY";
-    String predicate =
-        "upper(event_name) LIKE '%SUSPEND%'"
-            + " AND "
-            + "upper(event_name) LIKE '%CLUSTER%'"
-            + " AND "
-            + TIME_PREDICATE;
-    String query = buildQuery(selectList, view, predicate);
-    ImmutableList<String> header =
-        ImmutableList.of("WarehouseName", "ClusterNumber", "EventState", "Timestamp");
-    return new LiteTimeSeriesTask("clusters_spin_downs.csv", query, header);
-  }
-
-  Task<?> operationStartsTask() {
-    String selectList = "warehouse_name, cluster_number, event_state, timestamp";
-    String view = "SNOWFLAKE.ACCOUNT_USAGE.WAREHOUSE_EVENTS_HISTORY";
-    String predicate =
-        "upper(event_name) LIKE '%RESUME%'"
-            + " AND "
-            + "upper(event_name) LIKE '%CLUSTER%'"
-            + " AND "
-            + TIME_PREDICATE;
-    String query = buildQuery(selectList, view, predicate);
-    ImmutableList<String> header =
-        ImmutableList.of("WarehouseName", "ClusterNumber", "EventState", "Timestamp");
-    return new LiteTimeSeriesTask("clusters_spin_ups.csv", query, header);
   }
 
   Task<?> proceduresTask() {


### PR DESCRIPTION
Removing creating csv with clusters spin on and spin off. This logic is already done inside materialized view.
And there is no ingestion logic for these files.