### PR TITLE
Add missing license URLs

### DIFF
--- a/buildSrc/src/main/groovy/com/google/edwmigration/dumper/build/licensereport/OverridesUtil.groovy
+++ b/buildSrc/src/main/groovy/com/google/edwmigration/dumper/build/licensereport/OverridesUtil.groovy
@@ -917,7 +917,15 @@ class OverridesUtil {
             "net.java.dev.jna:jna": [
                 projectUrl: "https://github.com/java-native-access/jna",
                 licenseUrl: "https://github.com/java-native-access/jna/blob/master/LICENSE"
-            ]
+            ],
+            "net.java.dev.jna:jna-platform": [
+                projectUrl: "https://github.com/java-native-access/jna",
+                licenseUrl: "https://github.com/java-native-access/jna/blob/master/LICENSE"
+            ],
+            "net.harawata:appdirs": [
+                projectUrl: "https://github.com/harawata/appdirs",
+                licenseUrl: "https://raw.githubusercontent.com/harawata/appdirs/refs/heads/master/LICENSE.txt"
+            ],
         ]
     }
 }


### PR DESCRIPTION
Add missing license URLs for `net.java.dev.jna:jna-platform` and `net.harawata:appdirs`.