### PR TITLE
[b440295519] Add test coverage report to PRs

### DIFF
--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,0 +1,51 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Report tests results
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Tests report
+        run: ./gradlew :dumper:app:jacocoTestReport
+
+      - name: Add coverage to PR
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.7.2
+        with:
+          paths: ${{ github.workspace }}/dumper/app/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "Code Coverage Report"
+          debug-mode: false
+          update-comment: true

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -40,12 +40,20 @@ jobs:
       - name: Tests report
         run: ./gradlew :dumper:app:jacocoTestReport
 
-      - name: Add coverage to PR
+      - name: Add coverage JaCoCo report to PR
         id: jacoco
         uses: madrapps/jacoco-report@v1.7.2
         with:
           paths: ${{ github.workspace }}/dumper/app/build/reports/jacoco/test/jacocoTestReport.xml
           token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 50
+          min-coverage-changed-files: 50
           title: "Code Coverage Report"
           debug-mode: false
           update-comment: true
+
+      - name: Upload JaCoCo HTML report
+        uses: actions/upload-artifact@v4
+        with:
+          name: jacoco-html-report
+          path: ${{ github.workspace }}/dumper/app/build/reports/jacoco/test/html/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,16 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 name: DWH Dumper CI
 
 on:
@@ -15,7 +28,7 @@ jobs:
 
     steps:
     - name: Checkout latest code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up JDK 8
       uses: actions/setup-java@v4
@@ -26,7 +39,7 @@ jobs:
     # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
     # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582 # v4.0.0
+      uses: gradle/actions/setup-gradle@v4
 
     - name: Setup Protobuf
       uses: arduino/setup-protoc@v3
@@ -37,10 +50,10 @@ jobs:
       run: ./gradlew -Pci clean
     
     - name: Test Dumper
-      run: ./gradlew -Pci :dumper:app:test
+      run: ./gradlew -Pci :dumper:app:test --stacktrace
     
     - name: Test DTS transfer
-      run: ./gradlew -Pci :dts-transfer-status:app:test
+      run: ./gradlew -Pci :dts-transfer-status:app:test --stacktrace
     
     - name: Test Permissions migration
-      run: ./gradlew -Pci :permissions-migration:app:test
+      run: ./gradlew -Pci :permissions-migration:app:test --stacktrace

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -145,9 +145,8 @@ test {
 jacocoTestReport {
     dependsOn test
     reports {
-        xml.required = false
+        xml.required = true
         csv.required = false
-        html.outputLocation = layout.buildDirectory.dir('reports/jacocoHtml')
     }
     afterEvaluate {
         classDirectories.setFrom(files(classDirectories.files.collect {


### PR DESCRIPTION
Add test coverage reports to PRs for Dumper only for now.

Next steps:

1.  apply to all the modules
2. add minimal test coverage as a mandatory check
3. publish with the releases