### PR TITLE
[b/441876236] Refactor: don't "partially format" in Assessment flow

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -322,19 +322,24 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         item.needsOverride
             ? getOverrideableQuery(arguments, item.formatString, TABLE_STORAGE_METRICS)
             : item.formatString;
-    String whereCondition;
     // Check whether the overrides changed anything.
     if (formatString.equals(item.formatString)) {
       // Overrides either not applied or equal to default values.
-      whereCondition =
+      String whereCondition =
           " WHERE deleted = FALSE AND schema_dropped IS NULL AND table_dropped IS NULL";
+      // The condition is always passed to String.format. SHOW queries simply ignore it.
+      String query = String.format(formatString, ACCOUNT_USAGE_SCHEMA_NAME, whereCondition);
+      return new JdbcSelectTask(
+              item.zipEntryName, query, TaskCategory.REQUIRED, TaskOptions.DEFAULT)
+          .withHeaderTransformer(item.transformer());
     } else {
-      whereCondition = "";
+      String whereCondition = "";
+      // The condition is always passed to String.format. SHOW queries simply ignore it.
+      String query = String.format(formatString, ACCOUNT_USAGE_SCHEMA_NAME, whereCondition);
+      return new JdbcSelectTask(
+              item.zipEntryName, query, TaskCategory.REQUIRED, TaskOptions.DEFAULT)
+          .withHeaderTransformer(item.transformer());
     }
-    // The condition is always passed to String.format. SHOW queries simply ignore it.
-    String query = String.format(formatString, ACCOUNT_USAGE_SCHEMA_NAME, whereCondition);
-    return new JdbcSelectTask(item.zipEntryName, query, TaskCategory.REQUIRED, TaskOptions.DEFAULT)
-        .withHeaderTransformer(item.transformer());
   }
 
   private void addAssessmentQuery(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -147,6 +147,10 @@ final class SnowflakePlanner {
     ResultSetTransformer<String[]> transformer() {
       return HeaderTransformerUtil.toCamelCaseFrom(caseFormat);
     }
+
+    String substitute(String schema, String whereCondition) {
+      return String.format(formatString, schema, whereCondition);
+    }
   }
 
   Task<?> eventStateTask() {


### PR DESCRIPTION
This is the first step of a refactor, which is meant to simplify how the queries are built for assessment.

Change the flow of assessment to avoid the partial-substitution trick while creating tasks:
```java
String overrideWhere = arguments.getDefinition(propertyWhere);
if (overrideWhere != null) {
  // Partially format the SQL template by re-introducing the first format specifier.
  return String.format(defaultSql, "%1$s", " WHERE " + overrideWhere);
}
```
Instead, apply both substitutions in a single step (using `AssessmentQuery#substitute`).