### PR TITLE
Fixes for Connector#validate

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -61,8 +61,7 @@ public interface Connector {
     if (start == null && end == null) {
       return;
     }
-    checkState(
-        start != null, "End date can be specified only with start date, but start date was null.");
+    checkNotNull(start, "End date can be specified only with start date, but start date was null.");
     // The assignment makes 'end' recognized as @Nonnull.
     end = checkNotNull(end, "End date must be specified with start date, but was null.");
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -16,7 +16,9 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector;
 
-import com.google.common.base.Preconditions;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
@@ -55,22 +57,19 @@ public interface Connector {
   default void validate(@Nonnull ConnectorArguments arguments) {}
 
   static void validateDateRange(@Nonnull ConnectorArguments arguments) {
-    ZonedDateTime startDate = arguments.getStartDate();
-    ZonedDateTime endDate = arguments.getEndDate();
+    ZonedDateTime start = arguments.getStartDate();
+    ZonedDateTime end = arguments.getEndDate();
 
-    if (startDate != null) {
-      Preconditions.checkNotNull(
-          endDate, "End date must be specified with start date, but was null.");
-      Preconditions.checkState(
-          startDate.isBefore(endDate),
-          "Start date [%s] must be before end date [%s].",
-          startDate,
-          endDate);
-    } else {
-      Preconditions.checkState(
-          endDate == null,
-          "End date can be specified only with start date, but start date was null.");
+    if (start == null && end == null) {
+      return;
     }
+    checkState(
+        start != null, "End date can be specified only with start date, but start date was null.");
+    // The assignment makes 'end' recognized as @Nonnull.
+    end = checkNotNull(end, "End date must be specified with start date, but was null.");
+
+    String message = String.format("Start date [%s] must be before end date [%s].", start, end);
+    checkState(end.isAfter(start), message);
   }
 
   void addTasksTo(@Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -26,7 +26,6 @@ import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.List;
 import javax.annotation.Nonnull;
-import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 /** @author shevek */
 public interface Connector {
@@ -53,7 +52,6 @@ public interface Connector {
    * @param arguments cli params
    * @throws RuntimeException if incorrect set of arguments passed to the particular connector
    */
-  @OverridingMethodsMustInvokeSuper
   default void validate(@Nonnull ConnectorArguments arguments) {}
 
   static void validateDateRange(@Nonnull ConnectorArguments arguments) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -24,6 +24,7 @@ import java.time.Clock;
 import java.time.ZonedDateTime;
 import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.OverridingMethodsMustInvokeSuper;
 
 /** @author shevek */
 public interface Connector {
@@ -50,7 +51,8 @@ public interface Connector {
    * @param arguments cli params
    * @throws RuntimeException if incorrect set of arguments passed to the particular connector
    */
-  default void validate(ConnectorArguments arguments) {}
+  @OverridingMethodsMustInvokeSuper
+  default void validate(@Nonnull ConnectorArguments arguments) {}
 
   default void validateDateRange(ConnectorArguments arguments) {
     ZonedDateTime startDate = arguments.getStartDate();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/Connector.java
@@ -54,7 +54,7 @@ public interface Connector {
   @OverridingMethodsMustInvokeSuper
   default void validate(@Nonnull ConnectorArguments arguments) {}
 
-  default void validateDateRange(ConnectorArguments arguments) {
+  static void validateDateRange(@Nonnull ConnectorArguments arguments) {
     ZonedDateTime startDate = arguments.getStartDate();
     ZonedDateTime endDate = arguments.getEndDate();
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
@@ -210,7 +210,7 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
   }
 
   @Override
-  public void validate(@Nonnull ConnectorArguments arguments) {
+  public final void validate(@Nonnull ConnectorArguments arguments) {
     Preconditions.checkState(arguments.isAssessment(), "--assessment flag is required");
     Preconditions.checkState(
         arguments.getDriverPaths() != null && !arguments.getDriverPaths().isEmpty(),

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
@@ -209,7 +209,7 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
   }
 
   @Override
-  public void validate(ConnectorArguments arguments) {
+  public void validate(@Nonnull ConnectorArguments arguments) {
     Preconditions.checkState(arguments.isAssessment(), "--assessment flag is required");
     Preconditions.checkState(
         arguments.getDriverPaths() != null && !arguments.getDriverPaths().isEmpty(),

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
@@ -236,7 +236,7 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
       Preconditions.checkState(arguments.getSchema() != null, "--schema is required with --host");
     }
 
-    validateDateRange(arguments);
+    Connector.validateDateRange(arguments);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnector.java
@@ -17,6 +17,7 @@
 package com.google.edwmigration.dumper.application.dumper.connector.airflow;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.edwmigration.dumper.application.dumper.connector.Connector.validateDateRange;
 import static com.google.edwmigration.dumper.application.dumper.connector.airflow.AirflowDatabaseDriverClasses.jdbcPrefixForClassName;
 
 import com.google.auto.service.AutoService;
@@ -236,7 +237,7 @@ public class AirflowConnector extends AbstractJdbcConnector implements MetadataC
       Preconditions.checkState(arguments.getSchema() != null, "--schema is required with --host");
     }
 
-    Connector.validateDateRange(arguments);
+    validateDateRange(arguments);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
@@ -130,7 +130,7 @@ public class ClouderaManagerConnector extends AbstractConnector {
   }
 
   @Override
-  public void validate(@Nonnull ConnectorArguments arguments) {
+  public final void validate(@Nonnull ConnectorArguments arguments) {
     String clouderaUri = arguments.getUri();
     Preconditions.checkNotNull(clouderaUri, "--url for Cloudera Manager API is required");
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
@@ -16,6 +16,7 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.Connector.validateDateRange;
 import static com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.AbstractClouderaTimeSeriesTask.TimeSeriesAggregation.DAILY;
 import static com.google.edwmigration.dumper.application.dumper.task.TaskCategory.OPTIONAL;
 
@@ -137,7 +138,7 @@ public class ClouderaManagerConnector extends AbstractConnector {
     Preconditions.checkNotNull(
         clouderaUser, "--user is required for Cloudera Manager API connector");
 
-    Connector.validateDateRange(arguments);
+    validateDateRange(arguments);
   }
 
   private void doClouderaManagerLogin(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
@@ -137,7 +137,7 @@ public class ClouderaManagerConnector extends AbstractConnector {
     Preconditions.checkNotNull(
         clouderaUser, "--user is required for Cloudera Manager API connector");
 
-    validateDateRange(arguments);
+    Connector.validateDateRange(arguments);
   }
 
   private void doClouderaManagerLogin(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
@@ -129,7 +129,7 @@ public class ClouderaManagerConnector extends AbstractConnector {
   }
 
   @Override
-  public void validate(ConnectorArguments arguments) {
+  public void validate(@Nonnull ConnectorArguments arguments) {
     String clouderaUri = arguments.getUri();
     Preconditions.checkNotNull(clouderaUri, "--url for Cloudera Manager API is required");
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
@@ -16,6 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.hadoop.oozie;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.Connector.validateDateRange;
+
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -82,7 +84,7 @@ public class OozieConnector extends AbstractConnector implements MetadataConnect
   public void validate(@Nonnull ConnectorArguments arguments) {
     Preconditions.checkState(arguments.isAssessment(), "--assessment flag is required");
 
-    Connector.validateDateRange(arguments);
+    validateDateRange(arguments);
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
@@ -81,7 +81,7 @@ public class OozieConnector extends AbstractConnector implements MetadataConnect
   }
 
   @Override
-  public void validate(@Nonnull ConnectorArguments arguments) {
+  public final void validate(@Nonnull ConnectorArguments arguments) {
     Preconditions.checkState(arguments.isAssessment(), "--assessment flag is required");
 
     validateDateRange(arguments);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
@@ -79,7 +79,7 @@ public class OozieConnector extends AbstractConnector implements MetadataConnect
   }
 
   @Override
-  public void validate(ConnectorArguments arguments) {
+  public void validate(@Nonnull ConnectorArguments arguments) {
     Preconditions.checkState(arguments.isAssessment(), "--assessment flag is required");
 
     validateDateRange(arguments);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnector.java
@@ -82,7 +82,7 @@ public class OozieConnector extends AbstractConnector implements MetadataConnect
   public void validate(@Nonnull ConnectorArguments arguments) {
     Preconditions.checkState(arguments.isAssessment(), "--assessment flag is required");
 
-    validateDateRange(arguments);
+    Connector.validateDateRange(arguments);
   }
 
   @Override

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -131,7 +131,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
       exception = new MetadataDumperUsageException(unsupportedFilter, messages);
     }
     removeDuplicateMessageAndThrow(exception);
-    validateForSnowflake(arguments);
+    validateForConnector(arguments);
   }
 
   /**
@@ -141,7 +141,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
    *
    * @param arguments User-provided arguments of the Dumper run.
    */
-  protected abstract void validateForSnowflake(@Nonnull ConnectorArguments arguments);
+  protected abstract void validateForConnector(@Nonnull ConnectorArguments arguments);
 
   private static void removeDuplicateMessageAndThrow(
       @Nullable MetadataDumperUsageException exception) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -101,7 +101,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
   }
 
   @Override
-  public void validate(ConnectorArguments arguments) {
+  public void validate(@Nonnull ConnectorArguments arguments) {
     super.validate(arguments);
 
     ArrayList<String> messages = new ArrayList<>();

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnector.java
@@ -101,9 +101,7 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
   }
 
   @Override
-  public void validate(@Nonnull ConnectorArguments arguments) {
-    super.validate(arguments);
-
+  public final void validate(@Nonnull ConnectorArguments arguments) {
     ArrayList<String> messages = new ArrayList<>();
     MetadataDumperUsageException exception = null;
 
@@ -133,7 +131,17 @@ public abstract class AbstractSnowflakeConnector extends AbstractJdbcConnector {
       exception = new MetadataDumperUsageException(unsupportedFilter, messages);
     }
     removeDuplicateMessageAndThrow(exception);
+    validateForSnowflake(arguments);
   }
+
+  /**
+   * Called by {@link #validate} to perform connector-specific checks.
+   *
+   * <p>Subclasses should override this with logic to run after the common validation for Snowflake.
+   *
+   * @param arguments User-provided arguments of the Dumper run.
+   */
+  protected abstract void validateForSnowflake(@Nonnull ConnectorArguments arguments);
 
   private static void removeDuplicateMessageAndThrow(
       @Nullable MetadataDumperUsageException exception) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -56,7 +56,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   }
 
   @Override
-  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
+  public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
     out.addAll(planner.generateLiteSpecificQueries());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -20,12 +20,10 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.handle.Handle;
 import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
-import java.sql.SQLException;
 import java.time.Clock;
 import java.util.List;
 import javax.annotation.Nonnull;
@@ -47,13 +45,6 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   @Override
   @Nonnull
-  public Handle open(ConnectorArguments arguments)
-      throws MetadataDumperUsageException, SQLException {
-    return super.open(arguments);
-  }
-
-  @Override
-  @Nonnull
   public String getDefaultFileName(boolean isAssessment, @Nullable Clock clock) {
     return ArchiveNameUtil.getFileName(NAME);
   }
@@ -65,16 +56,14 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   }
 
   @Override
-  public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
+  public void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
     out.addAll(planner.generateLiteSpecificQueries());
   }
 
   @Override
-  public final void validate(ConnectorArguments arguments) {
-    super.validate(arguments);
-
+  protected void validateForSnowflake(ConnectorArguments arguments) {
     if (!arguments.isAssessment()) {
       throw noAssessmentException();
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -63,7 +63,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   }
 
   @Override
-  protected void validateForSnowflake(ConnectorArguments arguments) {
+  protected void validateForConnector(ConnectorArguments arguments) {
     if (!arguments.isAssessment()) {
       throw noAssessmentException();
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -28,7 +28,6 @@ import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
 import java.sql.SQLException;
 import java.time.Clock;
 import java.util.List;
-import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -73,10 +72,9 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
   }
 
   @Override
-  public final void validate(@Nullable ConnectorArguments arguments) {
+  public final void validate(ConnectorArguments arguments) {
     super.validate(arguments);
 
-    Objects.requireNonNull(arguments);
     if (!arguments.isAssessment()) {
       throw noAssessmentException();
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -161,7 +161,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   }
 
   @Override
-  public final void validate(ConnectorArguments arguments) {
+  public final void validate(@Nonnull ConnectorArguments arguments) {
     super.validate(arguments);
 
     if (arguments.isAssessment() && arguments.hasQueryLogEarliestTimestamp()) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -161,7 +161,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   }
 
   @Override
-  protected final void validateForSnowflake(@Nonnull ConnectorArguments arguments) {
+  protected final void validateForConnector(@Nonnull ConnectorArguments arguments) {
     if (arguments.isAssessment() && arguments.hasQueryLogEarliestTimestamp()) {
       throw unsupportedOption(ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP);
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -161,9 +161,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   }
 
   @Override
-  public final void validate(@Nonnull ConnectorArguments arguments) {
-    super.validate(arguments);
-
+  protected final void validateForSnowflake(@Nonnull ConnectorArguments arguments) {
     if (arguments.isAssessment() && arguments.hasQueryLogEarliestTimestamp()) {
       throw unsupportedOption(ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP);
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -129,6 +129,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     return builder.build();
   }
 
+  @Override
+  protected final void validateForSnowflake(@Nonnull ConnectorArguments arguments) {}
+
   private void addSqlTasksWithInfoSchemaFallback(
       @Nonnull List<? super Task<?>> out,
       @Nonnull Class<? extends Enum<?>> header,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -130,7 +130,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   @Override
-  protected final void validateForSnowflake(@Nonnull ConnectorArguments arguments) {}
+  protected final void validateForConnector(@Nonnull ConnectorArguments arguments) {}
 
   private void addSqlTasksWithInfoSchemaFallback(
       @Nonnull List<? super Task<?>> out,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/ConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/ConnectorTest.java
@@ -42,7 +42,7 @@ public class ConnectorTest {
             "--connector", "test", "--start-date=2001-02-20", "--end-date=2001-02-20");
 
     Exception exception =
-        assertThrows(IllegalStateException.class, () -> Connector.validateDateRange(args));
+        assertThrows(RuntimeException.class, () -> Connector.validateDateRange(args));
     assertEquals(
         "Start date [2001-02-20T00:00Z] must be before end date [2001-02-20T00:00Z].",
         exception.getMessage());
@@ -53,7 +53,7 @@ public class ConnectorTest {
     ConnectorArguments args =
         new ConnectorArguments("--connector", "test", "--end-date=2001-02-20");
 
-    Exception exception = assertThrows(IllegalStateException.class, () -> validateDateRange(args));
+    Exception exception = assertThrows(RuntimeException.class, () -> validateDateRange(args));
     assertEquals(
         "End date can be specified only with start date, but start date was null.",
         exception.getMessage());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/ConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/ConnectorTest.java
@@ -16,58 +16,55 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.Connector.validateDateRange;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.application.dumper.handle.Handle;
-import com.google.edwmigration.dumper.application.dumper.task.Task;
-import java.time.Clock;
-import java.util.List;
-import javax.annotation.Nonnull;
 import org.junit.Test;
 
 public class ConnectorTest {
-  private final Connector connector = new EmptyConnector();
 
   @Test
   public void validateDateRange_startDateAndEndDate_success() throws Exception {
-    String argsStr = "--connector test --start-date=2001-02-20 --end-date=2001-02-25";
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector", "test", "--start-date=2001-02-20", "--end-date=2001-02-25");
 
     // Act
-    connector.validateDateRange(toArgs(argsStr));
+    validateDateRange(args);
   }
 
   @Test
-  public void validateDateRange_startDateAfterEndDate_throws() {
-    String argsStr = "--connector test --start-date=2001-02-20 --end-date=2001-02-20";
+  public void validateDateRange_startDateAfterEndDate_throws() throws Exception {
+    ConnectorArguments args =
+        new ConnectorArguments(
+            "--connector", "test", "--start-date=2001-02-20", "--end-date=2001-02-20");
 
     Exception exception =
-        assertThrows(
-            IllegalStateException.class, () -> connector.validateDateRange(toArgs(argsStr)));
+        assertThrows(IllegalStateException.class, () -> Connector.validateDateRange(args));
     assertEquals(
         "Start date [2001-02-20T00:00Z] must be before end date [2001-02-20T00:00Z].",
         exception.getMessage());
   }
 
   @Test
-  public void validateDateRange_endDateAlone_throws() {
-    String argsStr = "--connector test --end-date=2001-02-20";
+  public void validateDateRange_endDateAlone_throws() throws Exception {
+    ConnectorArguments args =
+        new ConnectorArguments("--connector", "test", "--end-date=2001-02-20");
 
-    Exception exception =
-        assertThrows(
-            IllegalStateException.class, () -> connector.validateDateRange(toArgs(argsStr)));
+    Exception exception = assertThrows(IllegalStateException.class, () -> validateDateRange(args));
     assertEquals(
         "End date can be specified only with start date, but start date was null.",
         exception.getMessage());
   }
 
   @Test
-  public void validateDateRange_startDateAlone_throws() {
-    String argsStr = "--connector test --start-date=2001-02-20";
+  public void validateDateRange_startDateAlone_throws() throws Exception {
+    ConnectorArguments args =
+        new ConnectorArguments("--connector", "test", "--start-date=2001-02-20");
 
-    Exception exception =
-        assertThrows(RuntimeException.class, () -> connector.validateDateRange(toArgs(argsStr)));
+    Exception exception = assertThrows(RuntimeException.class, () -> validateDateRange(args));
     assertEquals(
         "End date must be specified with start date, but was null.", exception.getMessage());
   }
@@ -75,42 +72,6 @@ public class ConnectorTest {
   @Test
   public void validateDateRange_requiredArgs_success() throws Exception {
     // Act
-    connector.validateDateRange(toArgs("--connector test"));
-  }
-
-  private static class EmptyConnector implements Connector {
-
-    @Nonnull
-    @Override
-    public String getName() {
-      return null;
-    }
-
-    @Nonnull
-    @Override
-    public String getDefaultFileName(boolean isAssessment, Clock clock) {
-      return null;
-    }
-
-    @Override
-    public void addTasksTo(
-        @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
-        throws Exception {}
-
-    @Nonnull
-    @Override
-    public Handle open(@Nonnull ConnectorArguments arguments) throws Exception {
-      return null;
-    }
-
-    @Nonnull
-    @Override
-    public Iterable<ConnectorProperty> getPropertyConstants() {
-      return null;
-    }
-  }
-
-  private static ConnectorArguments toArgs(String args) throws Exception {
-    return new ConnectorArguments(args.split(" "));
+    validateDateRange(new ConnectorArguments("--connector", "test"));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/airflow/AirflowConnectorTest.java
@@ -58,7 +58,7 @@ public class AirflowConnectorTest {
     String argsStr = validRequiredArgs + " --start-date=2001-02-20 --end-date=2001-02-20";
 
     Exception exception =
-        assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+        assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
     assertEquals(
         "Start date [2001-02-20T00:00Z] must be before end date [2001-02-20T00:00Z].",
         exception.getMessage());
@@ -69,7 +69,7 @@ public class AirflowConnectorTest {
     String argsStr = validRequiredArgs + " --end-date=2001-02-20";
 
     Exception exception =
-        assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+        assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
     assertEquals(
         "End date can be specified only with start date, but start date was null.",
         exception.getMessage());
@@ -94,7 +94,7 @@ public class AirflowConnectorTest {
 
     // Act
     Exception exception =
-        assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+        assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
     assertEquals("--database is not supported, use --schema or --url", exception.getMessage());
   }
 
@@ -117,19 +117,19 @@ public class AirflowConnectorTest {
     {
       String argsWithHost = argsStr + " --host localhost ";
       Exception exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsWithHost)));
+          assertThrows(RuntimeException.class, () -> connector.validate(args(argsWithHost)));
       assertEquals("--port is required with --host", exception.getMessage());
     }
     {
       String argsWithPort = argsStr + " --host localhost --port 8080";
       Exception exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsWithPort)));
+          assertThrows(RuntimeException.class, () -> connector.validate(args(argsWithPort)));
       assertEquals("--schema is required with --host", exception.getMessage());
     }
     {
       String argsWithPort = argsStr + " --host localhost --schema 8080";
       Exception exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsWithPort)));
+          assertThrows(RuntimeException.class, () -> connector.validate(args(argsWithPort)));
       assertEquals("--port is required with --host", exception.getMessage());
     }
   }
@@ -153,19 +153,19 @@ public class AirflowConnectorTest {
     {
       String argsWithPort = argsStr + " --port 8080";
       Exception exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsWithPort)));
+          assertThrows(RuntimeException.class, () -> connector.validate(args(argsWithPort)));
       assertEquals("--port param should not be used with --url", exception.getMessage());
     }
     {
       String argsWithSchema = argsStr + " --schema 8080";
       Exception exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsWithSchema)));
+          assertThrows(RuntimeException.class, () -> connector.validate(args(argsWithSchema)));
       assertEquals("--schema param should not be used with --url", exception.getMessage());
     }
     {
       String argsWithSchema = argsStr + " --host localhost";
       Exception exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsWithSchema)));
+          assertThrows(RuntimeException.class, () -> connector.validate(args(argsWithSchema)));
       assertEquals(
           "--url either --host must be provided (both parameters at once are not acceptable)",
           exception.getMessage());
@@ -178,33 +178,28 @@ public class AirflowConnectorTest {
 
     {
       String argsStr = "--connector airflow ";
-      exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+      exception = assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
       assertEquals("--assessment flag is required", exception.getMessage());
     }
     {
       String argsStr = "--connector airflow  --assessment";
-      exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+      exception = assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
       assertEquals("Path to jdbc driver is required in --driver param", exception.getMessage());
     }
     {
       String argsStr = "--connector airflow  --assessment --driver /home/dir/";
-      exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+      exception = assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
       assertEquals("--user param is required", exception.getMessage());
     }
     {
       String argsStr = "--connector airflow --driver /home/dir/ --user dbusername --assessment";
-      exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+      exception = assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
       assertEquals("--password param is required", exception.getMessage());
     }
     {
       String argsStr =
           "--connector airflow " + "--driver /home/dir/ --user dbusername --assessment --password";
-      exception =
-          assertThrows(IllegalStateException.class, () -> connector.validate(args(argsStr)));
+      exception = assertThrows(RuntimeException.class, () -> connector.validate(args(argsStr)));
       assertEquals(
           "--url either --host must be provided (both parameters at once are not acceptable)",
           exception.getMessage());

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/OozieConnectorTest.java
@@ -60,7 +60,7 @@ public class OozieConnectorTest {
     String argsStr = validRequiredArgs + " --start-date=2001-02-20 --end-date=2001-02-20";
 
     Exception exception =
-        assertThrows(IllegalStateException.class, () -> connector.validate(toArgs(argsStr)));
+        assertThrows(RuntimeException.class, () -> connector.validate(toArgs(argsStr)));
     assertEquals(
         "Start date [2001-02-20T00:00Z] must be before end date [2001-02-20T00:00Z].",
         exception.getMessage());
@@ -71,7 +71,7 @@ public class OozieConnectorTest {
     String argsStr = validRequiredArgs + " --end-date=2001-02-20";
 
     Exception exception =
-        assertThrows(IllegalStateException.class, () -> connector.validate(toArgs(argsStr)));
+        assertThrows(RuntimeException.class, () -> connector.validate(toArgs(argsStr)));
     assertEquals(
         "End date can be specified only with start date, but start date was null.",
         exception.getMessage());
@@ -97,8 +97,7 @@ public class OozieConnectorTest {
   public void validate_AssessmentIsRequired_throw() throws Exception {
 
     Exception exception =
-        assertThrows(
-            IllegalStateException.class, () -> connector.validate(toArgs("--connector oozie")));
+        assertThrows(RuntimeException.class, () -> connector.validate(toArgs("--connector oozie")));
 
     assertEquals("--assessment flag is required", exception.getMessage());
   }


### PR DESCRIPTION
- Add a method `validateForConnector` called by `AbstractSnowflakeConnector#validate`. The method `validate` handles common checks for the data source, while `validateForConnector` handles checks for a specific connector, e.g. `snowflake-logs`. This is done to ensure that a connector doesn't accidentally skip common validation.
- Add `Nonnull` to the param of `validate`. We don't expect `ConnectorArguments` to be null.
- Make `validateDateRange` non-default. This method is not core connector functionality, it doesn't depend on the connector instance and it shouldn't be overridden. A static method fits better for the usage.
- Simplify some checks in `validateDateRange` to make it less nested.