### PR TITLE
Add teradata-logs flag to keep failed logs

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -72,6 +72,7 @@ public class ConnectorArguments extends DefaultArguments {
           + "\n";
 
   public static final String OPT_CONNECTOR = "connector";
+  public static final String OPT_KEEP_FAILED_LOGS = "keep-failed-logs";
   public static final String OPT_TELEMETRY = "telemetry";
   public static final String OPT_DRIVER = "driver";
   public static final String OPT_CLASS = "jdbcDriverClass";
@@ -166,6 +167,9 @@ public class ConnectorArguments extends DefaultArguments {
 
   private final OptionSpec<String> connectorNameOption =
       parser.accepts(OPT_CONNECTOR, "Target connector name").withRequiredArg().required();
+  private final OptionSpec<Void> optionKeepFailedLogs =
+      parser.accepts(OPT_KEEP_FAILED_LOGS, "Keep failed query logs.");
+
   private final OptionSpec<String> optionDriver =
       parser
           .accepts(
@@ -723,6 +727,10 @@ public class ConnectorArguments extends DefaultArguments {
   @CheckForNull
   public String getOracleSID() {
     return getOptions().valueOf(optionOracleSID);
+  }
+
+  public boolean shouldKeepFailedLogs() {
+    return getOptions().has(OPT_KEEP_FAILED_LOGS);
   }
 
   @Nonnull

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
@@ -199,7 +199,7 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
         keepFailedLogs);
   }
 
-  public static TeradataAssessmentLogsJdbcTask withFailedLogs(
+  public static TeradataAssessmentLogsJdbcTask keepingFailedLogs(
       @Nonnull String targetPath,
       SharedState state,
       QueryLogTableNames tableNames,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTask.java
@@ -164,6 +164,28 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
       @CheckForNull String logDateColumn,
       OptionalLong maxSqlLength,
       List<String> orderBy) {
+    this(
+        targetPath,
+        state,
+        tableNames,
+        conditions,
+        interval,
+        logDateColumn,
+        maxSqlLength,
+        orderBy,
+        false);
+  }
+
+  private TeradataAssessmentLogsJdbcTask(
+      @Nonnull String targetPath,
+      SharedState state,
+      QueryLogTableNames tableNames,
+      Set<String> conditions,
+      ZonedInterval interval,
+      @CheckForNull String logDateColumn,
+      OptionalLong maxSqlLength,
+      List<String> orderBy,
+      boolean keepFailedLogs) {
     super(
         targetPath,
         state,
@@ -173,6 +195,28 @@ public class TeradataAssessmentLogsJdbcTask extends TeradataLogsJdbcTask {
         logDateColumn,
         maxSqlLength,
         orderBy,
-        EXPRESSIONS);
+        EXPRESSIONS,
+        keepFailedLogs);
+  }
+
+  public static TeradataAssessmentLogsJdbcTask withFailedLogs(
+      @Nonnull String targetPath,
+      SharedState state,
+      QueryLogTableNames tableNames,
+      Set<String> conditions,
+      ZonedInterval interval,
+      @CheckForNull String logDateColumn,
+      OptionalLong maxSqlLength,
+      List<String> orderBy) {
+    return new TeradataAssessmentLogsJdbcTask(
+        targetPath,
+        state,
+        tableNames,
+        conditions,
+        interval,
+        logDateColumn,
+        maxSqlLength,
+        orderBy,
+        true);
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -30,6 +30,7 @@ import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArg
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogDays;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogEnd;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentQueryLogStart;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsInput;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorPropertyWithDefault;
@@ -58,6 +59,9 @@ import org.slf4j.LoggerFactory;
 /** @author matt */
 @AutoService({Connector.class, LogsConnector.class})
 @Description("Dumps logs from Teradata version >=15.")
+@RespectsInput(
+    arg = ConnectorArguments.OPT_KEEP_FAILED_LOGS,
+    description = "If provided, disables filtering of failed queries.")
 @RespectsArgumentQueryLogDays
 @RespectsArgumentQueryLogStart
 @RespectsArgumentQueryLogEnd
@@ -258,7 +262,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
         String file = getEntryFileNameWithTimestamp(ZIP_ENTRY_PREFIX, interval);
         List<String> orderBy = Arrays.asList("ST.QueryID", "ST.SQLRowNo");
         TeradataAssessmentLogsJdbcTask logsTask;
-        if (arguments.isAssessment() && arguments.shouldKeepFailedLogs()) {
+        if (arguments.shouldKeepFailedLogs()) {
           logsTask =
               TeradataAssessmentLogsJdbcTask.keepingFailedLogs(
                   file,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -260,7 +260,7 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
         TeradataAssessmentLogsJdbcTask logsTask;
         if (arguments.isAssessment() && arguments.shouldKeepFailedLogs()) {
           logsTask =
-              TeradataAssessmentLogsJdbcTask.withFailedLogs(
+              TeradataAssessmentLogsJdbcTask.keepingFailedLogs(
                   file,
                   queryLogsState,
                   tableNames,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnector.java
@@ -257,17 +257,31 @@ public class TeradataLogsConnector extends AbstractTeradataConnector
       for (ZonedInterval interval : intervals) {
         String file = getEntryFileNameWithTimestamp(ZIP_ENTRY_PREFIX, interval);
         List<String> orderBy = Arrays.asList("ST.QueryID", "ST.SQLRowNo");
-        out.add(
-            new TeradataAssessmentLogsJdbcTask(
-                    file,
-                    queryLogsState,
-                    tableNames,
-                    conditions,
-                    interval,
-                    logDateColumn,
-                    maxSqlLength,
-                    orderBy)
-                .withHeaderClass(HeaderForAssessment.class));
+        TeradataAssessmentLogsJdbcTask logsTask;
+        if (arguments.isAssessment() && arguments.shouldKeepFailedLogs()) {
+          logsTask =
+              TeradataAssessmentLogsJdbcTask.withFailedLogs(
+                  file,
+                  queryLogsState,
+                  tableNames,
+                  conditions,
+                  interval,
+                  logDateColumn,
+                  maxSqlLength,
+                  orderBy);
+        } else {
+          logsTask =
+              new TeradataAssessmentLogsJdbcTask(
+                  file,
+                  queryLogsState,
+                  tableNames,
+                  conditions,
+                  interval,
+                  logDateColumn,
+                  maxSqlLength,
+                  orderBy);
+        }
+        out.add(logsTask.withHeaderClass(HeaderForAssessment.class));
         out.addAll(createTimeSeriesTasks(interval, arguments));
         out.add(
             new TeradataUtilityLogsJdbcTask(

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTask.java
@@ -105,6 +105,7 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
   private final OptionalLong maxSqlLength;
   protected final ImmutableList<String> orderBy;
   private final ImmutableList<String> expressions;
+  private final boolean keepFailedLogs;
 
   private Optional<String> sql = Optional.empty();
 
@@ -123,7 +124,8 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
         /* logDateColumn= */ null,
         /* maxSqlLength= */ OptionalLong.empty(),
         /* orderBy= */ ImmutableList.of(),
-        EXPRESSIONS);
+        EXPRESSIONS,
+        /* keepFailedLogs= */ false);
   }
 
   protected TeradataLogsJdbcTask(
@@ -135,7 +137,8 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
       @CheckForNull String logDateColumn,
       OptionalLong maxSqlLength,
       List<String> orderBy,
-      List<String> expressions) {
+      List<String> expressions,
+      boolean keepFailedLogs) {
     super(targetPath);
     this.state = Preconditions.checkNotNull(state, "SharedState was null.");
     this.tableNames = tableNames;
@@ -145,6 +148,7 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
     this.maxSqlLength = maxSqlLength;
     this.orderBy = ImmutableList.copyOf(orderBy);
     this.expressions = ImmutableList.copyOf(expressions);
+    this.keepFailedLogs = keepFailedLogs;
   }
 
   private static boolean isQueryTable(@Nonnull String expression) {
@@ -234,14 +238,13 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
 
     buf.append(
         String.format(
-            " WHERE L.ErrorCode=0\n"
-                + "AND L.StartTime >= CAST('%s' AS TIMESTAMP)\n"
+            " WHERE L.StartTime >= CAST('%s' AS TIMESTAMP)\n"
                 + "AND L.StartTime < CAST('%s' AS TIMESTAMP)\n",
             SQL_FORMAT.format(interval.getStart()), SQL_FORMAT.format(interval.getEndExclusive())));
-
-    if (logDateColumn != null) {
-      buf.append(" AND L.").append(createLogDateColumnConditionStr());
+    if (!keepFailedLogs) {
+      buf.append("AND L.ErrorCode=0\n");
     }
+    buf.append(createLogDateColumnConditionStr());
 
     for (String condition : conditions) {
       buf.append(" AND ").append(condition);
@@ -255,7 +258,12 @@ public class TeradataLogsJdbcTask extends AbstractJdbcTask<Summary> {
   }
 
   private String createLogDateColumnConditionStr() {
-    return logDateColumn + " = CAST('" + SQL_DATE_FORMAT.format(interval.getStart()) + "' AS DATE)";
+    if (logDateColumn == null) {
+      return "";
+    } else {
+      String start = SQL_DATE_FORMAT.format(interval.getStart());
+      return " AND L." + logDateColumn + " = CAST('" + start + "' AS DATE)";
+    }
   }
 
   private Expression createLogDateColumnCondition() {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
@@ -65,9 +65,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -93,9 +93,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT NULL, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -127,9 +127,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + "     CAST(SUBSTR(SqlTextInfo, 20001, 20000) AS VARCHAR(20000)) AS SqlTextInfo,"
             + "     (((SqlRowNo - 1) * 2) + 2) AS SqlRowNo FROM SampleSqlTable"
             + " ) ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -153,9 +153,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID"
             + " FROM SampleQueryTable L"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -179,10 +179,11 @@ public class TeradataAssessmentLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID"
             + " FROM SampleQueryTable L"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND"
-            + " L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0"
+            + " AND L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
         query);
   }
 
@@ -206,9 +207,10 @@ public class TeradataAssessmentLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID"
             + " FROM SampleQueryTable L"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND L.QueryID=7",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n" + 
+            " AND L.QueryID=7",
         query);
   }
 
@@ -232,9 +234,10 @@ public class TeradataAssessmentLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID"
             + " FROM SampleQueryTable L"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
             + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+             + " AND L.ErrorCode=0\n"
             + " ORDER BY L.QueryID, L.QueryText",
         query);
   }
@@ -260,10 +263,11 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         "SELECT L.QueryID, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST"
             + " ON (L.QueryID=ST.QueryID AND L.SampleLogDate=ST.SampleLogDate)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND"
-            + " L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+             + " AND L.ErrorCode=0\n"
+            + " AND L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
         query);
   }
 
@@ -298,10 +302,11 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + "     WHERE SampleLogDate = CAST('2023-03-04Z' AS DATE)"
             + " ) ST"
             + " ON (L.QueryID=ST.QueryID AND L.SampleLogDate=ST.SampleLogDate)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND"
-            + " L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n"
+            + " AND L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
         query);
   }
 
@@ -328,11 +333,13 @@ public class TeradataAssessmentLogsJdbcTaskTest {
         "SELECT L.QueryID, L.QueryText, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST"
             + " ON (L.QueryID=ST.QueryID AND L.SampleLogDate=ST.SampleLogDate)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND"
-            + " L.SampleLogDate = CAST('2023-03-04Z' AS DATE) AND"
-            + " QueryID=7 AND QueryText LIKE '%abc%'"
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+                         + " AND L.ErrorCode=0"
+
+            + " AND L.SampleLogDate = CAST('2023-03-04Z' AS DATE)"
+            + " AND QueryID=7 AND QueryText LIKE '%abc%'"
             + " ORDER BY ST.QueryID, ST.RowNo",
         query);
   }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.connector.teradata;
 
 import static com.google.edwmigration.dumper.application.dumper.test.DumperTestUtils.assertQueryEquals;
 import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertFalse;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -342,6 +343,29 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " AND QueryID=7 AND QueryText LIKE '%abc%'"
             + " ORDER BY ST.QueryID, ST.RowNo",
         query);
+  }
+
+  @Test
+  public void getOrCreateSql_failedLogsPreserved_noErrorCheckInQuery() {
+    QueryLogTableNames names = QueryLogTableNames.create("SampleQueryTable", "SampleSqlTable", false);
+        TeradataAssessmentLogsJdbcTask jdbcTask =
+        TeradataAssessmentLogsJdbcTask.keepingFailedLogs(
+            "query_history.csv",
+            queryLogsState,
+            names,
+            ImmutableSet.of("QueryID=7", "QueryText LIKE '%abc%'"),
+            interval,
+            "SampleLogDate",
+            /* maxSqlLength= */ OptionalLong.of(999999),
+            ImmutableList.of("ST.QueryID", "ST.RowNo"));
+
+    // Act
+    String query =
+        jdbcTask.getOrCreateSql(
+            s -> true, ImmutableList.of("L.QueryID", "L.QueryText", "ST.QueryID"));
+
+    // Assert
+    assertFalse(query, query.replace(" ", "").contains(".ErrorCode="));
   }
 
   private QueryLogTableNames createTableName(String logTable, String sqlTable) {

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataAssessmentLogsJdbcTaskTest.java
@@ -68,7 +68,8 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -96,7 +97,8 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -130,7 +132,8 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " ) ST ON (L.QueryID=ST.QueryID)"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -156,7 +159,8 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " FROM SampleQueryTable L"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -210,8 +214,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " FROM SampleQueryTable L"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n" + 
-            " AND L.QueryID=7",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n"
+            + " AND L.QueryID=7",
         query);
   }
 
