### PR TITLE
Separate DumpMetadataTask version for Snowflake

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -20,7 +20,6 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
@@ -58,7 +57,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   @Override
   public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.add(new FormatTask(FORMAT_NAME));
     out.addAll(planner.generateLiteSpecificQueries());
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -39,7 +39,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterable;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterableGenerator;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
@@ -295,7 +294,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.add(new FormatTask(FORMAT_NAME));
 
     // (24 * 7) -> 7 trailing days == 168 hours

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -33,7 +33,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.snowflake.Sno
 import com.google.edwmigration.dumper.application.dumper.io.OutputHandle.WriteMode;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractTask.TaskOptions;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
@@ -169,7 +168,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   @Override
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments) {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.add(new FormatTask(FORMAT_NAME));
 
     boolean INJECT_IS_FAULT = arguments.isTestFlag('A');

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.io.ByteSink;
+import com.google.common.io.CharSink;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.handle.Handle;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractTask;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Product;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Root;
+import java.io.IOException;
+import java.io.Writer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.anarres.jdiagnostics.ProductMetadata;
+
+/** A {@link Task} that creates YAML with extraction metadata. */
+@ParametersAreNonnullByDefault
+abstract class SnowflakeYamlSummaryTask extends AbstractTask<Void> {
+
+  private static final String zipEntryName = CompilerWorksDumpMetadataTaskFormat.ZIP_ENTRY_NAME;
+
+  @Nonnull private final String zipFormat;
+
+  @Override
+  public final String describeSourceData() {
+    return "containing dump metadata.";
+  }
+
+  @Override
+  protected final Void doRun(@Nullable TaskRunContext context, ByteSink sink, Handle handle)
+      throws IOException {
+    Product product = new Product();
+    product.version = String.valueOf(new ProductMetadata());
+    product.arguments = serializedArguments(context);
+
+    CharSink streamSupplier = sink.asCharSink(UTF_8);
+    try (Writer writer = streamSupplier.openBufferedStream()) {
+
+      Root root = new Root();
+      root.format = zipFormat;
+      root.timestamp = System.currentTimeMillis();
+      root.product = product;
+      CoreMetadataDumpFormat.MAPPER.writeValue(writer, root);
+      return null;
+    }
+  }
+
+  @Nonnull
+  static SnowflakeYamlSummaryTask create(String zipFormat) {
+    return new ContextArgumentsTask(zipFormat);
+  }
+
+  @Nonnull
+  static SnowflakeYamlSummaryTask create(String zipFormat, ConnectorArguments arguments) {
+    return new FixedArgumentsTask(zipFormat, arguments);
+  }
+
+  private SnowflakeYamlSummaryTask(String format) {
+    super(zipEntryName);
+    this.zipFormat = format;
+  }
+
+  @Nonnull
+  abstract String serializedArguments(@Nullable TaskRunContext context);
+
+  /** A task that takes arguments from {@link TaskRunContext}. */
+  private static class ContextArgumentsTask extends SnowflakeYamlSummaryTask {
+
+    ContextArgumentsTask(String zipFormat) {
+      super(zipFormat);
+    }
+
+    @Override
+    @Nonnull
+    String serializedArguments(@Nullable TaskRunContext context) {
+      context = requireNonNull(context);
+      return String.valueOf(context.getArguments());
+    }
+  }
+
+  /** A task that stores its own {@link ConnectorArguments}. */
+  private static class FixedArgumentsTask extends SnowflakeYamlSummaryTask {
+
+    @Nonnull final ConnectorArguments arguments;
+
+    FixedArgumentsTask(String zipFormat, ConnectorArguments arguments) {
+      super(zipFormat);
+      this.arguments = arguments;
+    }
+
+    @Override
+    @Nonnull
+    String serializedArguments(@Nullable TaskRunContext unused) {
+      return String.valueOf(arguments);
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
@@ -50,22 +50,25 @@ abstract class SnowflakeYamlSummaryTask extends AbstractTask<Void> {
   }
 
   @Override
-  protected final Void doRun(@Nullable TaskRunContext context, ByteSink sink, Handle handle)
+  protected final Void doRun(@Nullable TaskRunContext context, ByteSink sink, Handle unused)
       throws IOException {
+    CharSink streamSupplier = sink.asCharSink(UTF_8);
+    try (Writer writer = streamSupplier.openBufferedStream()) {
+      CoreMetadataDumpFormat.MAPPER.writeValue(writer, createRoot(context));
+      return null;
+    }
+  }
+
+  Root createRoot(@Nullable TaskRunContext context) throws IOException {
     Product product = new Product();
     product.version = String.valueOf(new ProductMetadata());
     product.arguments = serializedArguments(context);
 
-    CharSink streamSupplier = sink.asCharSink(UTF_8);
-    try (Writer writer = streamSupplier.openBufferedStream()) {
-
-      Root root = new Root();
-      root.format = zipFormat;
-      root.timestamp = System.currentTimeMillis();
-      root.product = product;
-      CoreMetadataDumpFormat.MAPPER.writeValue(writer, root);
-      return null;
-    }
+    Root root = new Root();
+    root.format = zipFormat;
+    root.timestamp = System.currentTimeMillis();
+    root.product = product;
+    return root;
   }
 
   @Nonnull

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnectorTest.java
@@ -40,6 +40,15 @@ public class SnowflakeLiteConnectorTest {
   }
 
   @Test
+  public void getDescription_success() {
+
+    String description = connector.getDescription();
+
+    assertTrue(description, description.contains("lite"));
+    assertTrue(description, description.contains("Snowflake"));
+  }
+
+  @Test
   public void validate_databaseFlag_throwsException() {
     ImmutableList<String> list =
         ImmutableList.of(

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeYamlSummaryTask.create;
+import static java.lang.Math.abs;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Root;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.function.LongPredicate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SnowflakeYamlSummaryTaskTest {
+
+  @Test
+  public void createRoot_success() throws IOException {
+    ImmutableList<String> argumentValues = ImmutableList.of("--connector", "snowflake");
+    ConnectorArguments arguments = ConnectorArguments.create(argumentValues);
+    LongPredicate timeCheck = millis -> abs(Instant.now().toEpochMilli() - millis) < 10000L;
+    SnowflakeYamlSummaryTask task = create("snowflake.metadata.zip", arguments);
+
+    Root root = task.createRoot(null);
+
+    assertEquals("snowflake.metadata.zip", root.format);
+    assertTrue(root.product.arguments, root.product.arguments.contains("connector=snowflake"));
+    assertTrue(String.valueOf(root.timestamp), timeCheck.test(root.timestamp));
+  }
+}


### PR DESCRIPTION
### Motivation

Changes to core Dumper logic (e.g. `DumpMetadataTask`) should be avoided when possible. This is to avoid breaking untested parts of legacy code and to preserve the simplicity of core Dumper mechanics.

On the other hand, there is a need to provide additional dump metadata for Snowflake on top of the existing files:
- `compilerworks-arguments.txt`
- `compilerworks-format.txt`
- `compilerworks-version.txt`
- `compilerworks-metadata.yaml`
- `dumper-telemetry.jsonl`

Adding yet another item to the list doesn't look like the best course of action - the current list is already confusing and we're close to a point where the metadata files outnumber the data files that they're supposed to describe.

### Change

Add a new task as an alternative to DumpMetadataTask meant for Snowflake. For now, this is identical to the original, but it allows for future development while keeping the changes local.