### PR TITLE
[b/462688456] Add known CVEs files and schema.

### DIFF
--- a/.security/known_cves.yml
+++ b/.security/known_cves.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=./known_cves_schema.json
+
+- CVE: CVE-2025-52999
+  artifact: org.example:vulnerability-lib:3.18.0
+  justification: >
+    Some text
+    with very nice and clear explanation
+  expiration_date: 2030-05-18

--- a/.security/known_cves_schema.json
+++ b/.security/known_cves_schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Know vulnerabilities exceptions report",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "CVE": {
+        "type": "string",
+        "description": "The Common Vulnerabilities and Exposures Id. https://www.cve.org/",
+        "pattern": "^CVE-\\d{4}-\\d{4,}$"
+      },
+      "artifact": {
+        "type": "string",
+        "description": "The Maven style artifact id. (group:artifact:version)"
+      },
+      "justification": {
+        "type": "string",
+        "description": "The reason why this vulnerability does not impact the tools."
+      },
+      "expiration_date": {
+        "type": "string",
+        "format": "date",
+        "description": "The date (YYYY-MM-DD) when this waiver expires and must be reviewed."
+      }
+    },
+    "required": [
+      "CVE",
+      "artifact",
+      "justification"
+    ]
+  }
+}


### PR DESCRIPTION
We already have some know CVEs in the project. These CVEs must be explicitly mentioned in this file with a justification. 

Both `Yaml` and `Json` formats can be supported with the single JSONSchema. In this example I use `yml` because it seems more human redable in case of multiple lines `justification`.

Examples:
```
# yaml-language-server: $schema=./known_cves_schema.json

- CVE: CVE-2025-52999
  artifact: org.example:vulnerability-lib:3.18.0
  justification: |
    Some text
    with very nice and clear explanation
  expiration_date: 2030-05-18
```

```
[
  {
    "CVE": "CVE-2025-52999",
    "artifact": "org.apache.commons:commons-lang3:3.18.0",
    "justification": "We can and we do",
    "expiration_date": "ISO something"
  },
...
]
```