### PR TITLE
[b/420597265] update Oozie date range logic to support Coordinator and Bundle jobs

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/AbstractOozieJobsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/AbstractOozieJobsTask.java
@@ -99,12 +99,7 @@ public abstract class AbstractOozieJobsTask<J> extends AbstractTask<Void> {
       while (latestFetchedJobEndTimestamp >= minJobEndTimeTimestamp) {
         List<J> jobs = fetchJobsWithFilter(oozieClient, SORT_BY_END_TIME, offset, batchSize);
         for (J job : jobs) {
-          Date currentJobEndTime = getJobEndTime(job);
-          boolean inDateRange =
-              currentJobEndTime != null
-                  && minJobEndTimeTimestamp <= currentJobEndTime.getTime()
-                  && currentJobEndTime.getTime() < maxJobEndTimeTimestamp;
-          if (!inDateRange) {
+          if (!isInDateRange(job, minJobEndTimeTimestamp, maxJobEndTimeTimestamp)) {
             // It's client side filtering. It's inefficient.
             // Unfortunately  Oozie doesn't provide an API to filter by start/end date.
             // It's possible to filter by OozieClient.FILTER_CREATED_TIME_START
@@ -133,6 +128,9 @@ public abstract class AbstractOozieJobsTask<J> extends AbstractTask<Void> {
     }
     return null;
   }
+
+  abstract boolean isInDateRange(
+      @Nullable J job, long minJobEndTimeTimestamp, long maxJobEndTimeTimestamp);
 
   CSVFormat createJobSpecificCSVFormat() {
     return newCsvFormatForClass(oozieJobClass);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieBundleJobsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieBundleJobsTask.java
@@ -16,9 +16,11 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.hadoop.oozie;
 
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
+import javax.annotation.Nonnull;
 import org.apache.oozie.client.BundleJob;
 import org.apache.oozie.client.OozieClientException;
 import org.apache.oozie.client.XOozieClient;
@@ -27,6 +29,25 @@ public class OozieBundleJobsTask extends AbstractOozieJobsTask<BundleJob> {
 
   public OozieBundleJobsTask(ZonedDateTime startDate, ZonedDateTime endDate) {
     super("oozie_bundle_jobs.csv", startDate, endDate);
+  }
+
+  @Nonnull
+  @Override
+  public TaskCategory getCategory() {
+    return TaskCategory.OPTIONAL;
+  }
+
+  @Override
+  boolean isInDateRange(BundleJob job, long minJobEndTimeTimestamp, long maxJobEndTimeTimestamp) {
+    Date jobEndTime = getJobEndTime(job);
+    // Bundle's endTime is obtained from Coordinators under the bundle control,
+    // so the similar logic is applied.
+    if (jobEndTime == null) {
+      return job.getStartTime().getTime() < maxJobEndTimeTimestamp;
+    } else {
+      return minJobEndTimeTimestamp <= jobEndTime.getTime()
+          && jobEndTime.getTime() < maxJobEndTimeTimestamp;
+    }
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieWorkflowJobsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieWorkflowJobsTask.java
@@ -30,6 +30,16 @@ public class OozieWorkflowJobsTask extends AbstractOozieJobsTask<WorkflowJob> {
   }
 
   @Override
+  boolean isInDateRange(WorkflowJob job, long minJobEndTimeTimestamp, long maxJobEndTimeTimestamp) {
+    Date jobEndTime = getJobEndTime(job);
+
+    // endTime null for Workflow means the job is in progress
+    return jobEndTime != null
+        && minJobEndTimeTimestamp <= jobEndTime.getTime()
+        && jobEndTime.getTime() < maxJobEndTimeTimestamp;
+  }
+
+  @Override
   List<WorkflowJob> fetchJobsWithFilter(
       XOozieClient oozieClient, String oozieFilter, int start, int len)
       throws OozieClientException {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieBundleJobsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieBundleJobsTaskTest.java
@@ -18,13 +18,17 @@ package com.google.edwmigration.dumper.application.dumper.connector.hadoop.oozie
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Date;
 import org.apache.oozie.client.BundleJob;
 import org.apache.oozie.client.XOozieClient;
 import org.junit.Test;
@@ -60,6 +64,44 @@ public class OozieBundleJobsTaskTest {
     // Verify
     verify(job).getEndTime();
     verifyNoMoreInteractions(job);
+  }
+
+  @Test
+  public void isInDateRange_endDateIsExcluded() {
+    BundleJob job = mock(BundleJob.class);
+
+    when(job.getEndTime()).thenReturn(new Date(-1L));
+    assertFalse(
+        "a job with endDate before the range must not be included",
+        task.isInDateRange(job, 0L, 10L));
+
+    when(job.getEndTime()).thenReturn(new Date(5L));
+    assertFalse("a defined date range must be excluded.", task.isInDateRange(job, 0L, 5L));
+
+    when(job.getEndTime()).thenReturn(new Date(6L));
+    assertFalse(
+        "a job with endDate after the range must not be included", task.isInDateRange(job, 0L, 5L));
+  }
+
+  @Test
+  public void isInDateRange_endDateIsNull() {
+    BundleJob job = mock(BundleJob.class);
+    when(job.getEndTime()).thenReturn(null);
+
+    when(job.getStartTime()).thenReturn(new Date(2L));
+    assertTrue(
+        "endTime is null, so Coordinators with start time before end should be included",
+        task.isInDateRange(job, 4L, 6L));
+
+    when(job.getStartTime()).thenReturn(new Date(5L));
+    assertTrue(
+        "endTime is null, so Coordinators with start time before end should be included",
+        task.isInDateRange(job, 4L, 6L));
+
+    when(job.getStartTime()).thenReturn(new Date(7L));
+    assertFalse(
+        "endTime is null, so Coordinators with start time after end should not be included",
+        task.isInDateRange(job, 4L, 6L));
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnectorTest.java
@@ -110,8 +110,8 @@ public class OozieConnectorTest {
             "compilerworks-metadata.yaml", TaskCategory.REQUIRED,
             "compilerworks-format.txt", TaskCategory.REQUIRED,
             "oozie_info.csv", TaskCategory.REQUIRED,
-            "oozie_coord_jobs.csv", TaskCategory.REQUIRED,
-            "oozie_bundle_jobs.csv", TaskCategory.REQUIRED,
+            "oozie_coord_jobs.csv", TaskCategory.OPTIONAL,
+            "oozie_bundle_jobs.csv", TaskCategory.OPTIONAL,
             "oozie_servers.csv", TaskCategory.REQUIRED,
             "oozie_workflow_jobs.csv", TaskCategory.REQUIRED);
     List<Task<?>> tasks = new ArrayList<>();

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieCoordinatorJobsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieCoordinatorJobsTaskTest.java
@@ -18,13 +18,17 @@ package com.google.edwmigration.dumper.application.dumper.connector.hadoop.oozie
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.Date;
 import org.apache.oozie.client.CoordinatorJob;
 import org.apache.oozie.client.XOozieClient;
 import org.junit.Test;
@@ -60,6 +64,44 @@ public class OozieCoordinatorJobsTaskTest {
     // Verify
     verify(job).getEndTime();
     verifyNoMoreInteractions(job);
+  }
+
+  @Test
+  public void isInDateRange_endDateIsExcluded() {
+    CoordinatorJob job = mock(CoordinatorJob.class);
+
+    when(job.getEndTime()).thenReturn(new Date(-1L));
+    assertFalse(
+        "a job with endDate before the range must not be included",
+        task.isInDateRange(job, 0L, 10L));
+
+    when(job.getEndTime()).thenReturn(new Date(5L));
+    assertFalse("a defined date range must be excluded.", task.isInDateRange(job, 0L, 5L));
+
+    when(job.getEndTime()).thenReturn(new Date(6L));
+    assertFalse(
+        "a job with endDate after the range must not be included", task.isInDateRange(job, 0L, 5L));
+  }
+
+  @Test
+  public void isInDateRange_endDateIsNull() {
+    CoordinatorJob job = mock(CoordinatorJob.class);
+    when(job.getEndTime()).thenReturn(null);
+
+    when(job.getStartTime()).thenReturn(new Date(2L));
+    assertTrue(
+        "endTime is null, so Coordinators with start time before end should be included",
+        task.isInDateRange(job, 4L, 6L));
+
+    when(job.getStartTime()).thenReturn(new Date(5L));
+    assertTrue(
+        "endTime is null, so Coordinators with start time before end should be included",
+        task.isInDateRange(job, 4L, 6L));
+
+    when(job.getStartTime()).thenReturn(new Date(7L));
+    assertFalse(
+        "endTime is null, so Coordinators with start time after end should not be included",
+        task.isInDateRange(job, 4L, 6L));
   }
 
   @Test


### PR DESCRIPTION
1. Make Coordinator and Bundle taks optional - The useful data is in Workflows, so it should be ok
2. `null` in `endTim` for Coordinator means that no end date when jobs will stop scheduling by the coordinator
3. `null` in `endTim` for Bundle is date collected from coordinators managed by the bundled
4. tests added/updated