### PR TITLE
[OPS] Add GitHub Action to clean-up stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 35 # 5 working weeks should be ok
           days-before-close: 14 # plus 2 weeks to act
           stale-pr-label: 'stale'


### PR DESCRIPTION
Well, some PRs stay open without any actions for long time.

I cleaned them manually on Friday or Monday. I would prefer to automate it.

5 weeks: A PR will be marked as `Stale`. Only marked without any additional actions
2 weeks: `Stale` PRs will be closed after 2 weeks. Any action will refresh PR and make it active. 