### PR TITLE
[b/446687185] Extract new metrics from Snowflake

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -207,6 +207,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
             + "session_id, \n"
             + "user_name, \n"
             + "warehouse_name, \n"
+            + "warehouse_size, \n"
             + "cluster_number, \n"
             + "query_tag, \n"
             + "execution_status, \n"
@@ -423,6 +424,12 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
         TimeSeriesColumn.END_TIME,
         SnowflakeLogsConnectorProperty.QUERY_ACCELERATION_HISTORY_OVERRIDE_QUERY,
         TaskCategory.OPTIONAL),
+    QUERY_ATTRIBUTION_HISTORY(
+        QueryAttributionHistoryFormat.Header.class,
+        QueryAttributionHistoryFormat.ZIP_ENTRY_PREFIX,
+        TimeSeriesColumn.END_TIME,
+        SnowflakeLogsConnectorProperty.QUERY_ATTRIBUTION_HISTORY_OVERRIDE_QUERY
+    ),
     REPLICATION_GROUP_USAGE_HISTORY(
         ReplicationGroupUsageHistoryFormat.Header.class,
         ReplicationGroupUsageHistoryFormat.ZIP_ENTRY_PREFIX,
@@ -488,6 +495,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
             METERING_DAILY_HISTORY,
             PIPE_USAGE_HISTORY,
             QUERY_ACCELERATION_HISTORY,
+            QUERY_ATTRIBUTION_HISTORY,
             REPLICATION_GROUP_USAGE_HISTORY,
             SERVERLESS_TASK_HISTORY,
             TASK_HISTORY,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorProperty.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnectorProperty.java
@@ -47,6 +47,10 @@ enum SnowflakeLogsConnectorProperty implements ConnectorProperty {
   QUERY_ACCELERATION_HISTORY_OVERRIDE_QUERY(
       "snowflake.query_acceleration_history.query",
       "Custom query for query acceleration history dump"),
+  QUERY_ATTRIBUTION_HISTORY_OVERRIDE_QUERY(
+      "snowflake.query_attribution_history.query",
+      "Custom query for query attribution history dump"
+  ),
   REPLICATION_GROUP_USAGE_HISTORY_OVERRIDE_QUERY(
       "snowflake.replication_group_usage_history.query",
       "Custom query for replication group usage history dump"),

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeLogsDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeLogsDumpFormat.java
@@ -54,6 +54,7 @@ public interface SnowflakeLogsDumpFormat {
       SessionId,
       UserName,
       WarehouseName,
+      WarehouseSize,
       ClusterNumber,
       QueryTag,
       ExecutionStatus,
@@ -238,6 +239,22 @@ public interface SnowflakeLogsDumpFormat {
       CreditsUsed,
       WarehouseId,
       WarehouseName
+    }
+  }
+
+  interface QueryAttributionHistoryFormat {
+
+    String ZIP_ENTRY_PREFIX = "query_attribution_history-au_";
+
+    enum Header {
+      QueryId,
+      QueryHash,
+      WarehouseName,
+      UserName,
+      StartTime,
+      EndTime,
+      CreditsAttributedCompute,
+      CreditsUsedQueryAcceleration
     }
   }
 


### PR DESCRIPTION
Extract metrics from the `QUERY_ATTRIBUTION_HISTORY` view.
Extract `warehouse_size` from the `QUERY_HISTORY` view.

These metrics will be used by the ML model developed in the project [b/432667540].