### PR TITLE
[b/497794395] Remove stale tools from the build lifecycle

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,3 @@ jobs:
     
     - name: Test Dumper
       run: ./gradlew -Pci -Pjdk8 :dumper:app:build --stacktrace
-
-    - name: Test Permissions migration
-      run: ./gradlew -Pci :permissions-migration:app:build --stacktrace

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,7 +19,5 @@ include(
 	':dumper:lib-dumper-spi',
 	':dumper:lib-ext-bigquery',
 	':dumper:lib-ext-hive-metastore',
-	':dumper:app',
-    ':permissions-migration:app',
-    ':dts-transfer-status:app'
+	':dumper:app'
 )


### PR DESCRIPTION
The tools were still under main build lifecycle and the support was costly.