### PR TITLE
[b/432671467] Add missing Redshift Serverless library

### DIFF
--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -84,6 +84,7 @@ dependencies {
     implementation libs.google.cloud.kms
     implementation libs.httpclient5
     implementation libs.aws.java.sdk.redshift
+    implementation libs.aws.java.sdk.redshiftserverless
     implementation libs.aws.java.sdk.cloudwatch
     implementation(libs.oozie.client) {
         exclude group: 'javax.jms', module: 'jms'

--- a/dumper/app/gradle.lockfile
+++ b/dumper/app/gradle.lockfile
@@ -7,6 +7,7 @@ com.amazon.redshift:redshift-jdbc42:2.1.0.32=runtimeClasspath,testFixturesRuntim
 com.amazonaws:aws-java-sdk-cloudwatch:1.12.778=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.amazonaws:aws-java-sdk-core:1.12.778=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.amazonaws:aws-java-sdk-redshift:1.12.778=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
+com.amazonaws:aws-java-sdk-redshiftserverless:1.12.778=compileClasspath,runtimeClasspath,testCompileClasspath,testRuntimeClasspath
 com.amazonaws:jmespath-java:1.12.778=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-annotations:2.18.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath
 com.fasterxml.jackson.core:jackson-core:2.18.3=compileClasspath,runtimeClasspath,testCompileClasspath,testFixturesRuntimeClasspath,testRuntimeClasspath

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -83,6 +83,7 @@ auto-value = { module = "com.google.auto.value:auto-value", version.ref = "auto-
 auto-value-annotations = { module = "com.google.auto.value:auto-value-annotations", version.ref = "auto-value" }
 aws-java-sdk-cloudwatch = { module = "com.amazonaws:aws-java-sdk-cloudwatch", version.ref = "aws-java-sdk" }
 aws-java-sdk-redshift = { module = "com.amazonaws:aws-java-sdk-redshift", version.ref = "aws-java-sdk" }
+aws-java-sdk-redshiftserverless = { module = "com.amazonaws:aws-java-sdk-redshiftserverless", version.ref = "aws-java-sdk" }
 cel = { module = "dev.cel:cel", version.ref = "cel" }
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checkerframework" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }


### PR DESCRIPTION
This PR fixes the error: `Exception in thread "main" java.lang.NoClassDefFoundError: com/amazonaws/services/redshiftserverless/AWSRedshiftServerlessClientBuilder
` that occurs when user tries to connect to Redshift Serverless using IAM credentials instead of password.