### PR TITLE
Additional unit tests for AbstractOozieJobsTask

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/AbstractOozieJobsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/AbstractOozieJobsTask.java
@@ -162,13 +162,13 @@ public abstract class AbstractOozieJobsTask<J> extends AbstractTask<Void> {
     for (int i = 0; i < header.size(); i++) {
       Object property = jobObjectWrapper.getPropertyValue(header.get(i));
       if (property != null) {
-        record[i] = toRecord(property);
+        record[i] = toRecordProperty(property);
       }
     }
     return record;
   }
 
-  static Object toRecord(Object property) throws JsonProcessingException {
+  static Object toRecordProperty(Object property) throws JsonProcessingException {
     if (property instanceof Date) {
       // avoid date formats complexity and use milliseconds
       return ((Date) property).getTime();

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/AbstractOozieJobsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/hadoop/oozie/AbstractOozieJobsTaskTest.java
@@ -31,29 +31,29 @@ public class AbstractOozieJobsTaskTest {
   static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 
   @Test
-  public void toRecord_dateArgument_convertsToLong() throws Exception {
+  public void toRecordProperty_dateArgument_convertsToLong() throws Exception {
     Date christmas = dateFormat.parse("2025-12-25");
 
-    Object result = AbstractOozieJobsTask.toRecord(christmas);
+    Object result = AbstractOozieJobsTask.toRecordProperty(christmas);
 
     assertEquals(Long.class, result.getClass());
     assertEquals("2025-12-25", convertDate(result));
   }
 
   @Test
-  public void toRecord_listArgument_success() throws Exception {
+  public void toRecordProperty_listArgument_success() throws Exception {
     ImmutableList<String> list = ImmutableList.of("abcde", "fghi");
 
-    Object result = AbstractOozieJobsTask.toRecord(list);
+    Object result = AbstractOozieJobsTask.toRecordProperty(list);
 
     assertEquals("[\"abcde\",\"fghi\"]", result);
   }
 
   @Test
-  public void toRecord_otherArgument_nothingChanges() throws Exception {
+  public void toRecordProperty_otherArgument_nothingChanges() throws Exception {
     Object value = new Object();
 
-    Object result = AbstractOozieJobsTask.toRecord(value);
+    Object result = AbstractOozieJobsTask.toRecordProperty(value);
 
     assertEquals(value, result);
   }


### PR DESCRIPTION
The lines:
```java
  // AbstractOozieJobsTask.java
  if (record[i] != null && record[i] instanceof List) {
    // write Actions arrays as json string in csv
    record[i] = objectMapper.writeValueAsString(record[i]);
```
show up as covered in jacoco, but after removing them the tests still pass.

Add class-specific tests for AbstractOozieJobsTask to ensure that validation is correct.