### PR TITLE
Make the Snowflake features.csv guarded by the --assessment flag

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/FeaturesQueryPath.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/FeaturesQueryPath.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2022-2025 Google LLC
+ * Copyright 2013-2021 CompilerWorks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
+
+import static com.google.common.io.Resources.getResource;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.io.Resources;
+import com.google.edwmigration.dumper.application.dumper.io.OutputHandle.WriteMode;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractTask.TaskOptions;
+import java.io.IOException;
+import java.net.URL;
+
+enum FeaturesQueryPath {
+  SIMPLE("account-usage-simple.sql") {
+    @Override
+    TaskOptions taskOptions() {
+      return TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
+    }
+  },
+  COMPLEX("account-usage-complex.sql") {
+    @Override
+    TaskOptions taskOptions() {
+      return TaskOptions.DEFAULT;
+    }
+  },
+  SHOW_BASED("show-based.sql") {
+    @Override
+    TaskOptions taskOptions() {
+      return TaskOptions.DEFAULT;
+    }
+  };
+
+  private final String file;
+
+  FeaturesQueryPath(String file) {
+    this.file = file;
+  }
+
+  abstract TaskOptions taskOptions();
+
+  String loadFile() {
+    String value = "snowflake-features/" + file;
+    try {
+      URL queryUrl = getResource(value);
+      return Resources.toString(queryUrl, UTF_8);
+    } catch (IOException e) {
+      String message = String.format("An invalid file was provided: '%s'.", value);
+      throw new IllegalArgumentException(message, e);
+    }
+  }
+}

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -16,10 +16,10 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
+import static com.google.common.io.Resources.getResource;
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.MetadataView.TABLE_STORAGE_METRICS;
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.Arrays.stream;
 
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
@@ -67,7 +67,6 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   private static final String ACCOUNT_USAGE_SIMPLE_FILE = "account-usage-simple.sql";
   private static final String ACCOUNT_USAGE_COMPLEX_FILE = "account-usage-complex.sql";
   private static final String SHOW_BASED_FILE = "show-based.sql";
-  private static final String SNOWFLAKE_FEATURES_PREFIX = "snowflake-features/";
 
   private enum PropertyAction {
     QUERY("query", "query"),
@@ -273,23 +272,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         isAssessment,
         getInformationSchemaWhereCondition("function_catalog", arguments.getDatabases()));
 
