### PR TITLE
[b456377401] Implement Spark History discovery

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaYarnApplicationTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaYarnApplicationTask.java
@@ -19,7 +19,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.cloudera.man
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.base.Preconditions;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYARNApplicationDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYarnApplicationDto;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import java.io.IOException;
 import java.net.URI;
@@ -83,20 +83,20 @@ public abstract class AbstractClouderaYarnApplicationTask extends AbstractCloude
       toAppCreationDate = toDate.format(dtFormatter);
     }
 
-    public int load(String clusterName, Consumer<List<ApiYARNApplicationDTO>> onPageLoad) {
+    public int load(String clusterName, Consumer<List<ApiYarnApplicationDto>> onPageLoad) {
       return load(clusterName, null, onPageLoad);
     }
 
     public int load(
         String clusterName,
         @Nullable String appType,
-        Consumer<List<ApiYARNApplicationDTO>> onPageLoad) {
+        Consumer<List<ApiYarnApplicationDto>> onPageLoad) {
       offset = 0;
       boolean fetchedNewApps;
       do {
         fetchedNewApps = false;
         URI yarnAppsURI = buildNextYARNApplicationPageURI(clusterName, appType);
-        List<ApiYARNApplicationDTO> newLoad = load(yarnAppsURI);
+        List<ApiYarnApplicationDto> newLoad = load(yarnAppsURI);
         if (!newLoad.isEmpty()) {
           onPageLoad.accept(newLoad);
           offset += newLoad.size();
@@ -106,7 +106,7 @@ public abstract class AbstractClouderaYarnApplicationTask extends AbstractCloude
       return offset;
     }
 
-    private List<ApiYARNApplicationDTO> load(URI yarnAppURI) {
+    private List<ApiYarnApplicationDto> load(URI yarnAppURI) {
       try (CloseableHttpResponse resp = httpClient.execute(new HttpGet(yarnAppURI))) {
         int statusCode = resp.getStatusLine().getStatusCode();
         if (!isStatusCodeOK(statusCode)) {
@@ -130,10 +130,10 @@ public abstract class AbstractClouderaYarnApplicationTask extends AbstractCloude
       }
     }
 
-    private List<ApiYARNApplicationDTO> toDTOs(ArrayNode applicationsArray) {
-      List<ApiYARNApplicationDTO> yarnApplicationDTOs = new ArrayList<>();
+    private List<ApiYarnApplicationDto> toDTOs(ArrayNode applicationsArray) {
+      List<ApiYarnApplicationDto> yarnApplicationDTOs = new ArrayList<>();
       for (JsonNode application : applicationsArray) {
-        yarnApplicationDTOs.add(new ApiYARNApplicationDTO(application));
+        yarnApplicationDTOs.add(new ApiYarnApplicationDto(application));
       }
 
       return yarnApplicationDTOs;

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCpuChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCpuChartTask.java
@@ -40,12 +40,12 @@ import org.slf4j.LoggerFactory;
  * href="https://docs.cloudera.com/documentation/enterprise/latest/topics/cm_dg_tsquery.html">tsquery</a>
  * language.
  */
-public class ClouderaClusterCPUChartTask extends AbstractClouderaTimeSeriesTask {
-  private static final Logger logger = LoggerFactory.getLogger(ClouderaClusterCPUChartTask.class);
+public class ClouderaClusterCpuChartTask extends AbstractClouderaTimeSeriesTask {
+  private static final Logger logger = LoggerFactory.getLogger(ClouderaClusterCpuChartTask.class);
   private static final String TS_CPU_QUERY_TEMPLATE =
       "SELECT cpu_percent_across_hosts WHERE entityName = \"%s\" AND category = CLUSTER";
 
-  public ClouderaClusterCPUChartTask(
+  public ClouderaClusterCpuChartTask(
       ZonedDateTime startDate,
       ZonedDateTime endDate,
       TimeSeriesAggregation tsAggregation,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTask.java
@@ -20,8 +20,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiClusterDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiClusterListDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiClusterDto;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiClusterListDto;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.Writer;
 import java.net.URI;
@@ -52,18 +52,18 @@ public class ClouderaClustersTask extends AbstractClouderaManagerTask {
       throws Exception {
     CloseableHttpClient httpClient = handle.getClouderaManagerHttpClient();
 
-    ApiClusterListDTO clusterList;
+    ApiClusterListDto clusterList;
 
     if (context.getArguments().getCluster() != null) {
       final String clusterName = context.getArguments().getCluster();
       try (CloseableHttpResponse clusterResponse =
           httpClient.execute(new HttpGet(handle.getApiURI() + "/clusters/" + clusterName))) {
 
-        ApiClusterDTO cluster =
+        ApiClusterDto cluster =
             parseJsonStringToObject(
-                EntityUtils.toString(clusterResponse.getEntity()), ApiClusterDTO.class);
+                EntityUtils.toString(clusterResponse.getEntity()), ApiClusterDto.class);
 
-        clusterList = new ApiClusterListDTO();
+        clusterList = new ApiClusterListDto();
         clusterList.setClusters(ImmutableList.of(cluster));
       }
     } else {
@@ -74,7 +74,7 @@ public class ClouderaClustersTask extends AbstractClouderaManagerTask {
       try (CloseableHttpResponse clustersResponse =
           httpClient.execute(new HttpGet(handle.getApiURI() + "/clusters?clusterType=ANY"))) {
         String clustersJson = EntityUtils.toString(clustersResponse.getEntity());
-        clusterList = parseJsonStringToObject(clustersJson, ApiClusterListDTO.class);
+        clusterList = parseJsonStringToObject(clustersJson, ApiClusterListDto.class);
       }
     }
 
@@ -83,7 +83,7 @@ public class ClouderaClustersTask extends AbstractClouderaManagerTask {
     }
 
     List<ClouderaClusterDTO> clusters = new ArrayList<>();
-    for (ApiClusterDTO item : clusterList.getClusters()) {
+    for (ApiClusterDto item : clusterList.getClusters()) {
       String clusterId = requestClusterIdByName(httpClient, handle.getBaseURI(), item.getName());
       clusters.add(ClouderaClusterDTO.create(clusterId, item.getName()));
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCmfHostsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCmfHostsTask.java
@@ -16,32 +16,39 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.io.ByteSink;
-import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaHostDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiHostDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiHostListDTO;
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.Writer;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * The task dump data from the <a
- * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiHostList.html">Hosts
- * API</a> which doesn't contain usage and disk data and collected as a fallback.
+ * The task collects hosts from Cloudera Manager {@code /cmf/} urls. These API contains
+ * well-structured data but is not well documented.
  */
-public class ClouderaAPIHostsTask extends AbstractClouderaManagerTask {
+public class ClouderaCmfHostsTask extends AbstractClouderaManagerTask {
 
-  public ClouderaAPIHostsTask() {
-    super("api-hosts.jsonl");
+  private static final Logger logger = LoggerFactory.getLogger(ClouderaCmfHostsTask.class);
+
+  public ClouderaCmfHostsTask() {
+    super("cmf-hosts.jsonl");
+  }
+
+  @Nonnull
+  @Override
+  public TaskCategory getCategory() {
+    return TaskCategory.OPTIONAL;
   }
 
   @Override
@@ -51,40 +58,39 @@ public class ClouderaAPIHostsTask extends AbstractClouderaManagerTask {
     CloseableHttpClient httpClient = handle.getClouderaManagerHttpClient();
     List<ClouderaClusterDTO> clusters = handle.getClusters();
     if (clusters == null) {
-      throw new MetadataDumperUsageException(
+      throw new IllegalStateException(
           "Cloudera clusters must be initialized before hosts dumping.");
     }
 
-    List<ClouderaHostDTO> hosts = new ArrayList<>();
+    final URI baseURI = handle.getBaseURI();
     try (Writer writer = sink.asCharSink(StandardCharsets.UTF_8).openBufferedStream()) {
       for (ClouderaClusterDTO cluster : clusters) {
-        String hostPerClusterUrl = handle.getApiURI() + "/clusters/" + cluster.getName() + "/hosts";
+        if (cluster.getId() == null) {
+          logger.warn(
+              "Cloudera cluster id is null for cluster [{}]. "
+                  + "Skip dumping hosts overview for the cluster.",
+              cluster.getName());
+          continue;
+        }
 
-        JsonNode jsonHosts;
+        String hostPerClusterUrl =
+            baseURI + "/cmf/hardware/hosts/hostsOverview.json?clusterId=" + cluster.getId();
+
+        JsonNode hostsJson;
         try (CloseableHttpResponse hostsResponse =
             httpClient.execute(new HttpGet(hostPerClusterUrl))) {
-          final int statusCode = hostsResponse.getStatusLine().getStatusCode();
-          if (!isStatusCodeOK(statusCode)) {
-            throw new RuntimeException(
-                String.format(
-                    "Cloudera Error: Response status code is %d but 2xx is expected.", statusCode));
+          try {
+            hostsJson = readJsonTree(hostsResponse.getEntity().getContent());
+          } catch (JsonParseException ex) {
+            logger.warn(
+                "Could not parse json from cloudera hosts response: " + ex.getMessage(), ex);
+            continue;
           }
-          jsonHosts = readJsonTree(hostsResponse.getEntity().getContent());
         }
-        String stringifiedHosts = jsonHosts.toString();
+        String stringifiedHosts = hostsJson.toString();
         writer.write(stringifiedHosts);
         writer.write('\n');
-
-        ApiHostListDTO apiHosts = parseJsonStringToObject(stringifiedHosts, ApiHostListDTO.class);
-        for (ApiHostDTO apiHost : apiHosts.getHosts()) {
-          hosts.add(ClouderaHostDTO.create(apiHost.getId(), apiHost.getName()));
-        }
       }
-      if (hosts.isEmpty()) {
-        throw new MetadataDumperUsageException(
-            "No hosts were found in any of the initialized Cloudera clusters.");
-      }
-      handle.initHosts(hosts);
     }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRamChartTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRamChartTask.java
@@ -39,14 +39,14 @@ import org.slf4j.LoggerFactory;
  * href="https://docs.cloudera.com/documentation/enterprise/latest/topics/cm_dg_tsquery.html">tsquery</a>
  * language.
  */
-public class ClouderaHostRAMChartTask extends AbstractClouderaTimeSeriesTask {
+public class ClouderaHostRamChartTask extends AbstractClouderaTimeSeriesTask {
 
-  private static final Logger logger = LoggerFactory.getLogger(ClouderaHostRAMChartTask.class);
+  private static final Logger logger = LoggerFactory.getLogger(ClouderaHostRamChartTask.class);
 
   private static final String TS_RAM_QUERY_TEMPLATE =
       "select swap_used, physical_memory_used, physical_memory_total, physical_memory_cached, physical_memory_buffers where entityName = \"%s\"";
 
-  public ClouderaHostRAMChartTask(
+  public ClouderaHostRamChartTask(
       ZonedDateTime startDate,
       ZonedDateTime endDate,
       TimeSeriesAggregation tsAggregation,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnector.java
@@ -91,8 +91,8 @@ public class ClouderaManagerConnector extends AbstractConnector {
     out.add(new DumpMetadataTask(arguments, FORMAT_NAME));
     out.add(new FormatTask(FORMAT_NAME));
     out.add(new ClouderaClustersTask());
-    out.add(new ClouderaCMFHostsTask());
-    out.add(new ClouderaAPIHostsTask());
+    out.add(new ClouderaCmfHostsTask());
+    out.add(new ClouderaApiHostsTask());
     out.add(new ClouderaServicesTask());
     out.add(new ClouderaHostComponentsTask());
 
@@ -107,8 +107,8 @@ public class ClouderaManagerConnector extends AbstractConnector {
       endDate = arguments.getEndDate();
     }
 
-    out.add(new ClouderaClusterCPUChartTask(startDate, endDate, DAILY, REQUIRED));
-    out.add(new ClouderaHostRAMChartTask(startDate, endDate, DAILY, REQUIRED));
+    out.add(new ClouderaClusterCpuChartTask(startDate, endDate, DAILY, REQUIRED));
+    out.add(new ClouderaHostRamChartTask(startDate, endDate, DAILY, REQUIRED));
     out.add(new ClouderaServiceResourceAllocationChartTask(startDate, endDate, HOURLY, OPTIONAL));
     out.add(new ClouderaYarnApplicationsTask(startDate, endDate, OPTIONAL));
     out.add(new ClouderaYarnApplicationTypeTask(startDate, endDate, OPTIONAL));

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationTypeTask.java
@@ -27,7 +27,7 @@ import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaYarnApplicationDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYARNApplicationDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYarnApplicationDto;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.model.YarnApplicationType;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
@@ -108,9 +108,9 @@ public class ClouderaYarnApplicationTypeTask extends AbstractClouderaYarnApplica
   }
 
   private void writeYarnAppTypes(
-      Writer writer, List<ApiYARNApplicationDTO> yarnApps, String appType, String clusterName) {
+      Writer writer, List<ApiYarnApplicationDto> yarnApps, String appType, String clusterName) {
     List<ApplicationTypeToYarnApplication> yarnAppTypeMappings = new ArrayList<>();
-    for (ApiYARNApplicationDTO yarnApp : yarnApps) {
+    for (ApiYarnApplicationDto yarnApp : yarnApps) {
       yarnAppTypeMappings.add(
           new ApplicationTypeToYarnApplication(yarnApp.getApplicationId(), appType, clusterName));
     }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationsTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaYarnApplicationsTask.java
@@ -20,7 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYARNApplicationDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYarnApplicationDto;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.IOException;
@@ -67,8 +67,8 @@ public class ClouderaYarnApplicationsTask extends AbstractClouderaYarnApplicatio
   }
 
   private void writeYarnApplications(
-      Writer writer, List<ApiYARNApplicationDTO> yarnApps, String clusterName) {
-    for (ApiYARNApplicationDTO yarnApp : yarnApps) {
+      Writer writer, List<ApiYarnApplicationDto> yarnApps, String clusterName) {
+    for (ApiYarnApplicationDto yarnApp : yarnApps) {
       yarnApp.setClusterName(clusterName);
     }
     try {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/SparkHistoryDiscoveryService.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/SparkHistoryDiscoveryService.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiConfigDto;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiConfigListDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiRoleDto;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiRoleListDto;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiServiceDto;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiServiceListDto;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SparkHistoryDiscoveryService {
+
+  private static final Logger logger = LoggerFactory.getLogger(SparkHistoryDiscoveryService.class);
+
+  private static final List<String> DEFAULT_CANDIDATE_PATHS =
+      ImmutableList.of("spark3history", "sparkhistory");
+
+  private final ObjectMapper objectMapper;
+  private final CloseableHttpClient clouderaManagerHttpClient;
+  private final URI apiURI;
+
+  public SparkHistoryDiscoveryService(
+      ObjectMapper objectMapper, CloseableHttpClient clouderaManagerHttpClient, URI apiURI) {
+    this.objectMapper = objectMapper;
+    this.clouderaManagerHttpClient = clouderaManagerHttpClient;
+    this.apiURI = apiURI;
+  }
+
+  /**
+   * Discovers the active Spark History Server URLs. Probes Spark 3 and Spark 2 endpoints, including
+   * any custom paths, against the discovered Knox Gateway instance.
+   */
+  public List<String> resolveUrl(
+      String clusterName, CloseableHttpClient knoxClient, List<String> customCandidatePaths) {
+    Set<String> reachableUrls = new LinkedHashSet<>();
+    try {
+      Optional<KnoxGatewayInfo> knoxInfo = getKnoxGatewayInfo(clusterName);
+
+      if (!knoxInfo.isPresent()) {
+        logger.warn("Could not find Knox Service or Role for cluster: {}", clusterName);
+        return ImmutableList.of();
+      }
+
+      KnoxGatewayInfo info = knoxInfo.get();
+
+      Set<String> allCandidates = new LinkedHashSet<>(customCandidatePaths);
+      allCandidates.addAll(DEFAULT_CANDIDATE_PATHS);
+
+      for (String context : allCandidates) {
+        String candidateUrl =
+            String.format(
+                "https://%s/%s/%s/%s/api/v1",
+                info.hostname, info.gatewayPath, info.topologyName, context);
+
+        if (isReachable(candidateUrl, knoxClient)) {
+          logger.info("Found active Spark History Server at: {}", candidateUrl);
+          reachableUrls.add(candidateUrl);
+        }
+      }
+
+      if (reachableUrls.isEmpty()) {
+        logger.warn(
+            "Knox is active, but no Spark history endpoints are reachable for candidates: {}",
+            allCandidates);
+      }
+    } catch (IOException e) {
+      logger.warn(
+          "Cluster '{}': Failed to discover Spark History URL due to error: {}",
+          clusterName,
+          e.getMessage());
+    }
+    return new ArrayList<>(reachableUrls);
+  }
+
+  private boolean isReachable(String url, CloseableHttpClient knoxHttpClient) {
+    String probeUrl = url + "/applications?limit=1";
+
+    try (CloseableHttpResponse response = knoxHttpClient.execute(new HttpGet(probeUrl))) {
+      int status = response.getStatusLine().getStatusCode();
+      return status == 200;
+    } catch (IOException e) {
+      logger.debug("Probe failed for URL: {}", url);
+      return false;
+    }
+  }
+
+  private Optional<KnoxGatewayInfo> getKnoxGatewayInfo(String clusterName) throws IOException {
+    Optional<String> knoxServiceName = getKnoxServiceName(clusterName);
+    if (!knoxServiceName.isPresent()) {
+      return Optional.empty();
+    }
+
+    String serviceName = knoxServiceName.get();
+    Optional<ApiRoleDto> knoxRole = getKnoxRole(clusterName, serviceName);
+    if (!knoxRole.isPresent()) {
+      return Optional.empty();
+    }
+
+    ApiRoleDto role = knoxRole.get();
+    if (role.getHostRef() == null || role.getRoleConfigGroupRef() == null) {
+      logger.warn("Knox role is missing hostRef or roleConfigGroupRef.");
+      return Optional.empty();
+    }
+
+    String hostname = role.getHostRef().getHostname();
+    String roleConfigGroup = role.getRoleConfigGroupRef().getRoleConfigGroupName();
+    if (hostname == null || roleConfigGroup == null) {
+      logger.warn("Knox role has null hostname or roleConfigGroupName.");
+      return Optional.empty();
+    }
+
+    String gatewayPath = getGatewayPath(clusterName, serviceName, roleConfigGroup);
+    String topologyName = getTopologyName(clusterName, serviceName, roleConfigGroup);
+
+    return Optional.of(new KnoxGatewayInfo(hostname, gatewayPath, topologyName));
+  }
+
+  private Optional<String> getKnoxServiceName(String clusterName) throws IOException {
+    String path = String.format("clusters/%s/services", clusterName);
+    Optional<ApiServiceListDto> serviceList = get(path, ApiServiceListDto.class);
+    return serviceList.flatMap(
+        list ->
+            list.getItems().stream()
+                .filter(service -> "KNOX".equals(service.getType()))
+                .map(ApiServiceDto::getName)
+                .findFirst());
+  }
+
+  private Optional<ApiRoleDto> getKnoxRole(String clusterName, String knoxServiceName)
+      throws IOException {
+    String path = String.format("clusters/%s/services/%s/roles", clusterName, knoxServiceName);
+    Optional<ApiRoleListDto> roleList = get(path, ApiRoleListDto.class);
+    return roleList.flatMap(list -> list.getItems().stream().findFirst());
+  }
+
+  private String getGatewayPath(
+      String clusterName, String knoxServiceName, String roleConfigGroupName) throws IOException {
+    return getConfigValue(clusterName, knoxServiceName, roleConfigGroupName, "gateway_path")
+        .orElse(clusterName);
+  }
+
+  private String getTopologyName(
+      String clusterName, String knoxServiceName, String roleConfigGroupName) throws IOException {
+    return getConfigValue(
+            clusterName, knoxServiceName, roleConfigGroupName, "gateway_default_api_topology_name")
+        .orElse("cdp-proxy-api");
+  }
+
+  private Optional<String> getConfigValue(
+      String clusterName, String knoxServiceName, String roleConfigGroupName, String configName)
+      throws IOException {
+    String path =
+        String.format(
+            "clusters/%s/services/%s/roleConfigGroups/%s/config",
+            clusterName, knoxServiceName, roleConfigGroupName);
+    Optional<ApiConfigListDTO> configList = get(path, ApiConfigListDTO.class);
+    return configList.flatMap(
+        list ->
+            list.getItems().stream()
+                .filter(config -> configName.equals(config.getName()))
+                .map(ApiConfigDto::getValue)
+                .findFirst());
+  }
+
+  private <T> Optional<T> get(String path, Class<T> responseType) throws IOException {
+    URI requestUri = apiURI.resolve(path);
+    try (CloseableHttpResponse response =
+        clouderaManagerHttpClient.execute(new HttpGet(requestUri))) {
+      if (response.getStatusLine().getStatusCode() != 200) {
+        throw new IOException(
+            "Unexpected status code "
+                + response.getStatusLine().getStatusCode()
+                + " from "
+                + requestUri);
+      }
+      HttpEntity entity = response.getEntity();
+      if (entity == null) {
+        return Optional.empty();
+      }
+      return Optional.of(objectMapper.readValue(entity.getContent(), responseType));
+    }
+  }
+
+  private static class KnoxGatewayInfo {
+    String hostname;
+    String gatewayPath;
+    String topologyName;
+
+    KnoxGatewayInfo(String hostname, String gatewayPath, String topologyName) {
+      this.hostname = hostname;
+      this.gatewayPath = gatewayPath;
+      this.topologyName = topologyName;
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiClusterDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiClusterDto.java
@@ -29,7 +29,7 @@ import java.util.List;
  * code is unclear, the own model for public schema used instead of it.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class ApiClusterDTO {
+public final class ApiClusterDto {
   @JsonProperty(required = true)
   private String name;
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiClusterListDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiClusterListDto.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * DTO class for the official Cloudera API <a
+ * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiClusterList.html">json</a>
+ *
+ * <p>Note: The license for <a
+ * href="https://mvnrepository.com/artifact/com.cloudera.api.swagger/cloudera-manager-api-swagger/7.11.0">generated</a>
+ * code is unclear, the own model for public schema used instead of it.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final class ApiClusterListDto {
+
+  @JsonProperty(required = true)
+  private List<ApiClusterDto> items;
+
+  public List<ApiClusterDto> getClusters() {
+    return items;
+  }
+
+  public void setClusters(List<ApiClusterDto> items) {
+    this.items = items;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiConfigDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiConfigDto.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiConfigDto {
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("value")
+  private String value;
+
+  public String getName() {
+    return name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiConfigListDTO.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiConfigListDTO.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiConfigListDTO {
+
+  @JsonProperty("items")
+  private List<ApiConfigDto> items;
+
+  public List<ApiConfigDto> getItems() {
+    return items;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiHostDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiHostDto.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO class for the official Cloudera API <a
+ * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiHost.html">json</a>
+ *
+ * <p>Note: The license for <a
+ * href="https://mvnrepository.com/artifact/com.cloudera.api.swagger/cloudera-manager-api-swagger/7.11.0">generated</a>
+ * code is unclear, the own model for public schema used instead of it.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiHostDto {
+
+  @JsonProperty(required = true)
+  private String hostname;
+
+  @JsonProperty(required = true)
+  private String hostId;
+
+  public String getName() {
+    return hostname;
+  }
+
+  public String getId() {
+    return hostId;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiHostListDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiHostListDto.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/**
+ * DTO class for the official Cloudera API <a
+ * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiHostList.html">json</a>
+ *
+ * <p>Note: The license for <a
+ * href="https://mvnrepository.com/artifact/com.cloudera.api.swagger/cloudera-manager-api-swagger/7.11.0">generated</a>
+ * code is unclear, the own model for public schema used instead of it.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiHostListDto {
+  private final List<ApiHostDto> hosts;
+
+  @JsonCreator
+  public ApiHostListDto(@JsonProperty(value = "items", required = true) List<ApiHostDto> hosts) {
+    this.hosts = hosts;
+  }
+
+  public List<ApiHostDto> getHosts() {
+    return hosts;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiHostRefDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiHostRefDto.java
@@ -16,29 +16,16 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 
-/**
- * DTO class for the official Cloudera API <a
- * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiHostList.html">json</a>
- *
- * <p>Note: The license for <a
- * href="https://mvnrepository.com/artifact/com.cloudera.api.swagger/cloudera-manager-api-swagger/7.11.0">generated</a>
- * code is unclear, the own model for public schema used instead of it.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ApiHostListDTO {
-  private final List<ApiHostDTO> hosts;
+public class ApiHostRefDto {
 
-  @JsonCreator
-  public ApiHostListDTO(@JsonProperty(value = "items", required = true) List<ApiHostDTO> hosts) {
-    this.hosts = hosts;
-  }
+  @JsonProperty("hostname")
+  private String hostname;
 
-  public List<ApiHostDTO> getHosts() {
-    return hosts;
+  public String getHostname() {
+    return hostname;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiRoleConfigGroupRefDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiRoleConfigGroupRefDto.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiRoleConfigGroupRefDto {
+
+  @JsonProperty("roleConfigGroupName")
+  private String roleConfigGroupName;
+
+  public String getRoleConfigGroupName() {
+    return roleConfigGroupName;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiRoleDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiRoleDto.java
@@ -19,28 +19,20 @@ package com.google.edwmigration.dumper.application.dumper.connector.cloudera.man
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/**
- * DTO class for the official Cloudera API <a
- * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiHost.html">json</a>
- *
- * <p>Note: The license for <a
- * href="https://mvnrepository.com/artifact/com.cloudera.api.swagger/cloudera-manager-api-swagger/7.11.0">generated</a>
- * code is unclear, the own model for public schema used instead of it.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ApiHostDTO {
+public class ApiRoleDto {
 
-  @JsonProperty(required = true)
-  private String hostname;
+  @JsonProperty("hostRef")
+  private ApiHostRefDto hostRef;
 
-  @JsonProperty(required = true)
-  private String hostId;
+  @JsonProperty("roleConfigGroupRef")
+  private ApiRoleConfigGroupRefDto roleConfigGroupRef;
 
-  public String getName() {
-    return hostname;
+  public ApiHostRefDto getHostRef() {
+    return hostRef;
   }
 
-  public String getId() {
-    return hostId;
+  public ApiRoleConfigGroupRefDto getRoleConfigGroupRef() {
+    return roleConfigGroupRef;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiRoleListDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiRoleListDto.java
@@ -20,25 +20,13 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
-/**
- * DTO class for the official Cloudera API <a
- * href="https://archive.cloudera.com/cm7/7.11.3.0/generic/jar/cm_api/apidocs/json_ApiClusterList.html">json</a>
- *
- * <p>Note: The license for <a
- * href="https://mvnrepository.com/artifact/com.cloudera.api.swagger/cloudera-manager-api-swagger/7.11.0">generated</a>
- * code is unclear, the own model for public schema used instead of it.
- */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public final class ApiClusterListDTO {
+public class ApiRoleListDto {
 
-  @JsonProperty(required = true)
-  private List<ApiClusterDTO> items;
+  @JsonProperty("items")
+  private List<ApiRoleDto> items;
 
-  public List<ApiClusterDTO> getClusters() {
+  public List<ApiRoleDto> getItems() {
     return items;
-  }
-
-  public void setClusters(List<ApiClusterDTO> items) {
-    this.items = items;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiServiceDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiServiceDto.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiServiceDto {
+
+  @JsonProperty("name")
+  private String name;
+
+  @JsonProperty("type")
+  private String type;
+
+  public String getName() {
+    return name;
+  }
+
+  public String getType() {
+    return type;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiServiceListDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiServiceListDto.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ApiServiceListDto {
+
+  @JsonProperty("items")
+  private List<ApiServiceDto> items;
+
+  public List<ApiServiceDto> getItems() {
+    return items;
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiYarnApplicationDto.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiYarnApplicationDto.java
@@ -28,7 +28,7 @@ import org.springframework.util.StringUtils;
  * with additional information about cluster.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class ApiYARNApplicationDTO {
+public class ApiYarnApplicationDto {
 
   @JsonProperty(required = true)
   private String clusterName;
@@ -40,7 +40,7 @@ public class ApiYARNApplicationDTO {
    */
   private final JsonNode apiYarnApplication;
 
-  public ApiYARNApplicationDTO(JsonNode apiYarnApplication) {
+  public ApiYarnApplicationDto(JsonNode apiYarnApplication) {
     this.apiYarnApplication = apiYarnApplication;
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaYarnApplicationTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/AbstractClouderaYarnApplicationTaskTest.java
@@ -26,7 +26,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.matching.StringValuePattern;
 import com.google.common.io.ByteSink;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYARNApplicationDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiYarnApplicationDto;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.IOException;
@@ -54,7 +54,7 @@ public class AbstractClouderaYarnApplicationTaskTest {
   private static WireMockServer server;
   private MockedYarnApplicationTask task;
   private ClouderaManagerHandle handle;
-  private List<ApiYARNApplicationDTO> loadResponse;
+  private List<ApiYarnApplicationDto> loadResponse;
 
   @BeforeClass
   public static void beforeClass() {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaApiHostsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaApiHostsTaskTest.java
@@ -59,10 +59,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ClouderaAPIHostsTaskTest {
+public class ClouderaApiHostsTaskTest {
 
   private static WireMockServer server;
-  private final ClouderaAPIHostsTask task = new ClouderaAPIHostsTask();
+  private final ClouderaApiHostsTask task = new ClouderaApiHostsTask();
   private ClouderaManagerHandle handle;
 
   @Mock private TaskRunContext context;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCpuChartTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClusterCpuChartTaskTest.java
@@ -60,9 +60,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ClouderaClusterCPUChartTaskTest {
-  private final ClouderaClusterCPUChartTask task =
-      new ClouderaClusterCPUChartTask(
+public class ClouderaClusterCpuChartTaskTest {
+  private final ClouderaClusterCpuChartTask task =
+      new ClouderaClusterCpuChartTask(
           timeTravelDaysAgo(30),
           timeTravelDaysAgo(0),
           TimeSeriesAggregation.HOURLY,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaClustersTaskTest.java
@@ -39,7 +39,7 @@ import com.google.common.io.ByteSink;
 import com.google.common.io.CharSink;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.ClouderaManagerHandle.ClouderaClusterDTO;
-import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiClusterListDTO;
+import com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager.dto.ApiClusterListDto;
 import com.google.edwmigration.dumper.application.dumper.task.TaskRunContext;
 import java.io.Writer;
 import java.net.URI;
@@ -128,8 +128,8 @@ public class ClouderaClustersTaskTest {
                 argThat(
                     content -> {
                       try {
-                        ApiClusterListDTO listDto =
-                            objectMapper.readValue((String) content, ApiClusterListDTO.class);
+                        ApiClusterListDto listDto =
+                            objectMapper.readValue((String) content, ApiClusterListDto.class);
                         assertNotNull(listDto.getClusters());
                       } catch (JsonProcessingException e) {
                         throw new RuntimeException(e);
@@ -170,8 +170,8 @@ public class ClouderaClustersTaskTest {
                 argThat(
                     content -> {
                       try {
-                        ApiClusterListDTO listDto =
-                            objectMapper.readValue((String) content, ApiClusterListDTO.class);
+                        ApiClusterListDto listDto =
+                            objectMapper.readValue((String) content, ApiClusterListDto.class);
                         assertNotNull(listDto.getClusters());
                       } catch (JsonProcessingException e) {
                         throw new RuntimeException(e);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCmfHostsTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaCmfHostsTaskTest.java
@@ -53,10 +53,10 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ClouderaCMFHostsTaskTest {
+public class ClouderaCmfHostsTaskTest {
 
   private static WireMockServer server;
-  private final ClouderaCMFHostsTask task = new ClouderaCMFHostsTask();
+  private final ClouderaCmfHostsTask task = new ClouderaCmfHostsTask();
   private ClouderaManagerHandle handle;
 
   @Mock private TaskRunContext context;

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRamChartTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaHostRamChartTaskTest.java
@@ -60,9 +60,9 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
-public class ClouderaHostRAMChartTaskTest {
-  private final ClouderaHostRAMChartTask task =
-      new ClouderaHostRAMChartTask(
+public class ClouderaHostRamChartTaskTest {
+  private final ClouderaHostRamChartTask task =
+      new ClouderaHostRamChartTask(
           timeTravelDaysAgo(1),
           timeTravelDaysAgo(0),
           TimeSeriesAggregation.HOURLY,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/ClouderaManagerConnectorTest.java
@@ -87,14 +87,14 @@ public class ClouderaManagerConnectorTest {
                     "compilerworks-metadata.yaml", DumpMetadataTask.class,
                     "compilerworks-format.txt", FormatTask.class,
                     "clusters.json", ClouderaClustersTask.class,
-                    "cmf-hosts.jsonl", ClouderaCMFHostsTask.class,
-                    "api-hosts.jsonl", ClouderaAPIHostsTask.class,
+                    "cmf-hosts.jsonl", ClouderaCmfHostsTask.class,
+                    "api-hosts.jsonl", ClouderaApiHostsTask.class,
                     "services.jsonl", ClouderaServicesTask.class))
             .putAll(
                 ImmutableMap.of(
                     "host-components.jsonl", ClouderaHostComponentsTask.class,
-                    "cluster-cpu.jsonl", ClouderaClusterCPUChartTask.class,
-                    "host-ram.jsonl", ClouderaHostRAMChartTask.class,
+                    "cluster-cpu.jsonl", ClouderaClusterCpuChartTask.class,
+                    "host-ram.jsonl", ClouderaHostRamChartTask.class,
                     "service-resource-allocation.jsonl",
                         ClouderaServiceResourceAllocationChartTask.class,
                     "yarn-applications.jsonl", ClouderaYarnApplicationsTask.class,
@@ -172,14 +172,14 @@ public class ClouderaManagerConnectorTest {
                     "compilerworks-metadata.yaml", DumpMetadataTask.class,
                     "compilerworks-format.txt", FormatTask.class,
                     "clusters.json", ClouderaClustersTask.class,
-                    "cmf-hosts.jsonl", ClouderaCMFHostsTask.class,
-                    "api-hosts.jsonl", ClouderaAPIHostsTask.class,
+                    "cmf-hosts.jsonl", ClouderaCmfHostsTask.class,
+                    "api-hosts.jsonl", ClouderaApiHostsTask.class,
                     "services.jsonl", ClouderaServicesTask.class,
                     "host-components.jsonl", ClouderaHostComponentsTask.class))
             .putAll(
                 ImmutableMap.of(
-                    "cluster-cpu.jsonl", ClouderaClusterCPUChartTask.class,
-                    "host-ram.jsonl", ClouderaHostRAMChartTask.class,
+                    "cluster-cpu.jsonl", ClouderaClusterCpuChartTask.class,
+                    "host-ram.jsonl", ClouderaHostRamChartTask.class,
                     "service-resource-allocation.jsonl",
                         ClouderaServiceResourceAllocationChartTask.class,
                     "yarn-applications.jsonl", ClouderaYarnApplicationsTask.class,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/SparkHistoryDiscoveryServiceTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/SparkHistoryDiscoveryServiceTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.cloudera.manager;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.serverError;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.net.URI;
+import java.util.List;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SparkHistoryDiscoveryServiceTest {
+
+  private static WireMockServer server;
+  private SparkHistoryDiscoveryService service;
+  private CloseableHttpClient cmClient;
+  private ObjectMapper objectMapper = new ObjectMapper();
+
+  @Mock private CloseableHttpClient knoxClient;
+
+  @BeforeClass
+  public static void beforeClass() {
+    server = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    server.start();
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    server.stop();
+  }
+
+  @Before
+  public void setUp() {
+    server.resetAll();
+    cmClient = HttpClients.createDefault();
+    URI apiUri = URI.create(server.baseUrl() + "/api/v41/");
+    service = new SparkHistoryDiscoveryService(objectMapper, cmClient, apiUri);
+  }
+
+  @Test
+  public void resolveUrl_spark3_success() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"hostRef\": {\"hostname\": \"knox-host\"}, \"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // 3. Mock config
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roleConfigGroups/knox-BASE/config")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"name\": \"gateway_path\", \"value\": \"gateway\"}, {\"name\": \"gateway_default_api_topology_name\", \"value\": \"cdp-proxy-api\"}]}")));
+
+    // 4. Mock Knox probe for Spark 3
+    CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+    when(mockStatusLine.getStatusCode()).thenReturn(200);
+    when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+
+    when(knoxClient.execute(any(HttpGet.class)))
+        .thenAnswer(
+            invocation -> {
+              HttpGet get = invocation.getArgument(0);
+              if (get.getURI().toString().contains("spark3history")) {
+                return mockResponse;
+              }
+              CloseableHttpResponse failResponse = mock(CloseableHttpResponse.class);
+              StatusLine failStatus = mock(StatusLine.class);
+              when(failStatus.getStatusCode()).thenReturn(404);
+              when(failResponse.getStatusLine()).thenReturn(failStatus);
+              return failResponse;
+            });
+
+    // Act
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals("https://knox-host/gateway/cdp-proxy-api/spark3history/api/v1", result.get(0));
+  }
+
+  @Test
+  public void resolveUrl_spark2_success() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"hostRef\": {\"hostname\": \"knox-host\"}, \"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // 3. Mock config
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roleConfigGroups/knox-BASE/config")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"name\": \"gateway_path\", \"value\": \"gateway\"}, {\"name\": \"gateway_default_api_topology_name\", \"value\": \"cdp-proxy-api\"}]}")));
+
+    // 4. Mock Knox probe for Spark 2 (Spark 3 fails)
+    CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+    when(mockStatusLine.getStatusCode()).thenReturn(200);
+    when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+
+    when(knoxClient.execute(any(HttpGet.class)))
+        .thenAnswer(
+            invocation -> {
+              HttpGet get = invocation.getArgument(0);
+              if (get.getURI().toString().contains("sparkhistory")) {
+                return mockResponse;
+              }
+              CloseableHttpResponse failResponse = mock(CloseableHttpResponse.class);
+              StatusLine failStatus = mock(StatusLine.class);
+              when(failStatus.getStatusCode()).thenReturn(404);
+              when(failResponse.getStatusLine()).thenReturn(failStatus);
+              return failResponse;
+            });
+
+    // Act
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals("https://knox-host/gateway/cdp-proxy-api/sparkhistory/api/v1", result.get(0));
+  }
+
+  @Test
+  public void resolveUrl_multipleReachable_success() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"hostRef\": {\"hostname\": \"knox-host\"}, \"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // 3. Mock config
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roleConfigGroups/knox-BASE/config")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"name\": \"gateway_path\", \"value\": \"gateway\"}, {\"name\": \"gateway_default_api_topology_name\", \"value\": \"cdp-proxy-api\"}]}")));
+
+    // 4. Mock Knox probe for both Spark 2 and Spark 3
+    CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+    when(mockStatusLine.getStatusCode()).thenReturn(200);
+    when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+
+    when(knoxClient.execute(any(HttpGet.class))).thenReturn(mockResponse);
+
+    // Act
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    // Assert
+    assertEquals(2, result.size());
+    assertTrue(result.contains("https://knox-host/gateway/cdp-proxy-api/spark3history/api/v1"));
+    assertTrue(result.contains("https://knox-host/gateway/cdp-proxy-api/sparkhistory/api/v1"));
+  }
+
+  @Test
+  public void resolveUrl_customCandidate_success() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"hostRef\": {\"hostname\": \"knox-host\"}, \"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // 3. Mock config
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roleConfigGroups/knox-BASE/config")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"name\": \"gateway_path\", \"value\": \"gateway\"}, {\"name\": \"gateway_default_api_topology_name\", \"value\": \"cdp-proxy-api\"}]}")));
+
+    // 4. Mock Knox probe for custom path
+    CloseableHttpResponse mockResponse = mock(CloseableHttpResponse.class);
+    StatusLine mockStatusLine = mock(StatusLine.class);
+    when(mockStatusLine.getStatusCode()).thenReturn(200);
+    when(mockResponse.getStatusLine()).thenReturn(mockStatusLine);
+
+    when(knoxClient.execute(any(HttpGet.class)))
+        .thenAnswer(
+            invocation -> {
+              HttpGet get = invocation.getArgument(0);
+              if (get.getURI().toString().contains("custom-spark")) {
+                return mockResponse;
+              }
+              CloseableHttpResponse failResponse = mock(CloseableHttpResponse.class);
+              StatusLine failStatus = mock(StatusLine.class);
+              when(failStatus.getStatusCode()).thenReturn(404);
+              when(failResponse.getStatusLine()).thenReturn(failStatus);
+              return failResponse;
+            });
+
+    // Act
+    List<String> result =
+        service.resolveUrl(
+            "my-cluster", knoxClient, com.google.common.collect.ImmutableList.of("custom-spark"));
+
+    // Assert
+    assertEquals(1, result.size());
+    assertEquals("https://knox-host/gateway/cdp-proxy-api/custom-spark/api/v1", result.get(0));
+  }
+
+  @Test
+  public void resolveUrl_neitherSparkVersionReachable_returnsEmpty() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"hostRef\": {\"hostname\": \"knox-host\"}, \"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // 3. Mock config
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roleConfigGroups/knox-BASE/config")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"name\": \"gateway_path\", \"value\": \"gateway\"}, {\"name\": \"gateway_default_api_topology_name\", \"value\": \"cdp-proxy-api\"}]}")));
+
+    // 4. Mock Knox probe always returning 404
+    CloseableHttpResponse failResponse = mock(CloseableHttpResponse.class);
+    StatusLine failStatus = mock(StatusLine.class);
+    when(failStatus.getStatusCode()).thenReturn(404);
+    when(failResponse.getStatusLine()).thenReturn(failStatus);
+    when(knoxClient.execute(any(HttpGet.class))).thenReturn(failResponse);
+
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void resolveUrl_missingHostRef_returnsEmpty() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list with missing hostRef
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // Act
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    // Assert
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void resolveUrl_noKnoxService_returnsEmpty() throws Exception {
+    // Mock empty services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services").willReturn(okJson("{\"items\": []}")));
+
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void resolveUrl_cmApiError_returnsEmpty() throws Exception {
+    // Mock CM API returning 500
+    server.stubFor(get("/api/v41/clusters/my-cluster/services").willReturn(serverError()));
+
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  public void resolveUrl_knoxNotReachable_returnsEmpty() throws Exception {
+    // 1. Mock services list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services")
+            .willReturn(okJson("{\"items\": [{\"name\": \"knox-1\", \"type\": \"KNOX\"}]}")));
+
+    // 2. Mock roles list
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roles")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"hostRef\": {\"hostname\": \"knox-host\"}, \"roleConfigGroupRef\": {\"roleConfigGroupName\": \"knox-BASE\"}}]}")));
+
+    // 3. Mock config
+    server.stubFor(
+        get("/api/v41/clusters/my-cluster/services/knox-1/roleConfigGroups/knox-BASE/config")
+            .willReturn(
+                okJson(
+                    "{\"items\": [{\"name\": \"gateway_path\", \"value\": \"gateway\"}, {\"name\": \"gateway_default_api_topology_name\", \"value\": \"cdp-proxy-api\"}]}")));
+
+    // 4. Mock Knox probe always failing
+    when(knoxClient.execute(any(HttpGet.class)))
+        .thenThrow(new java.io.IOException("Connection refused"));
+
+    List<String> result =
+        service.resolveUrl("my-cluster", knoxClient, com.google.common.collect.ImmutableList.of());
+
+    assertTrue(result.isEmpty());
+  }
+}

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiYarnApplicationDtoTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/cloudera/manager/dto/ApiYarnApplicationDtoTest.java
@@ -27,14 +27,14 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.junit.Test;
 
-public class ApiYARNApplicationDTOTest {
+public class ApiYarnApplicationDtoTest {
   private static final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
   public void applicationIdExists() throws Exception {
     JsonNode jsonNode =
         objectMapper.readTree(readString("/cloudera/manager/dto/ApiYARNApplicationDTO.json"));
-    ApiYARNApplicationDTO dto = new ApiYARNApplicationDTO(jsonNode);
+    ApiYarnApplicationDto dto = new ApiYarnApplicationDto(jsonNode);
 
     assertEquals("job_1741847944157_0018", dto.getApplicationId());
   }
@@ -42,14 +42,14 @@ public class ApiYARNApplicationDTOTest {
   @Test
   public void applicationIdDoesNotExist() throws Exception {
     JsonNode jsonNode = objectMapper.readTree("{ \"prop\": \"val\"}");
-    ApiYARNApplicationDTO dto = new ApiYARNApplicationDTO(jsonNode);
+    ApiYarnApplicationDto dto = new ApiYarnApplicationDto(jsonNode);
 
     assertNull("ApplicationId must be null if doesn't exist", dto.getApplicationId());
   }
 
   @Test
   public void nullJsonFieldHandled() {
-    ApiYARNApplicationDTO dto = new ApiYARNApplicationDTO(null);
+    ApiYarnApplicationDto dto = new ApiYarnApplicationDto(null);
 
     assertNull("ApplicationId must be null for null json", dto.getApplicationId());
   }
@@ -57,7 +57,7 @@ public class ApiYARNApplicationDTOTest {
   @Test
   public void jsonSerialization() throws Exception {
     JsonNode yarnApp = objectMapper.readTree("{ \"prop\": \"val\"}");
-    ApiYARNApplicationDTO dto = new ApiYARNApplicationDTO(yarnApp);
+    ApiYarnApplicationDto dto = new ApiYarnApplicationDto(yarnApp);
 
     JsonNode outputJsonl = objectMapper.convertValue(dto, JsonNode.class);
 


### PR DESCRIPTION
Add SparkHistoryDiscoveryService and supporting DTOs to automatically resolve Spark History Server URLs via Knox by probing Spark 2 and Spark 3 endpoints.