### PR TITLE
Add a summary YAML for Snowflake

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -20,6 +20,7 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
@@ -57,8 +58,9 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   @Override
   public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
-    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
+    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.addAll(planner.generateLiteSpecificQueries());
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnector.java
@@ -20,7 +20,6 @@ import com.google.auto.service.AutoService;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.utils.ArchiveNameUtil;
@@ -58,7 +57,7 @@ public final class SnowflakeLiteConnector extends AbstractSnowflakeConnector {
 
   @Override
   public final void addTasksTo(List<? super Task<?>> out, ConnectorArguments arguments) {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.add(new FormatTask(FORMAT_NAME));
     out.addAll(planner.generateLiteSpecificQueries());
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -39,6 +39,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterable;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterableGenerator;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
@@ -295,8 +296,9 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
-    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
+    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
 
     // (24 * 7) -> 7 trailing days == 168 hours
     // Actually, on Snowflake, 7 days ago starts at midnight in an unadvertised time zone. What the

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLogsConnector.java
@@ -39,7 +39,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.LogsConnector
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedInterval;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterable;
 import com.google.edwmigration.dumper.application.dumper.connector.ZonedIntervalIterableGenerator;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
@@ -296,7 +295,7 @@ public class SnowflakeLogsConnector extends AbstractSnowflakeConnector
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments)
       throws MetadataDumperUsageException {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.add(new FormatTask(FORMAT_NAME));
 
     // (24 * 7) -> 7 trailing days == 168 hours

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -33,7 +33,6 @@ import com.google.edwmigration.dumper.application.dumper.connector.snowflake.Sno
 import com.google.edwmigration.dumper.application.dumper.io.OutputHandle.WriteMode;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractTask.TaskOptions;
-import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
@@ -169,7 +168,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   @Override
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments) {
-    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
     out.add(new FormatTask(FORMAT_NAME));
 
     boolean INJECT_IS_FAULT = arguments.isTestFlag('A');

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -33,6 +33,7 @@ import com.google.edwmigration.dumper.application.dumper.connector.snowflake.Sno
 import com.google.edwmigration.dumper.application.dumper.io.OutputHandle.WriteMode;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractTask.TaskOptions;
+import com.google.edwmigration.dumper.application.dumper.task.DumpMetadataTask;
 import com.google.edwmigration.dumper.application.dumper.task.FormatTask;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
@@ -168,8 +169,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   @Override
   public final void addTasksTo(
       @Nonnull List<? super Task<?>> out, @Nonnull ConnectorArguments arguments) {
-    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
+    out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
+    out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
 
     boolean INJECT_IS_FAULT = arguments.isTestFlag('A');
     // INFORMATION_SCHEMA queries must be qualified with a database

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
+
+import com.google.common.io.ByteSink;
+import com.google.common.io.CharSink;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.application.dumper.handle.Handle;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractTask;
+import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Product;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Root;
+import java.io.IOException;
+import java.io.Writer;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.annotation.ParametersAreNonnullByDefault;
+import org.anarres.jdiagnostics.ProductMetadata;
+
+/** A {@link Task} that creates YAML with extraction metadata. */
+@ParametersAreNonnullByDefault
+abstract class SnowflakeYamlSummaryTask extends AbstractTask<Void> {
+
+  private static final String zipEntryName = CompilerWorksDumpMetadataTaskFormat.ZIP_ENTRY_NAME;
+
+  @Nonnull private final String zipFormat;
+
+  @Override
+  public final String describeSourceData() {
+    return "containing dump metadata.";
+  }
+
+  @Override
+  protected final Void doRun(@Nullable TaskRunContext context, ByteSink sink, Handle handle)
+      throws IOException {
+    Product product = new Product();
+    product.version = String.valueOf(new ProductMetadata());
+    product.arguments = serializedArguments(context);
+
+    CharSink streamSupplier = sink.asCharSink(UTF_8);
+    try (Writer writer = streamSupplier.openBufferedStream()) {
+
+      Root root = new Root();
+      root.format = zipFormat;
+      root.timestamp = System.currentTimeMillis();
+      root.product = product;
+      CoreMetadataDumpFormat.MAPPER.writeValue(writer, root);
+      return null;
+    }
+  }
+
+  @Nonnull
+  static SnowflakeYamlSummaryTask create(String zipFormat) {
+    return new ContextArgumentsTask(zipFormat);
+  }
+
+  @Nonnull
+  static SnowflakeYamlSummaryTask create(String zipFormat, ConnectorArguments arguments) {
+    return new FixedArgumentsTask(zipFormat, arguments);
+  }
+
+  private SnowflakeYamlSummaryTask(String format) {
+    super(zipEntryName);
+    this.zipFormat = format;
+  }
+
+  @Nonnull
+  abstract String serializedArguments(@Nullable TaskRunContext context);
+
+  /** A task that takes arguments from {@link TaskRunContext}. */
+  private static class ContextArgumentsTask extends SnowflakeYamlSummaryTask {
+
+    ContextArgumentsTask(String zipFormat) {
+      super(zipFormat);
+    }
+
+    @Override
+    @Nonnull
+    String serializedArguments(@Nullable TaskRunContext context) {
+      context = requireNonNull(context);
+      return String.valueOf(context.getArguments());
+    }
+  }
+
+  /** A task that stores its own {@link ConnectorArguments}. */
+  private static class FixedArgumentsTask extends SnowflakeYamlSummaryTask {
+
+    @Nonnull final ConnectorArguments arguments;
+
+    FixedArgumentsTask(String zipFormat, ConnectorArguments arguments) {
+      super(zipFormat);
+      this.arguments = arguments;
+    }
+
+    @Override
+    @Nonnull
+    String serializedArguments(@Nullable TaskRunContext unused) {
+      return String.valueOf(arguments);
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
@@ -50,22 +50,25 @@ abstract class SnowflakeYamlSummaryTask extends AbstractTask<Void> {
   }
 
   @Override
-  protected final Void doRun(@Nullable TaskRunContext context, ByteSink sink, Handle handle)
+  protected final Void doRun(@Nullable TaskRunContext context, ByteSink sink, Handle unused)
       throws IOException {
+    CharSink streamSupplier = sink.asCharSink(UTF_8);
+    try (Writer writer = streamSupplier.openBufferedStream()) {
+      CoreMetadataDumpFormat.MAPPER.writeValue(writer, createRoot(context));
+      return null;
+    }
+  }
+
+  Root createRoot(@Nullable TaskRunContext context) throws IOException {
     Product product = new Product();
     product.version = String.valueOf(new ProductMetadata());
     product.arguments = serializedArguments(context);
 
-    CharSink streamSupplier = sink.asCharSink(UTF_8);
-    try (Writer writer = streamSupplier.openBufferedStream()) {
-
-      Root root = new Root();
-      root.format = zipFormat;
-      root.timestamp = System.currentTimeMillis();
-      root.product = product;
-      CoreMetadataDumpFormat.MAPPER.writeValue(writer, root);
-      return null;
-    }
+    Root root = new Root();
+    root.format = zipFormat;
+    root.timestamp = System.currentTimeMillis();
+    root.product = product;
+    return root;
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTask.java
@@ -16,28 +16,46 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.LITERAL_BLOCK_STYLE;
+import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.SPLIT_LINES;
+import static com.fasterxml.jackson.dataformat.yaml.YAMLGenerator.Feature.WRITE_DOC_START_MARKER;
+import static java.lang.Integer.parseInt;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Objects.requireNonNull;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSink;
-import com.google.common.io.CharSink;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.handle.JdbcHandle;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.sql.Connection;
+import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.ResultSetExtractor;
 
 /** A {@link Task} that creates YAML with extraction metadata. */
 @ParametersAreNonnullByDefault
 final class SnowflakeYamlSummaryTask extends AbstractJdbcTask<Void> {
+
+  private static final YAMLFactory yamlFactory =
+      new YAMLFactory()
+          .enable(LITERAL_BLOCK_STYLE)
+          .disable(WRITE_DOC_START_MARKER)
+          .disable(SPLIT_LINES);
+  private static final ObjectMapper mapper =
+      new ObjectMapper(yamlFactory).enable(SerializationFeature.INDENT_OUTPUT);
 
   private final boolean isAssessment;
 
@@ -46,18 +64,24 @@ final class SnowflakeYamlSummaryTask extends AbstractJdbcTask<Void> {
     return "containing dump metadata.";
   }
 
-  static ImmutableMap<String, String> createRoot(boolean isAssessment, String count)
-      throws IOException {
-    ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    builder.put("assessment", String.valueOf(isAssessment));
-    builder.put("warehouse_count", count);
-    return builder.build();
+  static ImmutableMap<String, ?> createRoot(boolean isAssessment, Optional<String> optionalCount) {
+    ImmutableMap.Builder<String, Object> builder = ImmutableMap.builder();
+    builder.put("assessment", isAssessment);
+    String count = optionalCount.orElse(null);
+    int parsed;
+    if (count == null) {
+      parsed = 0;
+    } else {
+      parsed = parseInt(count);
+    }
+    builder.put("warehouse_count", parsed);
+    return ImmutableMap.of("metadata", builder.build());
   }
 
-  static String rootString(boolean isAssessment, String count) {
+  static String rootString(boolean isAssessment, Optional<String> optionalCount) {
     try {
-      ImmutableMap<String, String> root = createRoot(isAssessment, count);
-      return CoreMetadataDumpFormat.MAPPER.writeValueAsString(root);
+      ImmutableMap<String, ?> root = createRoot(isAssessment, optionalCount);
+      return mapper.writeValueAsString(root);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -77,27 +101,34 @@ final class SnowflakeYamlSummaryTask extends AbstractJdbcTask<Void> {
   protected Void doInConnection(
       TaskRunContext context, JdbcHandle jdbcHandle, ByteSink sink, Connection connection)
       throws SQLException {
-    ResultSetExtractor<Void> extractor =
-        resultSet -> {
-          try {
-            Object value = String.valueOf(resultSet.getMetaData().getColumnCount());
-            action(sink, isAssessment, String.valueOf(value));
-            return null;
-          } catch (IOException e) {
-            throw new UncheckedIOException(e);
-          }
-        };
     String sql = "SHOW WAREHOUSES ->> SELECT count(*) FROM $1";
-    doSelect(connection, extractor, sql);
-    return null;
+    return doSelect(connection, new Extractor(sink, isAssessment), sql);
   }
 
-  private static void action(ByteSink sink, boolean isAssessment, String count) throws IOException {
+  static final class Extractor implements ResultSetExtractor<Void> {
+    private final ByteSink sink;
+    private final boolean isAssessment;
 
-    CharSink streamSupplier = sink.asCharSink(UTF_8);
-    try (Writer writer = streamSupplier.openBufferedStream()) {
-      String value = rootString(isAssessment, count);
-      CoreMetadataDumpFormat.MAPPER.writeValue(writer, value);
+    Extractor(ByteSink sink, boolean isAssessment) {
+      this.sink = sink;
+      this.isAssessment = isAssessment;
+    }
+
+    @Override
+    public Void extractData(@Nullable ResultSet rs) throws SQLException, DataAccessException {
+      doExtract(requireNonNull(rs));
+      return null;
+    }
+
+    void doExtract(ResultSet resultSet) throws SQLException, DataAccessException {
+      resultSet.next();
+      Optional<String> count = Optional.ofNullable(resultSet.getString(1));
+      String yaml = rootString(isAssessment, count);
+      try (Writer writer = sink.asCharSink(UTF_8).openBufferedStream()) {
+        mapper.writeValue(writer, yaml);
+      } catch (IOException e) {
+        throw new UncheckedIOException(e);
+      }
     }
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeLiteConnectorTest.java
@@ -40,6 +40,15 @@ public class SnowflakeLiteConnectorTest {
   }
 
   @Test
+  public void getDescription_success() {
+
+    String description = connector.getDescription();
+
+    assertTrue(description, description.contains("lite"));
+    assertTrue(description, description.contains("Snowflake"));
+  }
+
+  @Test
   public void validate_databaseFlag_throwsException() {
     ImmutableList<String> list =
         ImmutableList.of(

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
@@ -16,17 +16,8 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeYamlSummaryTask.create;
-import static java.lang.Math.abs;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
-import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
-import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Root;
-import java.io.IOException;
-import java.time.Instant;
-import java.util.function.LongPredicate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -35,16 +26,7 @@ import org.junit.runners.JUnit4;
 public class SnowflakeYamlSummaryTaskTest {
 
   @Test
-  public void createRoot_success() throws IOException {
-    ImmutableList<String> argumentValues = ImmutableList.of("--connector", "snowflake");
-    ConnectorArguments arguments = ConnectorArguments.create(argumentValues);
-    LongPredicate timeCheck = millis -> abs(Instant.now().toEpochMilli() - millis) < 10000L;
-    SnowflakeYamlSummaryTask task = create("snowflake.metadata.zip", arguments);
-
-    Root root = task.createRoot(null);
-
-    assertEquals("snowflake.metadata.zip", root.format);
-    assertTrue(root.product.arguments, root.product.arguments.contains("connector=snowflake"));
-    assertTrue(String.valueOf(root.timestamp), timeCheck.test(root.timestamp));
+  public void createRoot_success() {
+    assertTrue(true);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
@@ -16,8 +16,13 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeYamlSummaryTask.createRoot;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeYamlSummaryTask.rootString;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableMap;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,7 +31,34 @@ import org.junit.runners.JUnit4;
 public class SnowflakeYamlSummaryTaskTest {
 
   @Test
-  public void createRoot_success() {
-    assertTrue(true);
+  public void rootString_success() {
+
+    String rootString = rootString(true, Optional.of("2345"));
+
+    assertTrue(rootString, rootString.contains("assessment"));
+    assertTrue(rootString, rootString.contains("true"));
+    assertTrue(rootString, rootString.contains("warehouse_count"));
+    assertTrue(rootString, rootString.contains("2345"));
+  }
+
+  @Test
+  public void createRoot_countAbsent_setToZero() {
+
+    ImmutableMap<String, ?> root = createRoot(true, Optional.empty());
+
+    assertTrue(root.toString(), root.containsKey("metadata"));
+    ImmutableMap<?, ?> value = (ImmutableMap<?, ?>) root.get("metadata");
+    assertEquals(0, value.get("warehouse_count"));
+  }
+
+  @Test
+  public void createRoot_noAssessment_success() {
+
+    ImmutableMap<String, ?> root = createRoot(false, Optional.of("123"));
+
+    assertTrue(root.toString(), root.containsKey("metadata"));
+    ImmutableMap<?, ?> value = (ImmutableMap<?, ?>) root.get("metadata");
+    assertEquals(false, value.get("assessment"));
+    assertEquals(123, value.get("warehouse_count"));
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeYamlSummaryTaskTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
+
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeYamlSummaryTask.create;
+import static java.lang.Math.abs;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
+import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat.CompilerWorksDumpMetadataTaskFormat.Root;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.function.LongPredicate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SnowflakeYamlSummaryTaskTest {
+
+  @Test
+  public void createRoot_success() throws IOException {
+    ImmutableList<String> argumentValues = ImmutableList.of("--connector", "snowflake");
+    ConnectorArguments arguments = ConnectorArguments.create(argumentValues);
+    LongPredicate timeCheck = millis -> abs(Instant.now().toEpochMilli() - millis) < 10000L;
+    SnowflakeYamlSummaryTask task = create("snowflake.metadata.zip", arguments);
+
+    Root root = task.createRoot(null);
+
+    assertEquals("snowflake.metadata.zip", root.format);
+    assertTrue(root.product.arguments, root.product.arguments.contains("connector=snowflake"));
+    assertTrue(String.valueOf(root.timestamp), timeCheck.test(root.timestamp));
+  }
+}


### PR DESCRIPTION
Provide simple feedback to users running Snowflake extraction.

- Add an additional, user-readable file - `snowflake.yaml`.
- Add a task which generates this file to the connectors: `snowflake`, `snowflake-logs`, `snowflake-lite`.

An example of file contents (assessment enabled, detected 17 warehouses on user system):

```yaml
metadata:
  assessment: true
  warehouse_count: 17
```