### PR TITLE
[b454252314] Add execution result to summary

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/MetadataDumper.java
@@ -296,6 +296,9 @@ public class MetadataDumper {
             linePrinter.println(
                 "Output, including debugging information, saved to '%s'", outputFileLocation);
           }
+
+          String stateToPrint = requiredTaskSucceeded ? "SUCCEEDED" : "FAILED";
+          linePrinter.println("Dumper execution: " + stateToPrint);
         });
   }
 }


### PR DESCRIPTION
Add execution result to summary

```
********************************************************************
* Dumper wrote 147070 bytes, took 26.31 min.
* Task summary: 5 FAILED, 4 SUCCEEDED
* Output, including debugging information, saved to 'dwh-migration-oozie-20251023T192218.zip'
* Dumper execution: FAILED
********************************************************************
```