### PR TITLE
Block deprecated option for SF Assessment

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -943,6 +943,10 @@ public class ConnectorArguments extends DefaultArguments {
     return getOptions().valueOf(optionQueryLogEarliestTimestamp);
   }
 
+  public boolean hasQueryLogEarliestTimestamp() {
+    return getOptions().valueOf(optionQueryLogEarliestTimestamp) != null;
+  }
+
   @CheckForNull
   public Integer getQueryLogDays() {
     return getOptions().valueOf(optionQueryLogDays);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -281,8 +281,6 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     String overrideQuery = getOverrideQuery(arguments);
     if (overrideQuery != null) return overrideQuery;
 
-    String overrideWhere = getOverrideWhere(arguments);
-
     @SuppressWarnings("OrphanedFormatString")
     StringBuilder queryBuilder =
         new StringBuilder(
@@ -333,12 +331,8 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
                 + "WHERE end_time >= to_timestamp_ltz('%s')\n"
                 + "AND end_time <= to_timestamp_ltz('%s')\n"
                 + "AND is_client_generated_statement = FALSE\n");
-    if (!StringUtils.isBlank(arguments.getQueryLogEarliestTimestamp()))
-      queryBuilder
-          .append("AND start_time >= ")
-          .append(arguments.getQueryLogEarliestTimestamp())
-          .append("\n");
-    if (overrideWhere != null) queryBuilder.append(" AND ").append(overrideWhere);
+
+    queryBuilder.append(getOverrideWhere(arguments));
     return queryBuilder.toString().replace('\n', ' ');
   }
 
@@ -356,16 +350,29 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     return null;
   }
 
-  @CheckForNull
+  @Nonnull
   private String getOverrideWhere(@Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
-    return arguments.getDefinition(SnowflakeLogConnectorProperties.OVERRIDE_WHERE);
+    ConnectorProperty property = SnowflakeLogConnectorProperties.OVERRIDE_WHERE;
+    String overrideWhere = arguments.getDefinition(property);
+    if (overrideWhere != null) {
+      return String.format(" AND %s", overrideWhere);
+    } else {
+      return "";
+    }
   }
 
   @Override
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
+
+    boolean isAssessment = arguments.isAssessment();
+
+    if (isAssessment && arguments.hasQueryLogEarliestTimestamp()) {
+      throw unsupportedOption(ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP);
+    }
+
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
 
@@ -399,6 +406,13 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     ZonedIntervalIterableGenerator.forConnectorArguments(
             arguments, duration, IntervalExpander.createBasedOnDuration(duration))
         .forEach(interval -> timeSeriesTasks.forEach(task -> addJdbcTask(out, interval, task)));
+  }
+
+  private static MetadataDumperUsageException unsupportedOption(String option) {
+    String assessment = ConnectorArguments.OPT_ASSESSMENT;
+    String message =
+        String.format("Unsupported option used with --%s: please remove --%s", assessment, option);
+    return new MetadataDumperUsageException(message);
   }
 
   private static void addJdbcTask(

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
@@ -17,9 +17,14 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import com.google.common.base.Predicates;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat;
 import com.google.edwmigration.dumper.test.TestUtils;
 import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,5 +45,20 @@ public class SnowflakeLogsConnectorTest extends AbstractSnowflakeConnectorExecut
     validator.withAllowedEntries(Predicates.alwaysTrue()); // Permit any files.
 
     validator.run(outputFile);
+  }
+
+  @Test
+  public void addTasksTo_unsupportedOption_throwsException() throws IOException {
+    ConnectorArguments arguments =
+        new ConnectorArguments(
+            "--connector",
+            "snowflake-logs",
+            "--assessment",
+            "--" + ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP,
+            "2024");
+
+    Assert.assertThrows(
+        MetadataDumperUsageException.class,
+        () -> connector.addTasksTo(new ArrayList<>(), arguments));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
@@ -23,7 +23,6 @@ import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFor
 import com.google.edwmigration.dumper.test.TestUtils;
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,7 +47,7 @@ public class SnowflakeLogsConnectorTest extends AbstractSnowflakeConnectorExecut
   }
 
   @Test
-  public void addTasksTo_unsupportedOption_throwsException() throws IOException {
+  public void validate_unsupportedOption_throwsException() throws IOException {
     ConnectorArguments arguments =
         new ConnectorArguments(
             "--connector",
@@ -57,8 +56,6 @@ public class SnowflakeLogsConnectorTest extends AbstractSnowflakeConnectorExecut
             "--" + ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP,
             "2024");
 
-    Assert.assertThrows(
-        MetadataDumperUsageException.class,
-        () -> connector.addTasksTo(new ArrayList<>(), arguments));
+    Assert.assertThrows(MetadataDumperUsageException.class, () -> connector.validate(arguments));
   }
 }


### PR DESCRIPTION
- The option query_logs_earliest_timestamp is not supported for Snowflake Assessment. Make it throw an exception if enabled together with assessment mode.
- Move a few lines from addTasksTo to a helper.