### PR TITLE
Filter databases for snowflake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ node_modules
 # Gradle build folders
 /**/build/
 !/**/scr/**/build/
+bin/

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -103,6 +103,7 @@ public class ConnectorArguments extends DefaultArguments {
   public static final String OPT_WAREHOUSE = "warehouse";
   public static final String OPT_DATABASE = "database";
   public static final String OPT_SCHEMA = "schema";
+  public static final String OPT_LIMIT_TO_DATABASES = "limit-to-databases";
   public static final String OPT_OUTPUT = "output";
   public static final String OPT_CONFIG = "config";
   public static final String OPT_ASSESSMENT = "assessment";
@@ -216,6 +217,13 @@ public class ConnectorArguments extends DefaultArguments {
   private final OptionSpec<String> optionDatabase =
       parser
           .accepts(OPT_DATABASE, "Database(s) to export")
+          .withRequiredArg()
+          .ofType(String.class)
+          .withValuesSeparatedBy(',')
+          .describedAs("db0,db1,...");
+  private final OptionSpec<String> optionLimitToDatabases =
+      parser
+          .accepts(OPT_LIMIT_TO_DATABASES, "Limit data extraction to specific databases")
           .withRequiredArg()
           .ofType(String.class)
           .withValuesSeparatedBy(',')
@@ -802,6 +810,14 @@ public class ConnectorArguments extends DefaultArguments {
   @Nonnull
   public ImmutableList<String> getDatabases() {
     return getOptions().valuesOf(optionDatabase).stream()
+        .map(String::trim)
+        .filter(StringUtils::isNotEmpty)
+        .collect(toImmutableList());
+  }
+
+  @Nonnull
+  public ImmutableList<String> getLimitToDatabases() {
+    return getOptions().valuesOf(optionLimitToDatabases).stream()
         .map(String::trim)
         .filter(StringUtils::isNotEmpty)
         .collect(toImmutableList());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -85,10 +85,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
       throws MetadataDumperUsageException, SQLException {
     validateConnectionArguments(arguments);
     String url = arguments.getUri() != null ? arguments.getUri() : getUrlFromArguments(arguments);
-    String databaseName =
-        arguments.getDatabases().isEmpty()
-            ? DEFAULT_DATABASE
-            : sanitizeDatabaseName(arguments.getDatabases().get(0));
+    String databaseName = selectDatabaseForConnection(arguments);
 
     DataSource dataSource =
         arguments.isPrivateKeyFileProvided()
@@ -98,6 +95,36 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
 
     setCurrentDatabase(databaseName, jdbcHandle.getJdbcTemplate());
     return jdbcHandle;
+  }
+
+  private String selectDatabaseForConnection(@Nonnull ConnectorArguments arguments)
+      throws MetadataDumperUsageException, SQLException {
+    if (!arguments.getDatabases().isEmpty()) {
+      return sanitizeDatabaseName(arguments.getDatabases().get(0));
+    }
+    
+    // If no database is specified, we need to select one for INFORMATION_SCHEMA access
+    // Create a temporary connection to discover available databases
+    String url = arguments.getUri() != null ? arguments.getUri() : getUrlFromArguments(arguments);
+    DataSource tempDataSource =
+        arguments.isPrivateKeyFileProvided()
+            ? createPrivateKeyDataSource(arguments, url)
+            : createUserPasswordDataSource(arguments, url);
+    
+    JdbcTemplate tempJdbcTemplate = new JdbcTemplate(tempDataSource);
+    List<String> availableDatabases =
+        tempJdbcTemplate.query("SHOW DATABASES", (rs, rowNum) -> rs.getString("name"));
+    
+    if (availableDatabases.isEmpty()) {
+      throw new MetadataDumperUsageException("No databases found in the Snowflake account.");
+    }
+    
+    // Prefer SNOWFLAKE database if available, otherwise use the first available database
+    if (availableDatabases.contains("SNOWFLAKE")) {
+      return "SNOWFLAKE";
+    } else {
+      return availableDatabases.get(0);
+    }
   }
 
   private void validateConnectionArguments(@Nonnull ConnectorArguments arguments)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -71,7 +71,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
-    out.addAll(planner.generateLiteSpecificQueries());
+    out.addAll(planner.generateLiteSpecificQueries(arguments));
   }
 
   private static MetadataDumperUsageException noAssessmentException() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -21,6 +21,7 @@ import static com.google.edwmigration.dumper.application.dumper.utils.ArchiveNam
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.CaseFormat;
+import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
@@ -34,12 +35,28 @@ import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterable;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterableGenerator;
+import com.google.edwmigration.dumper.application.dumper.handle.Handle;
+import com.google.edwmigration.dumper.application.dumper.io.OutputHandle.WriteMode;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.AutomaticClusteringHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.CopyHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.DatabaseReplicationUsageHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.LoginHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.MeteringDailyHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.PipeUsageHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.QueryHistoryExtendedFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.QueryAccelerationHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.ReplicationGroupUsageHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.ServerlessTaskHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.TaskHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.WarehouseEventsHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.WarehouseLoadHistoryFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat.WarehouseMeteringHistoryFormat;
 import java.time.Duration;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
@@ -216,6 +233,15 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
                 + "FROM SNOWFLAKE.ACCOUNT_USAGE.QUERY_HISTORY\n"
                 + "WHERE end_time >= to_timestamp_ltz('%s')\n"
                 + "AND end_time <= to_timestamp_ltz('%s')\n");
+    
+    // Add database filtering if limit-to-databases is provided
+    if (!arguments.getLimitToDatabases().isEmpty()) {
+      String quotedNames = arguments.getLimitToDatabases().stream()
+          .map(SnowflakeMetadataConnector::databaseNameStringLiteral)
+          .collect(Collectors.joining(", "));
+      queryBuilder.append("AND database_name IN (").append(quotedNames).append(")\n");
+    }
+    
     if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp()))
       queryBuilder
           .append("AND start_time >= ")