@@ -238,7 +243,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
             + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
-             + " AND L.ErrorCode=0\n"
+            + " AND L.ErrorCode=0\n"
             + " ORDER BY L.QueryID, L.QueryText",
         query);
   }
@@ -267,7 +272,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
             + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
-             + " AND L.ErrorCode=0\n"
+            + " AND L.ErrorCode=0\n"
             + " AND L.SampleLogDate = CAST('2023-03-04Z' AS DATE)",
         query);
   }
@@ -337,8 +342,7 @@ public class TeradataAssessmentLogsJdbcTaskTest {
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
             + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
-                         + " AND L.ErrorCode=0"
-
+            + " AND L.ErrorCode=0"
             + " AND L.SampleLogDate = CAST('2023-03-04Z' AS DATE)"
             + " AND QueryID=7 AND QueryText LIKE '%abc%'"
             + " ORDER BY ST.QueryID, ST.RowNo",
@@ -347,8 +351,9 @@ public class TeradataAssessmentLogsJdbcTaskTest {
 
   @Test
   public void getOrCreateSql_failedLogsPreserved_noErrorCheckInQuery() {
-    QueryLogTableNames names = QueryLogTableNames.create("SampleQueryTable", "SampleSqlTable", false);
-        TeradataAssessmentLogsJdbcTask jdbcTask =
+    QueryLogTableNames names =
+        QueryLogTableNames.create("SampleQueryTable", "SampleSqlTable", false);
+    TeradataAssessmentLogsJdbcTask jdbcTask =
         TeradataAssessmentLogsJdbcTask.keepingFailedLogs(
             "query_history.csv",
             queryLogsState,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
@@ -362,18 +362,18 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
                         .getOrCreateSql(unused -> true, ImmutableList.of("SampleColumn")))
             .collect(toImmutableList());
     assertEquals(
-        
-            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
-                + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP) AND"
-                + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
-                + " L.ErrorCode=0 AND"
-                + " L.UserName <> 'DBC'", queries.get(0));
+        "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
+            + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP) AND"
+            + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
+            + " L.ErrorCode=0 AND"
+            + " L.UserName <> 'DBC'",
+        queries.get(0));
     assertEquals(
-            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
-                + " L.StartTime >= CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
-                + " L.StartTime < CAST('2023-12-22T02:00:00Z' AS TIMESTAMP)"
-                + " AND L.ErrorCode=0"
-                + " AND L.UserName <> 'DBC'",
+        "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
+            + " L.StartTime >= CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
+            + " L.StartTime < CAST('2023-12-22T02:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0"
+            + " AND L.UserName <> 'DBC'",
         queries.get(1));
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsConnectorTest.java
@@ -331,9 +331,9 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
             .collect(toImmutableList());
     assertEquals(1, queries.size());
     assertQueryEquals(
-        "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE L.ErrorCode=0 AND"
+        "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
             + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
+            + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND L.ErrorCode=0 AND L.UserName <> 'DBC'",
         getOnlyElement(queries));
   }
 
