### PR TITLE
[OPS] parent folder for scripts that can be copied and executed by users

### DIFF
--- a/warehouse-discovery-scripts/README.md
+++ b/warehouse-discovery-scripts/README.md
@@ -1,0 +1,5 @@
+# Data Warehouse discovery scripts
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+
+This directory contains scripts that can be run on top of the data warehouse to 
+collect the metadata needed to evaluate the migration assessment.


### PR DESCRIPTION
The motivation of the folder in readme.

Other name options were:
execution-templates 
dw_metadata_utils
warehouse_inventory_scripts
warehouse_discovery_pack
warehouse_discovery_scripts  - [currently chosed]
run-scripts 

Feel free to suggest naming.