### PR TITLE
[OPS] remove dbsync from main project build

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -9,13 +9,6 @@ include(
 	':dumper:lib-ext-bigquery',
 	':dumper:lib-ext-hive-metastore',
 	':dumper:app',
-    ':dbsync:common',
-    ':dbsync:storage-gcs',
-    ':dbsync:storage-aws',
-    ':dbsync:storage-hdfs',
-    ':dbsync:server',
-    ':dbsync:client',
-    ':dbsync:gcsync',
     ':permissions-migration:app',
     ':dts-transfer-status:app'
 )


### PR DESCRIPTION
We do not have plans to invest into `dbsync`. So, remove it from the root build scripts.
1. The code is still here
2. It's possible to build the project directly from the module
3. The build is not triggered by root project, so no CI / CD for this module.