### PR TITLE
[b/506084395] Add jdk8 profile to check java version during the build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       run: ./gradlew -Pci clean
     
     - name: Test Dumper
-      run: ./gradlew -Pci :dumper:app:build --stacktrace
+      run: ./gradlew -Pci -Pjdk8 :dumper:app:build --stacktrace
     
     - name: Test DTS transfer
       run: ./gradlew -Pci :dts-transfer-status:app:build --stacktrace

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 apply plugin: 'com.github.jk1.dependency-license-report'
 apply plugin: 'com.adarshr.test-logger'
 
-if (project.hasProperty('release') || project.hasProperty('ci')) {
+if (project.hasProperty('release') || project.hasProperty('ci') || project.hasProperty('jdk8')) {
     // todo add check for version ends with '-SNAPSHOT' after b/440037454
     if (JavaVersion.current() != JavaVersion.VERSION_1_8) {
         throw new GradleException("The Dumper release and CI builds must be run with JDK 8 but was executed with JDK " + JavaVersion.current())


### PR DESCRIPTION
`jdk8` is more explicit name for the profile. This profile used in the internal build scripts to make sure a correct Java used for releases. 