### PR TITLE
Don't test dts-transfer-status during CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,9 +51,6 @@ jobs:
     
     - name: Test Dumper
       run: ./gradlew -Pci -Pjdk8 :dumper:app:build --stacktrace
-    
-    - name: Test DTS transfer
-      run: ./gradlew -Pci :dts-transfer-status:app:build --stacktrace
-    
+
     - name: Test Permissions migration
       run: ./gradlew -Pci :permissions-migration:app:build --stacktrace


### PR DESCRIPTION
Test failures on dts-transfer-status are blocking other changes. Since dts-transfer-status is no longer supplied after the change in b/497794395, its tests can be skipped by CI.