@@ -333,6 +359,15 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
                 + "WHERE end_time >= to_timestamp_ltz('%s')\n"
                 + "AND end_time <= to_timestamp_ltz('%s')\n"
                 + "AND is_client_generated_statement = FALSE\n");
+    
+    // Add database filtering if limit-to-databases is provided
+    if (!arguments.getLimitToDatabases().isEmpty()) {
+      String quotedNames = arguments.getLimitToDatabases().stream()
+          .map(SnowflakeMetadataConnector::databaseNameStringLiteral)
+          .collect(Collectors.joining(", "));
+      queryBuilder.append("AND database_name IN (").append(quotedNames).append(")\n");
+    }
+    
     if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp()))
       queryBuilder
           .append("AND start_time >= ")

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -178,7 +178,13 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     if (INJECT_IS_FAULT) {
       IS = "__NONEXISTENT__";
     } else if (databaseName == null) {
-      IS = "INFORMATION_SCHEMA";
+      // When no database is provided, use the first database from limit-to-databases
+      // for INFORMATION_SCHEMA access, or fall back to INFORMATION_SCHEMA without prefix
+      if (!arguments.getLimitToDatabases().isEmpty()) {
+        IS = sanitizeDatabaseName(arguments.getLimitToDatabases().get(0)) + ".INFORMATION_SCHEMA";
+      } else {
+        IS = "INFORMATION_SCHEMA";
+      }
     } else {
       IS = sanitizeDatabaseName(databaseName) + ".INFORMATION_SCHEMA";
     }
