### PR TITLE
Testing: Better unit tests for Snowflake

### DIFF
--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
@@ -17,7 +17,10 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeLogsConnector.earliestTimestamp;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeLogsConnector.overrideableQuery;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
@@ -37,7 +40,7 @@ public class SnowflakeLogsConnectorTest {
   @Test
   public void testExecution() throws Exception {
     class ExecutionTest extends AbstractSnowflakeConnectorExecutionTest {
-      void test(File output) {
+      void test(File output) throws Exception {
         if (run(ARGS(new SnowflakeLogsConnector(), output))) {
           new ZipValidator()
               .withFormat("snowflake.logs.zip")
@@ -52,16 +55,16 @@ public class SnowflakeLogsConnectorTest {
   }
 
   @Test
-  public void extractEarliestTimestamp_notProvided_emptyResult() throws IOException {
+  public void earliestTimestamp_notProvided_emptyResult() throws IOException {
     ConnectorArguments arguments = new ConnectorArguments("--connector", "snowflake-logs");
 
-    String result = SnowflakeLogsConnector.extractEarliestTimestamp(arguments);
+    String result = earliestTimestamp(arguments);
 
     assertEquals("", result);
   }
 
   @Test
-  public void extractEarliestTimestamp_provided_resultMatches() throws IOException {
+  public void earliestTimestamp_provided_resultMatches() throws IOException {
     ConnectorArguments arguments =
         new ConnectorArguments(
             "--connector",
@@ -69,7 +72,7 @@ public class SnowflakeLogsConnectorTest {
             "--" + ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP,
             "2024-03-21");
 
-    String result = SnowflakeLogsConnector.extractEarliestTimestamp(arguments);
+    String result = earliestTimestamp(arguments);
 
     assertTrue(result, result.contains("2024-03-21"));
     assertTrue(result, result.contains("start_time"));
@@ -77,7 +80,37 @@ public class SnowflakeLogsConnectorTest {
   }
 
   @Test
+  public void overrideableQuery_overrideAbsent_defaultUsed() throws IOException {
+    String defaultSql = "SELECT event_name, query_id FROM WAREHOUSE_EVENTS_HISTORY";
+
+    String result = overrideableQuery(null, defaultSql, "timestamp");
+
+    assertTrue(result, result.contains("event_name"));
+  }
+
+  @Test
+  public void overrideableQuery_overrideEmpty_resultEmpty() throws IOException {
+    String defaultSql = "SELECT event_name, query_id FROM WAREHOUSE_EVENTS_HISTORY";
+    String override = "";
+
+    String result = overrideableQuery(override, defaultSql, "timestamp");
+
+    assertFalse(result, result.contains("event_name"));
+  }
+
+  @Test
+  public void overrideableQuery_overridePresent_defaultIgnored() throws IOException {
+    String defaultSql = "SELECT event_name, query_id FROM WAREHOUSE_EVENTS_HISTORY";
+    String override = "SELECT query_id FROM WAREHOUSE_EVENTS_HISTORY";
+
+    String result = overrideableQuery(override, defaultSql, "timestamp");
+
+    assertFalse(result, result.contains("event_name"));
+  }
+
+  @Test
   public void validate_unsupportedOption_throwsException() throws IOException {
+    SnowflakeLogsConnector connector = new SnowflakeLogsConnector();
     ConnectorArguments arguments =
         new ConnectorArguments(
             "--connector",

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
@@ -16,10 +16,12 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import com.google.common.base.Predicates;
+import static com.google.common.base.Predicates.alwaysTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeLogsDumpFormat;
 import com.google.edwmigration.dumper.test.TestUtils;
 import java.io.File;
 import java.io.IOException;
@@ -30,20 +32,48 @@ import org.junit.runners.JUnit4;
 
 /** @author shevek */
 @RunWith(JUnit4.class)
-public class SnowflakeLogsConnectorTest extends AbstractSnowflakeConnectorExecutionTest {
-
-  private final SnowflakeLogsConnector connector = new SnowflakeLogsConnector();
+public class SnowflakeLogsConnectorTest {
 
   @Test
   public void testExecution() throws Exception {
+    class ExecutionTest extends AbstractSnowflakeConnectorExecutionTest {
+      void test(File output) {
+        if (run(ARGS(new SnowflakeLogsConnector(), output))) {
+          new ZipValidator()
+              .withFormat("snowflake.logs.zip")
+              .withAllowedEntries(alwaysTrue())
+              .run(output);
+        }
+      }
+    }
     File outputFile = TestUtils.newOutputFile("compilerworks-snowflake-logs-au.zip");
-    if (!run(ARGS(connector, outputFile))) return;
 
-    ZipValidator validator = new ZipValidator().withFormat(SnowflakeLogsDumpFormat.FORMAT_NAME);
+    new ExecutionTest().test(outputFile);
+  }
 
-    validator.withAllowedEntries(Predicates.alwaysTrue()); // Permit any files.
+  @Test
+  public void extractEarliestTimestamp_notProvided_emptyResult() throws IOException {
+    ConnectorArguments arguments = new ConnectorArguments("--connector", "snowflake-logs");
 
-    validator.run(outputFile);
+    String result = SnowflakeLogsConnector.extractEarliestTimestamp(arguments);
+
+    assertEquals("", result);
+  }
+
+  @Test
+  public void extractEarliestTimestamp_provided_resultMatches() throws IOException {
+    ConnectorArguments arguments =
+        new ConnectorArguments(
+            "--connector",
+            "snowflake-logs",
+            "--" + ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP,
+            "2024-03-21");
+
+    String result = SnowflakeLogsConnector.extractEarliestTimestamp(arguments);
+
+    assertTrue(result, result.contains("2024-03-21"));
+    assertTrue(result, result.contains("start_time"));
+    assertTrue(result, result.endsWith("\n"));
   }
 
   @Test


### PR DESCRIPTION
- Add more unit tests
- Don't extend AbstractSnowflakeConnectorExecutionTest - in general it's not needed, add subclass in the only test that uses it
- Small changes for testability: extract code to methods, add `WHERE 1=1` to one of the queries to simplify formatting