@@ -362,14 +362,19 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
                         .getOrCreateSql(unused -> true, ImmutableList.of("SampleColumn")))
             .collect(toImmutableList());
     assertEquals(
-        ImmutableList.of(
-            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE L.ErrorCode=0 AND"
+        
+            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
                 + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP) AND"
-                + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
-            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE L.ErrorCode=0 AND"
+                + " L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
+                + " L.ErrorCode=0 AND"
+                + " L.UserName <> 'DBC'", queries.get(0));
+    assertEquals(
+            "SELECT SampleColumn FROM dbc.DBQLogTbl L WHERE"
                 + " L.StartTime >= CAST('2023-12-22T01:00:00Z' AS TIMESTAMP) AND"
-                + " L.StartTime < CAST('2023-12-22T02:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'"),
-        queries);
+                + " L.StartTime < CAST('2023-12-22T02:00:00Z' AS TIMESTAMP)"
+                + " AND L.ErrorCode=0"
+                + " AND L.UserName <> 'DBC'",
+        queries.get(1));
   }
 
   @Test
@@ -401,10 +406,10 @@ public class TeradataLogsConnectorTest extends AbstractConnectorExecutionTest {
     assertQueryEquals(
         "SELECT ST.QueryID"
             + " FROM dbc.QryLogV L LEFT OUTER JOIN dbc.DBQLSQLTbl ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0"
-            + " AND L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP)"
+            + " WHERE"
+            + " L.StartTime >= CAST('2023-12-22T00:00:00Z' AS TIMESTAMP)"
             + " AND L.StartTime < CAST('2023-12-22T01:00:00Z' AS TIMESTAMP)"
-            + " ORDER BY ST.QueryID, ST.SQLRowNo",
+            + " AND L.ErrorCode=0 ORDER BY ST.QueryID, ST.SQLRowNo",
         getOnlyElement(queries));
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -58,7 +58,8 @@ public class TeradataLogsJdbcTaskTest {
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -147,7 +148,8 @@ public class TeradataLogsJdbcTaskTest {
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
             + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T13:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T14:00:00Z' AS TIMESTAMP)"+ " AND L.ErrorCode=0",
+            + " L.StartTime < CAST('2023-03-04T14:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0",
         taskDescription);
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/teradata/TeradataLogsJdbcTaskTest.java
@@ -56,9 +56,9 @@ public class TeradataLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)" + " AND L.ErrorCode=0\n",
         query);
   }
 