@@ -197,7 +203,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ACCOUNT_USAGE_SCHEMA_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         isAssessment,
-        getInformationSchemaWhereCondition("database_name", arguments.getDatabases()));
+        getInformationSchemaWhereCondition("database_name", arguments.getLimitToDatabases()));
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -212,7 +218,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ACCOUNT_USAGE_SCHEMA_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         isAssessment,
-        getInformationSchemaWhereCondition("catalog_name", arguments.getDatabases()));
+        getInformationSchemaWhereCondition("catalog_name", arguments.getLimitToDatabases()));
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -229,7 +235,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ACCOUNT_USAGE_WHERE_CONDITION,
         isAssessment,
         getInformationSchemaWhereCondition(
-            "table_catalog", arguments.getDatabases())); // Painfully slow.
+            "table_catalog", arguments.getLimitToDatabases())); // Painfully slow.
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -247,7 +253,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ACCOUNT_USAGE_WHERE_CONDITION,
         isAssessment,
         getInformationSchemaWhereCondition(
-            "table_catalog", arguments.getDatabases())); // Very fast.
+            "table_catalog", arguments.getLimitToDatabases())); // Very fast.
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -262,7 +268,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ACCOUNT_USAGE_SCHEMA_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         isAssessment,
-        getInformationSchemaWhereCondition("table_catalog", arguments.getDatabases()));
+        getInformationSchemaWhereCondition("table_catalog", arguments.getLimitToDatabases()));
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -278,20 +284,20 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ACCOUNT_USAGE_SCHEMA_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         isAssessment,
-        getInformationSchemaWhereCondition("function_catalog", arguments.getDatabases()));
+        getInformationSchemaWhereCondition("function_catalog", arguments.getLimitToDatabases()));
 
     if (isAssessment) {
-      for (AssessmentQuery item : planner.generateAssessmentQueries()) {
+      for (AssessmentQuery item : planner.generateAssessmentQueries(arguments)) {
         addAssessmentQuery(item, out, arguments, ACCOUNT_USAGE_SCHEMA_NAME);
       }
     } else {
-      if (!arguments.getDatabases().isEmpty()) {
+      if (!arguments.getLimitToDatabases().isEmpty()) {
         TaskOptions taskOptions = TaskOptions.DEFAULT;
-        for (String database : arguments.getDatabases()) {
+        for (String database : arguments.getLimitToDatabases()) {
           String formatString =
               String.format(
-                  "%s IN DATABASE %s",
-                  SnowflakePlanner.SHOW_EXTERNAL_TABLES.formatString, databaseNameQuoted(database));
+                  "%s IN DATABASE \"%s\"",
+                  SnowflakePlanner.SHOW_EXTERNAL_TABLES.formatString, database);
           addAssessmentQuery(
               SnowflakePlanner.SHOW_EXTERNAL_TABLES.withFormatString(formatString),
               out,
@@ -302,6 +308,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
           taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
         }
       } else {
+        // If no limit is provided, extract external tables for all databases
         addAssessmentQuery(
             SnowflakePlanner.SHOW_EXTERNAL_TABLES, out, arguments, ACCOUNT_USAGE_SCHEMA_NAME);
       }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -296,8 +296,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         for (String database : arguments.getLimitToDatabases()) {
           String formatString =
               String.format(
-                  "%s IN DATABASE \"%s\"",
-                  SnowflakePlanner.SHOW_EXTERNAL_TABLES.formatString, database);
+                  "%s IN DATABASE %s",
+                  SnowflakePlanner.SHOW_EXTERNAL_TABLES.formatString, databaseNameQuoted(database));
           addAssessmentQuery(
               SnowflakePlanner.SHOW_EXTERNAL_TABLES.withFormatString(formatString),
               out,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -21,6 +21,7 @@ import static com.google.common.base.CaseFormat.UPPER_UNDERSCORE;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.ResultSetTransformer;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
@@ -32,6 +33,8 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDum
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.TablesFormat;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat.WarehousesFormat;
 import javax.annotation.ParametersAreNonnullByDefault;
+import javax.annotation.Nullable;
+import java.util.stream.Collectors;
 
 /**
  * The generator of task lists for Snowflake connectors.
@@ -62,16 +65,53 @@ final class SnowflakePlanner {
       "timestamp > CURRENT_TIMESTAMP(0) - INTERVAL '14 days'";
 
   ImmutableList<AssessmentQuery> generateAssessmentQueries() {
-    return ImmutableList.of(
-        AssessmentQuery.createMetricsSelect(Format.TABLE_STORAGE_METRICS, UPPER_UNDERSCORE),
-        AssessmentQuery.createShow("WAREHOUSES", Format.WAREHOUSES, LOWER_UNDERSCORE),
-        SHOW_EXTERNAL_TABLES,
-        AssessmentQuery.createShow("FUNCTIONS", Format.FUNCTION_INFO, LOWER_UNDERSCORE));
+    return generateAssessmentQueries(null);
+  }
+
+  ImmutableList<AssessmentQuery> generateAssessmentQueries(@Nullable ConnectorArguments arguments) {
+    ImmutableList.Builder<AssessmentQuery> builder = ImmutableList.builder();
+    
+    // Add database filtering to assessment queries if limit-to-databases is provided
+    String databaseFilter = "";
+    if (arguments != null && !arguments.getLimitToDatabases().isEmpty()) {
+      String quotedNames = arguments.getLimitToDatabases().stream()
+          .map(SnowflakeMetadataConnector::databaseNameQuoted)
+          .collect(Collectors.joining(", "));
+      databaseFilter = String.format(" IN DATABASE %s", quotedNames);
+    }
+    
+    builder.add(AssessmentQuery.createMetricsSelect(Format.TABLE_STORAGE_METRICS, UPPER_UNDERSCORE));
+    builder.add(AssessmentQuery.createShow("WAREHOUSES", Format.WAREHOUSES, LOWER_UNDERSCORE));
+    
+    // Add database filter to external tables query if provided
+    if (!databaseFilter.isEmpty()) {
+      String externalTablesQuery = String.format("SHOW EXTERNAL TABLES%s", databaseFilter);
+      builder.add(AssessmentQuery.createCustomShow(externalTablesQuery, Format.EXTERNAL_TABLES, LOWER_UNDERSCORE));
+    } else {
+      builder.add(SHOW_EXTERNAL_TABLES);
+    }
+    
+    builder.add(AssessmentQuery.createShow("FUNCTIONS", Format.FUNCTION_INFO, LOWER_UNDERSCORE));
+    
+    return builder.build();
   }
 
   ImmutableList<Task<?>> generateLiteSpecificQueries() {
+    return generateLiteSpecificQueries(null);
+  }
+
+  ImmutableList<Task<?>> generateLiteSpecificQueries(@Nullable ConnectorArguments arguments) {
     String view = "SNOWFLAKE.ACCOUNT_USAGE";
     String filter = " WHERE DELETED IS NULL";
+    
+    // Add database filtering if limit-to-databases is provided
+    if (arguments != null && !arguments.getLimitToDatabases().isEmpty()) {
+      String quotedNames = arguments.getLimitToDatabases().stream()
+          .map(SnowflakeMetadataConnector::databaseNameStringLiteral)
+          .collect(Collectors.joining(", "));
+      filter += String.format(" AND database_name IN (%s)", quotedNames);
+    }
+    
     ImmutableList.Builder<Task<?>> builder = ImmutableList.builder();
 
     String databases =
@@ -141,6 +181,10 @@ final class SnowflakePlanner {
 
     static AssessmentQuery createShow(String view, Format zipFormat, CaseFormat caseFormat) {
       String queryString = String.format("SHOW %s", view);
+      return new AssessmentQuery(false, queryString, zipFormat.value, caseFormat);
+    }
+
+    static AssessmentQuery createCustomShow(String queryString, Format zipFormat, CaseFormat caseFormat) {
       return new AssessmentQuery(false, queryString, zipFormat.value, caseFormat);
     }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -187,7 +187,7 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
 
   @Test
   public void connector_generatesExpectedSql_withDatabaseFilter() throws IOException {
-    Map<String, String> actualSqls = collectSqlStatements("--database", "db1");
+    Map<String, String> actualSqls = collectSqlStatements("--limit-to-databases", "db1");
 
     assertEquals(
         "SELECT catalog_name, schema_name FROM SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA WHERE DELETED IS NULL AND catalog_name IN ('DB1')",
@@ -203,7 +203,7 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
       throws IOException {
     ImmutableMultimap<String, String> actualSqls =
         collectSqlStatementsAsMultimap(
-            "--database", "db1,db2", "-Dsnowflake.metadata.schemata.where=SQL_OVERRIDE");
+            "--limit-to-databases", "db1,db2", "-Dsnowflake.metadata.schemata.where=SQL_OVERRIDE");
 
     assertEquals(
         ImmutableList.of(
@@ -211,13 +211,58 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
         actualSqls.get("schemata-au.csv"));
     assertEquals(
         ImmutableList.of(
-            "SELECT catalog_name, schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE SQL_OVERRIDE"),
+            "SELECT catalog_name, schema_name FROM db1.INFORMATION_SCHEMA.SCHEMATA WHERE SQL_OVERRIDE"),
         actualSqls.get("schemata.csv"));
 
     // Two SHOW commands are executed and the result is appended to the same output file.
     assertEquals(
         ImmutableList.of(
             "SHOW EXTERNAL TABLES IN DATABASE \"DB1\"", "SHOW EXTERNAL TABLES IN DATABASE \"DB2\""),
+        actualSqls.get("external_tables.csv"));
+  }
+
+  @Test
+  public void connector_generatesExpectedSql_withDatabaseForConnectionAndLimitToDatabasesForFiltering()
+      throws IOException {
+    ImmutableMultimap<String, String> actualSqls = collectSqlStatementsAsMultimap("--database", "connection_db", "--limit-to-databases", "filter_db1,filter_db2");
+
+    // The database parameter should be used for INFORMATION_SCHEMA connection
+    assertEquals(
+        ImmutableList.of("SELECT catalog_name, schema_name FROM connection_db.INFORMATION_SCHEMA.SCHEMATA WHERE catalog_name IN ('FILTER_DB1', 'FILTER_DB2')"),
+        actualSqls.get("schemata.csv"));
+    
+    // The limit-to-databases parameter should be used for filtering
+    assertEquals(
+        ImmutableList.of("SELECT catalog_name, schema_name FROM SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA WHERE DELETED IS NULL AND catalog_name IN ('FILTER_DB1', 'FILTER_DB2')"),
+        actualSqls.get("schemata-au.csv"));
+    
+    // Multiple external table queries for different databases
+    assertEquals(
+        ImmutableList.of(
+            "SHOW EXTERNAL TABLES IN DATABASE \"FILTER_DB1\"", 
+            "SHOW EXTERNAL TABLES IN DATABASE \"FILTER_DB2\""),
+        actualSqls.get("external_tables.csv"));
+  }
+
+  @Test
+  public void connector_generatesExpectedSql_withLimitToDatabasesOnly() throws IOException {
+    ImmutableMultimap<String, String> actualSqls = collectSqlStatementsAsMultimap("--limit-to-databases", "db1,db2");
+
+    // Should use the first database from limit-to-databases for INFORMATION_SCHEMA access
+    assertEquals(
+        ImmutableList.of("SELECT catalog_name, schema_name FROM db1.INFORMATION_SCHEMA.SCHEMATA WHERE catalog_name IN ('DB1', 'DB2')"),
+        actualSqls.get("schemata.csv"));
+    
+    // Should still filter by limit-to-databases
+    assertEquals(
+        ImmutableList.of("SELECT catalog_name, schema_name FROM SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA WHERE DELETED IS NULL AND catalog_name IN ('DB1', 'DB2')"),
+        actualSqls.get("schemata-au.csv"));
+    
+    // Multiple external table queries for different databases
+    assertEquals(
+        ImmutableList.of(
+            "SHOW EXTERNAL TABLES IN DATABASE \"DB1\"", 
+            "SHOW EXTERNAL TABLES IN DATABASE \"DB2\""),
         actualSqls.get("external_tables.csv"));
   }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Limited to metadata connector

Observation 1: --database for metadata parameter MUST always contain a single database name despite the fact that some parts of the code expect that to be a list of database to filter with

Observation 2: if SNOWFLAKE.ACCOUNT_USAGE is accessible with the role that the dumper is run with then: --database parameter is used only to filter external tables https://github.com/google/dwh-migration-tools/blob/c7795917cf86e41e59165c137d0610532d3e9593/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java#L202

Observation 3: If SNOWFLAKE.ACCOUNT_USAGE is NOT accessible with the role that the dumper is run with then INFORMATION_SCHEMA is used and --database is used first to select a database for accessing INFORMATION_SCHEMA, and then to filter results by this database.

Observation 4: All Assessment specific queries in SnowflakePlanner.java do not respect any filtering

Solution:

Make --database optional. Select a database dynamically if no database is not provided (for INFORMATION_SCHEMA access purpose).
Create a separate optional parameter --limit-to-databases=X,Y,Z for both connectors that will limit the scope of extracted data
Replace all filtering logic that uses --database parameter (arguments.getDatabase()) with --limit-to-databases
Extract external tables respecting the --limit-to-databases parameter. If it is not provided then extract for all database (SHOW DATABASES).
Add filtering to SnowflakePlanner queries by respecting --limit-to-databases parameter.