-    stream(FeaturesQueryPath.values())
-        .forEach(
-            path -> {
-              TaskOptions taskOptions =
-                  path.value.contains(ACCOUNT_USAGE_SIMPLE_FILE)
-                      ? TaskOptions.DEFAULT
-                      : TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
-              out.add(
-                  new JdbcSelectTask(
-                          FeaturesFormat.IS_ZIP_ENTRY_NAME,
-                          loadFile(path.value),
-                          TaskCategory.OPTIONAL, // TODO: Change to REQUIRED after implementation
-                          taskOptions)
-                      .withHeaderClass(FeaturesFormat.Header.class));
-            });
-
     if (isAssessment) {
+      out.addAll(featuresTasks());
+
       for (AssessmentQuery item : planner.generateAssessmentQueries()) {
         String query = queryForAssessment(item, arguments);
         Task<?> task =
@@ -324,15 +309,57 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   enum FeaturesQueryPath {
-    SIMPLE(SNOWFLAKE_FEATURES_PREFIX + ACCOUNT_USAGE_SIMPLE_FILE),
-    COMPLEX(SNOWFLAKE_FEATURES_PREFIX + ACCOUNT_USAGE_COMPLEX_FILE),
-    SHOW_BASED(SNOWFLAKE_FEATURES_PREFIX + SHOW_BASED_FILE);
+    SIMPLE(ACCOUNT_USAGE_SIMPLE_FILE) {
+      @Override
+      TaskOptions taskOptions() {
+        return TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
+      }
+    },
+    COMPLEX(ACCOUNT_USAGE_COMPLEX_FILE) {
+      @Override
+      TaskOptions taskOptions() {
+        return TaskOptions.DEFAULT;
+      }
+    },
+    SHOW_BASED(SHOW_BASED_FILE) {
+      @Override
+      TaskOptions taskOptions() {
+        return TaskOptions.DEFAULT;
+      }
+    };
 
-    final String value;
+    final String file;
 
-    FeaturesQueryPath(String value) {
-      this.value = value;
+    FeaturesQueryPath(String file) {
+      this.file = file;
     }
+
+    abstract TaskOptions taskOptions();
+
+    String loadFile() {
+      String value = "snowflake-features/" + file;
+      try {
+        URL queryUrl = getResource(value);
+        return Resources.toString(queryUrl, UTF_8);
+      } catch (IOException e) {
+        throw new IllegalArgumentException(
+            String.format("An invalid file was provided: '%s'.", value), e);
+      }
+    }
+  }
+
+  private static ImmutableList<AbstractJdbcTask<Summary>> featuresTasks() {
+    ImmutableList<FeaturesQueryPath> paths =
+        ImmutableList.of(
+            FeaturesQueryPath.SIMPLE, FeaturesQueryPath.COMPLEX, FeaturesQueryPath.SHOW_BASED);
+    ImmutableList.Builder<AbstractJdbcTask<Summary>> builder = ImmutableList.builder();
+    for (FeaturesQueryPath item : paths) {
+      JdbcSelectTask task =
+          new JdbcSelectTask(
+              "features.csv", item.loadFile(), TaskCategory.OPTIONAL, item.taskOptions());
+      builder.add(task.withHeaderClass(FeaturesFormat.Header.class));
+    }
+    return builder.build();
   }
 
   // INFORMATION_SCHEMA queries must be qualified with a database
@@ -449,15 +476,5 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
     databaseName = databaseName.replace("\"", "\"\"");
     return String.format("\"%s\"", databaseName);
-  }
-
-  private static String loadFile(String path) {
-    try {
-      URL queryUrl = Resources.getResource(path);
-      return Resources.toString(queryUrl, UTF_8);
-    } catch (IOException e) {
-      throw new IllegalArgumentException(
-          String.format("An invalid file was provided: '%s'.", path), e);
-    }
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -16,15 +16,15 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static com.google.common.io.Resources.getResource;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.FeaturesQueryPath.COMPLEX;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.FeaturesQueryPath.SHOW_BASED;
+import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.FeaturesQueryPath.SIMPLE;
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.MetadataView.TABLE_STORAGE_METRICS;
 import static com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
@@ -43,8 +43,6 @@ import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat;
-import java.io.IOException;
-import java.net.URL;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -64,9 +62,6 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   private static final String ACCOUNT_USAGE_SCHEMA_NAME = "SNOWFLAKE.ACCOUNT_USAGE";
   private static final String ACCOUNT_USAGE_WHERE_CONDITION = "DELETED IS NULL";
   private static final String EMPTY_WHERE_CONDITION = "";
-  private static final String ACCOUNT_USAGE_SIMPLE_FILE = "account-usage-simple.sql";
-  private static final String ACCOUNT_USAGE_COMPLEX_FILE = "account-usage-complex.sql";
-  private static final String SHOW_BASED_FILE = "show-based.sql";
 
   private enum PropertyAction {
     QUERY("query", "query"),
@@ -308,50 +303,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
   }
 
-  enum FeaturesQueryPath {
-    SIMPLE(ACCOUNT_USAGE_SIMPLE_FILE) {
-      @Override
-      TaskOptions taskOptions() {
-        return TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
-      }
-    },
-    COMPLEX(ACCOUNT_USAGE_COMPLEX_FILE) {
-      @Override
-      TaskOptions taskOptions() {
-        return TaskOptions.DEFAULT;
-      }
-    },
-    SHOW_BASED(SHOW_BASED_FILE) {
-      @Override
-      TaskOptions taskOptions() {
-        return TaskOptions.DEFAULT;
-      }
-    };
-
-    final String file;
-
-    FeaturesQueryPath(String file) {
-      this.file = file;
-    }
-
-    abstract TaskOptions taskOptions();
-
-    String loadFile() {
-      String value = "snowflake-features/" + file;
-      try {
-        URL queryUrl = getResource(value);
-        return Resources.toString(queryUrl, UTF_8);
-      } catch (IOException e) {
-        throw new IllegalArgumentException(
-            String.format("An invalid file was provided: '%s'.", value), e);
-      }
-    }
-  }
-
   private static ImmutableList<AbstractJdbcTask<Summary>> featuresTasks() {
-    ImmutableList<FeaturesQueryPath> paths =
-        ImmutableList.of(
-            FeaturesQueryPath.SIMPLE, FeaturesQueryPath.COMPLEX, FeaturesQueryPath.SHOW_BASED);
+    ImmutableList<FeaturesQueryPath> paths = ImmutableList.of(SIMPLE, COMPLEX, SHOW_BASED);
     ImmutableList.Builder<AbstractJdbcTask<Summary>> builder = ImmutableList.builder();
     for (FeaturesQueryPath item : paths) {
       JdbcSelectTask task =

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -16,12 +16,12 @@
  */
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
@@ -39,12 +39,9 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Set;
 import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assume;
@@ -62,8 +59,6 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
   @SuppressWarnings("UnusedVariable")
   private static final Logger logger =
       LoggerFactory.getLogger(SnowflakeMetadataConnectorTest.class);
-
-  private static final String FEATURES_CSV = "features.csv";
 
   private final MetadataConnector connector = new SnowflakeMetadataConnector();
 
@@ -153,30 +148,43 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
   }
 
   @Test
-  public void connector_generatesExpectedSql() throws IOException {
-    Map<String, String> actualSqls = collectSqlStatements();
-    TaskSqlMap expectedSqls =
+  public void connector_noAssessment_doesNotContainFeatures() throws IOException {
+
+    ImmutableMap<String, String> sqls = collectSqlStatements();
+
+    assertFalse(sqls.containsKey("features.csv"));
+  }
+
+  @Test
+  public void connector_noAssessment_generatesExpectedSql() throws IOException {
+    TypeReference<Map<String, String>> typeReference = new TypeReference<Map<String, String>>() {};
+    Map<String, String> expectedSqls =
         CoreMetadataDumpFormat.MAPPER.readValue(
             Resources.toString(
                 Resources.getResource("connector/snowflake/jdbc-tasks-sql.yaml"),
                 StandardCharsets.UTF_8),
-            TaskSqlMap.class);
+            typeReference);
 
-    // ignore feature.csv, it will be tested in separate test because the query is too complex
-    int actualSizeWithoutFeatures = actualSqls.size() - 1;
-    Set<String> actualFileNamesWithoutFeatures = new HashSet<>(actualSqls.keySet());
-    actualFileNamesWithoutFeatures.remove(FEATURES_CSV);
+    ImmutableMap<String, String> sqls = collectSqlStatements();
 
-    assertEquals(expectedSqls.size(), actualSizeWithoutFeatures);
-    assertEquals(expectedSqls.keySet(), actualFileNamesWithoutFeatures);
-    for (String name : expectedSqls.keySet()) {
-      assertEquals(expectedSqls.get(name), actualSqls.get(name));
+    for (Entry<String, String> item : expectedSqls.entrySet()) {
+      String key = item.getKey();
+      assertTrue(key, sqls.containsKey(key));
+      assertEquals(key, sqls.get(key), item.getValue());
     }
+  }
+
+  @Test
+  public void connector_withAssessment_containsFeatures() throws IOException {
+
+    ImmutableMap<String, String> sqls = collectSqlStatements("--assessment");
+
+    assertTrue(sqls.containsKey("features.csv"));
   }
 
   @Theory
   public void featuresQueryPathValue_refersToExistingPath(FeaturesQueryPath path) {
-    loadFile(path.value);
+    path.loadFile();
   }
 
   @Test
@@ -284,16 +292,5 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
     return collectSqlStatementsAsMultimap(extraArgs).entries().stream()
         .collect(
             ImmutableMap.toImmutableMap(Entry::getKey, Entry::getValue, (first, dup) -> first));
-  }
-
-  static class TaskSqlMap extends HashMap<String, String> {}
-
-  private void loadFile(String path) {
-    try {
-      Resources.toString(Resources.getResource(path), UTF_8);
-    } catch (IOException e) {
-      throw new IllegalArgumentException(
-          String.format("An invalid file was provided: '%s'.", path), e);
-    }
   }
 }

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -29,7 +29,6 @@ import com.google.common.io.Resources;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
-import com.google.edwmigration.dumper.application.dumper.connector.snowflake.SnowflakeMetadataConnector.FeaturesQueryPath;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.CoreMetadataDumpFormat;

--- a/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeMetadataDumpFormat.java
+++ b/dumper/lib-dumper-spi/src/main/java/com/google/edwmigration/dumper/plugin/lib/dumper/spi/SnowflakeMetadataDumpFormat.java
@@ -196,8 +196,6 @@ public interface SnowflakeMetadataDumpFormat {
 
   interface FeaturesFormat {
 
-    String IS_ZIP_ENTRY_NAME = "features.csv";
-
     enum Header {
       FeatureType,
       FeatureName,


### PR DESCRIPTION
- Make non-assessment Dumper use safer by not extracting `features.csv` when not in Assessment mode.
- Move the FeaturesQueryPath enum (controlling parts of `features.csv`) into a separate file.
- Update unit tests.
