### PR TITLE
[b/504515495] Show root case error in case of lockfiles mismatch

### DIFF
--- a/dts-transfer-status/app/build.gradle
+++ b/dts-transfer-status/app/build.gradle
@@ -113,7 +113,9 @@ tasks.register('generateSourceMirror', Copy) {
         dependencies.createArtifactResolutionQuery()
                 .forComponents(
                         configurations.runtimeClasspath.incoming.resolutionResult
-                                .allDependencies.collect { it.selected.id }
+                                .allDependencies
+                                .findAll { it instanceof ResolvedDependencyResult }
+                                .collect { it.selected.id }
                 )
                 .withArtifacts(JvmLibrary, SourcesArtifact)
                 .execute()

--- a/dumper/app/build.gradle
+++ b/dumper/app/build.gradle
@@ -259,7 +259,9 @@ tasks.register('generateSourceMirror', Copy) {
         dependencies.createArtifactResolutionQuery()
                 .forComponents(
                         configurations.runtimeClasspath.incoming.resolutionResult
-                                .allDependencies.collect { it.selected.id }
+                                .allDependencies
+                                .findAll { it instanceof ResolvedDependencyResult }
+                                .collect { it.selected.id }
                 )
                 .withArtifacts(JvmLibrary, SourcesArtifact)
                 .execute()

--- a/permissions-migration/app/build.gradle
+++ b/permissions-migration/app/build.gradle
@@ -120,7 +120,9 @@ tasks.register('generateSourceMirror', Copy) {
         dependencies.createArtifactResolutionQuery()
             .forComponents(
                 configurations.runtimeClasspath.incoming.resolutionResult
-                    .allDependencies.collect { it.selected.id }
+                    .allDependencies
+                        .findAll { it instanceof ResolvedDependencyResult }
+                        .collect { it.selected.id }
             )
             .withArtifacts(JvmLibrary, SourcesArtifact)
             .execute()


### PR DESCRIPTION
Error message example for deps miss match.

```
* What went wrong:
Execution failed for task ':dumper:app:installDist'.
> Could not resolve all files for configuration ':dumper:app:runtimeClasspath'.
   > Could not resolve org.postgresql:postgresql:42.7.8.
     Required by:
         project :dumper:app
         project :dumper:app > project :dumper:lib-common
         project :dumper:app > project :dumper:lib-dumper-spi
         project :dumper:app > project :dumper:lib-ext-bigquery
         project :dumper:app > project :dumper:lib-ext-hive-metastore
      > Cannot find a version of 'org.postgresql:postgresql' that satisfies the version constraints:
           Dependency path 'dwh-migration-tools.dumper:app:unspecified' --> 'org.postgresql:postgresql:42.7.8'
           Dependency path 'dwh-migration-tools.dumper:app:unspecified' --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'org.postgresql:postgresql:{strictly 42.7.0}' because of the following reason: dependency was locked to version '42.7.0'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-common:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-dumper-spi:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-ext-bigquery:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-ext-hive-metastore:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'

   > Could not resolve org.postgresql:postgresql:{strictly 42.7.0}.
     Required by:
         project :dumper:app
      > Cannot find a version of 'org.postgresql:postgresql' that satisfies the version constraints:
           Dependency path 'dwh-migration-tools.dumper:app:unspecified' --> 'org.postgresql:postgresql:42.7.8'
           Dependency path 'dwh-migration-tools.dumper:app:unspecified' --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'org.postgresql:postgresql:{strictly 42.7.0}' because of the following reason: dependency was locked to version '42.7.0'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-common:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-dumper-spi:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-ext-bigquery:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'
           Constraint path 'dwh-migration-tools.dumper:app:unspecified' --> 'dwh-migration-tools.dumper:lib-ext-hive-metastore:unspecified' (runtimeElements) --> 'org.postgresql:postgresql:42.7.8'

```