### PR TITLE
Fix: acceleration history task should be optional

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -91,11 +91,6 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     private final TaskCategory taskCategory;
 
     private TaskDescription(
-        String zipPrefix, String unformattedQuery, Class<? extends Enum<?>> headerClass) {
-      this(zipPrefix, unformattedQuery, headerClass, TaskCategory.REQUIRED);
-    }
-
-    private TaskDescription(
         String zipPrefix,
         String unformattedQuery,
         Class<? extends Enum<?>> headerClass,
@@ -316,7 +311,8 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
 
     if (!arguments.isAssessment()) {
       TaskDescription queryHistoryTask =
-          new TaskDescription(ZIP_ENTRY_PREFIX, newQueryFormat(arguments), Header.class);
+          new TaskDescription(
+              ZIP_ENTRY_PREFIX, newQueryFormat(arguments), Header.class, TaskCategory.REQUIRED);
       queryLogIntervals.forEach(interval -> addJdbcTask(out, interval, queryHistoryTask));
       return;
     }
@@ -325,7 +321,8 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
         new TaskDescription(
             QueryHistoryExtendedFormat.ZIP_ENTRY_PREFIX,
             createExtendedQueryFromAccountUsage(arguments),
-            QueryHistoryExtendedFormat.Header.class);
+            QueryHistoryExtendedFormat.Header.class,
+            TaskCategory.REQUIRED);
     queryLogIntervals.forEach(interval -> addJdbcTask(out, interval, queryHistoryTask));
 
     List<TaskDescription> timeSeriesTasks =
@@ -335,7 +332,8 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
                   String override = arguments.getDefinition(item.property);
                   String prefix = formatPrefix(item.headerClass, item.viewName());
                   String query = overrideableQuery(override, prefix, item.column.value);
-                  return new TaskDescription(item.zipPrefix, query, item.headerClass);
+                  return new TaskDescription(
+                      item.zipPrefix, query, item.headerClass, item.category);
                 })
             .collect(toImmutableList());
     Duration duration = Duration.ofDays(1);
@@ -430,7 +428,8 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
         QueryAccelerationHistoryFormat.Header.class,
         QueryAccelerationHistoryFormat.ZIP_ENTRY_PREFIX,
         TimeSeriesColumn.END_TIME,
-        SnowflakeLogsConnectorProperty.QUERY_ACCELERATION_HISTORY_OVERRIDE_QUERY),
+        SnowflakeLogsConnectorProperty.QUERY_ACCELERATION_HISTORY_OVERRIDE_QUERY,
+        TaskCategory.OPTIONAL),
     REPLICATION_GROUP_USAGE_HISTORY(
         ReplicationGroupUsageHistoryFormat.Header.class,
         QueryAccelerationHistoryFormat.ZIP_ENTRY_PREFIX,
@@ -461,18 +460,29 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
     final ConnectorProperty property;
     final String queryPrefix;
     final String zipPrefix;
+    final TaskCategory category;
     final TimeSeriesColumn column;
 
     TimeSeriesView(
         Class<? extends Enum<?>> headerClass,
         String zipPrefix,
         TimeSeriesColumn column,
-        SnowflakeLogsConnectorProperty property) {
+        SnowflakeLogsConnectorProperty property,
+        TaskCategory category) {
       this.headerClass = headerClass;
       this.property = property;
       this.queryPrefix = formatPrefix(headerClass, name());
       this.zipPrefix = zipPrefix;
+      this.category = category;
       this.column = column;
+    }
+
+    TimeSeriesView(
+        Class<? extends Enum<?>> headerClass,
+        String zipPrefix,
+        TimeSeriesColumn column,
+        SnowflakeLogsConnectorProperty property) {
+      this(headerClass, zipPrefix, column, property, TaskCategory.REQUIRED);
     }
 
     static final ImmutableList<TimeSeriesView> valuesInOrder =

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -432,7 +432,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
         TaskCategory.OPTIONAL),
     REPLICATION_GROUP_USAGE_HISTORY(
         ReplicationGroupUsageHistoryFormat.Header.class,
-        QueryAccelerationHistoryFormat.ZIP_ENTRY_PREFIX,
+        ReplicationGroupUsageHistoryFormat.ZIP_ENTRY_PREFIX,
         TimeSeriesColumn.END_TIME,
         SnowflakeLogsConnectorProperty.REPLICATION_GROUP_USAGE_HISTORY_OVERRIDE_QUERY),
     SERVERLESS_TASK_HISTORY(

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorTest.java
@@ -26,11 +26,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeLogsConnector.TimeSeriesView;
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.test.TestUtils;
 import java.io.File;
 import org.junit.Test;
@@ -109,6 +111,20 @@ public class SnowflakeLogsConnectorTest {
     assertTrue(result, result.contains(originalQuery));
     assertTrue(result, result.contains("AND"));
     assertTrue(result, result.contains(override));
+  }
+
+  @Test
+  public void category_accelerationHistory_isOptional() {
+    TimeSeriesView view = TimeSeriesView.QUERY_ACCELERATION_HISTORY;
+
+    assertEquals(view.category, TaskCategory.OPTIONAL);
+  }
+
+  @Theory
+  public void category_notAccelerationHistory_isRequired(TimeSeriesView view) {
+    assumeFalse(view.equals(TimeSeriesView.QUERY_ACCELERATION_HISTORY));
+
+    assertEquals(view.category, TaskCategory.REQUIRED);
   }
 
   @Test


### PR DESCRIPTION
The category of this task was broken by an earlier change.