@@ -85,9 +85,10 @@ public class TeradataLogsJdbcTaskTest {
     assertEquals(
         "Write result.csv from\n        SELECT L.QueryID, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND"
+            + " L.ErrorCode=0",
         taskDescription);
   }
 
@@ -113,9 +114,11 @@ public class TeradataLogsJdbcTaskTest {
     assertQueryEquals(
         "SELECT L.QueryID, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T16:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP) AND L.UserName <> 'DBC'",
+            + " L.StartTime < CAST('2023-03-04T17:00:00Z' AS TIMESTAMP)"
+            + " AND L.ErrorCode=0"
+            + " AND L.UserName <> 'DBC'",
         query);
   }
 
@@ -142,9 +145,9 @@ public class TeradataLogsJdbcTaskTest {
     assertEquals(
         "Write result.csv from\n        SELECT L.QueryID, ST.QueryID"
             + " FROM SampleQueryTable L LEFT OUTER JOIN SampleSqlTable ST ON (L.QueryID=ST.QueryID)"
-            + " WHERE L.ErrorCode=0 AND"
+            + " WHERE"
             + " L.StartTime >= CAST('2023-03-04T13:00:00Z' AS TIMESTAMP) AND"
-            + " L.StartTime < CAST('2023-03-04T14:00:00Z' AS TIMESTAMP)",
+            + " L.StartTime < CAST('2023-03-04T14:00:00Z' AS TIMESTAMP)"+ " AND L.ErrorCode=0",
         taskDescription);
   }
 }


### PR DESCRIPTION
The current behavior of Teradata Dumper is to filter out all logs where the error code is not 0.

Add a flag that allows the user to extract non-zero error code logs as well.

The flag name is `--keep-failed-logs`.