### PR TITLE
[b/440029547] Add JDK check for the build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,8 +8,11 @@ plugins {
 apply plugin: 'com.github.jk1.dependency-license-report'
 apply plugin: 'com.adarshr.test-logger'
 
-if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
-    throw new GradleException("The Dumper build must be run with JDK 8 but was executed with JDK " + JavaVersion.current())
+if (project.hasProperty('release')) {
+    // todo add check for version ends with '-SNAPSHOT' after b/440037454
+    if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+        throw new GradleException("The Dumper release build must be run with JDK 8 but was executed with JDK " + JavaVersion.current())
+    }
 }
 
 distributions {
@@ -57,12 +60,12 @@ versionCatalogUpdate {
 
 licenseReport {
     filters = [
-        new com.github.jk1.license.filter.LicenseBundleNormalizer(bundlePath: rootProject.file("gradle/license-bundle-normalizer.json"), createDefaultTransformationRules: true)
+            new com.github.jk1.license.filter.LicenseBundleNormalizer(bundlePath: rootProject.file("gradle/license-bundle-normalizer.json"), createDefaultTransformationRules: true)
     ]
     renderers = [
-        new com.google.edwmigration.dumper.build.licensereport.CsvReportRenderer(),
-        new com.github.jk1.license.render.JsonReportRenderer('index.json', false),
-        new com.github.jk1.license.render.InventoryHtmlReportRenderer("index.html", "Licenses of Third Party Dependencies")
+            new com.google.edwmigration.dumper.build.licensereport.CsvReportRenderer(),
+            new com.github.jk1.license.render.JsonReportRenderer('index.json', false),
+            new com.github.jk1.license.render.InventoryHtmlReportRenderer("index.html", "Licenses of Third Party Dependencies")
     ]
     allowedLicensesFile = rootProject.file("gradle/license-allowed.json")
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,10 @@ plugins {
 apply plugin: 'com.github.jk1.dependency-license-report'
 apply plugin: 'com.adarshr.test-logger'
 
+if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
+    throw new GradleException("The Dumper build must be run with JDK 8 but was executed with JDK " + JavaVersion.current())
+}
+
 distributions {
     published {
         distributionBaseName = "dwh-migration-tools"


### PR DESCRIPTION
Fail the release build if JDK is not 8 to avoid human mistakes and keep all the build resource/tools in sync. 

Build with the check
```
./gradlew build -Prelease
```

Build without check
```
./gradlew build 
```

It's possible verify the JDK for all the build, but it seems more convenient for developers verify only the release. However, we can discuss this decision.  