### PR TITLE
[Snowflake] Allow list of databases to be passed to --database flag

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -152,7 +152,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     String globalDatabaseFilter =
         getInformationSchemaWhereCondition(databaseFilterColumnName, databases);
     AbstractJdbcTask<Summary> usageTask =
-        SnowflakeTaskUtil.withFilter(
+        SnowflakeTaskUtil.createJdbcSelectTask(
             format,
             ACCOUNT_USAGE_SCHEMA_NAME,
             accountUsageFileName,
@@ -165,7 +165,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
 
     if (databases.isEmpty()) {
       AbstractJdbcTask<Summary> schemaTask =
-          SnowflakeTaskUtil.withFilter(
+          SnowflakeTaskUtil.createJdbcSelectTask(
               format,
               "INFORMATION_SCHEMA",
               informationSchemaFileName,
@@ -182,6 +182,14 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
     if (inputSource == SnowflakeInput.SCHEMA_ONLY_SOURCE
         || inputSource == SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE) {
+      // INFORMATION_SCHEMA is database-scoped. To fetch metadata from multiple databases,
+      // we must query each database's INFORMATION_SCHEMA individually (e.g.,
+      // db.INFORMATION_SCHEMA.TABLES).
+      // Prefixing the database name also helps the query optimizer scope the metadata scan,
+      // avoiding performance issues that occur when querying INFORMATION_SCHEMA without a database
+      // scope.
+      //
+      // The first task overwrites the output file; subsequent tasks append to it.
       TaskOptions taskOptions = TaskOptions.DEFAULT;
       for (String database : databases) {
         String schemaPrefix = sanitizeDatabaseName(database) + ".INFORMATION_SCHEMA";
@@ -189,7 +197,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             getInformationSchemaWhereCondition(
                 databaseFilterColumnName, ImmutableList.of(database));
         AbstractJdbcTask<Summary> schemaTask =
-            SnowflakeTaskUtil.withFilter(
+            SnowflakeTaskUtil.createJdbcSelectTask(
                 format,
                 schemaPrefix,
                 informationSchemaFileName,

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -43,6 +43,7 @@ import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -142,30 +143,67 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       @Nonnull Class<? extends Enum<?>> header,
       @Nonnull String format,
       @Nonnull String informationSchemaFileName,
-      @Nonnull String informationSchemaName,
       @Nonnull String accountUsageFileName,
       @Nonnull String accountUsageWhereCondition,
-      boolean isAssessment,
-      @Nonnull String databaseFilter) {
-    AbstractJdbcTask<Summary> schemaTask =
-        SnowflakeTaskUtil.withFilter(
-            format,
-            informationSchemaName,
-            informationSchemaFileName,
-            ImmutableList.of(databaseFilter),
-            header);
+      @Nonnull ConnectorArguments arguments,
+      @Nonnull String databaseFilterColumnName) {
+    ImmutableList<String> databases = arguments.getDatabases();
+    boolean isAssessment = arguments.isAssessment();
+    String globalDatabaseFilter =
+        getInformationSchemaWhereCondition(databaseFilterColumnName, databases);
     AbstractJdbcTask<Summary> usageTask =
         SnowflakeTaskUtil.withFilter(
             format,
             ACCOUNT_USAGE_SCHEMA_NAME,
             accountUsageFileName,
-            ImmutableList.of(accountUsageWhereCondition, databaseFilter),
+            ImmutableList.of(accountUsageWhereCondition, globalDatabaseFilter),
             header);
     if (isAssessment) {
       out.add(usageTask);
-    } else {
-      out.addAll(inputSource.sqlTasks(schemaTask, usageTask));
+      return;
     }
+
+    if (databases.isEmpty()) {
+      AbstractJdbcTask<Summary> schemaTask =
+          SnowflakeTaskUtil.withFilter(
+              format,
+              "INFORMATION_SCHEMA",
+              informationSchemaFileName,
+              ImmutableList.of(""),
+              header);
+      out.addAll(inputSource.sqlTasks(schemaTask, usageTask));
+      return;
+    }
+
+    List<Task<?>> tasks = new ArrayList<>();
+    if (inputSource == SnowflakeInput.USAGE_ONLY_SOURCE
+        || inputSource == SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE) {
+      tasks.add(usageTask);
+    }
+    if (inputSource == SnowflakeInput.SCHEMA_ONLY_SOURCE
+        || inputSource == SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE) {
+      TaskOptions taskOptions = TaskOptions.DEFAULT;
+      for (String database : databases) {
+        String schemaPrefix = sanitizeDatabaseName(database) + ".INFORMATION_SCHEMA";
+        String databaseFilter =
+            getInformationSchemaWhereCondition(
+                databaseFilterColumnName, ImmutableList.of(database));
+        AbstractJdbcTask<Summary> schemaTask =
+            SnowflakeTaskUtil.withFilter(
+                format,
+                schemaPrefix,
+                informationSchemaFileName,
+                ImmutableList.of(databaseFilter),
+                header,
+                taskOptions);
+        if (inputSource == SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE) {
+          schemaTask.onlyIfFailed(usageTask);
+        }
+        tasks.add(schemaTask);
+        taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+      }
+    }
+    out.addAll(tasks);
   }
 
   @Override
@@ -175,7 +213,6 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     out.add(new FormatTask(FORMAT_NAME));
     out.add(SnowflakeYamlSummaryTask.create(FORMAT_NAME, arguments));
 
-    String schemaPrefix = getQualifierPrefix(arguments);
     boolean isAssessment = arguments.isAssessment();
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -185,11 +222,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             "SELECT database_name, database_owner FROM %1$s.DATABASES%2$s",
             MetadataView.DATABASES),
         DatabasesFormat.IS_ZIP_ENTRY_NAME,
-        schemaPrefix,
         DatabasesFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
-        isAssessment,
-        getInformationSchemaWhereCondition("database_name", arguments.getDatabases()));
+        arguments,
+        "database_name");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -199,11 +235,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             "SELECT catalog_name, schema_name FROM %1$s.SCHEMATA%2$s",
             MetadataView.SCHEMATA),
         SchemataFormat.IS_ZIP_ENTRY_NAME,
-        schemaPrefix,
         SchemataFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
-        isAssessment,
-        getInformationSchemaWhereCondition("catalog_name", arguments.getDatabases()));
+        arguments,
+        "catalog_name");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -214,12 +249,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
                 + " clustering_key FROM %1$s.TABLES%2$s",
             MetadataView.TABLES),
         TablesFormat.IS_ZIP_ENTRY_NAME,
-        schemaPrefix,
         TablesFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
-        isAssessment,
-        getInformationSchemaWhereCondition(
-            "table_catalog", arguments.getDatabases())); // Painfully slow.
+        arguments,
+        "table_catalog");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -231,12 +264,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
                 + " numeric_precision, numeric_scale, datetime_precision, comment FROM %1$s.COLUMNS%2$s",
             MetadataView.COLUMNS),
         ColumnsFormat.IS_ZIP_ENTRY_NAME,
-        schemaPrefix,
         ColumnsFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
-        isAssessment,
-        getInformationSchemaWhereCondition(
-            "table_catalog", arguments.getDatabases())); // Very fast.
+        arguments,
+        "table_catalog");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -246,11 +277,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
             "SELECT table_catalog, table_schema, table_name, view_definition FROM %1$s.VIEWS%2$s",
             MetadataView.VIEWS),
         ViewsFormat.IS_ZIP_ENTRY_NAME,
-        schemaPrefix,
         ViewsFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
-        isAssessment,
-        getInformationSchemaWhereCondition("table_catalog", arguments.getDatabases()));
+        arguments,
+        "table_catalog");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -261,11 +291,10 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
                 + " %1$s.FUNCTIONS%2$s",
             MetadataView.FUNCTIONS),
         FunctionsFormat.IS_ZIP_ENTRY_NAME,
-        schemaPrefix,
         FunctionsFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
-        isAssessment,
-        getInformationSchemaWhereCondition("function_catalog", arguments.getDatabases()));
+        arguments,
+        "function_catalog");
 
     if (isAssessment) {
       out.addAll(featuresTasks());

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeTaskUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeTaskUtil.java
@@ -22,8 +22,10 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.task.AbstractJdbcTask;
+import com.google.edwmigration.dumper.application.dumper.task.AbstractTask.TaskOptions;
 import com.google.edwmigration.dumper.application.dumper.task.JdbcSelectTask;
 import com.google.edwmigration.dumper.application.dumper.task.Summary;
+import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import java.util.Collection;
 import javax.annotation.ParametersAreNonnullByDefault;
 
@@ -37,8 +39,20 @@ final class SnowflakeTaskUtil {
       String zipEntryName,
       Collection<String> whereConditions,
       Class<? extends Enum<?>> header) {
+    return withFilter(
+        format, schemaName, zipEntryName, whereConditions, header, TaskOptions.DEFAULT);
+  }
+
+  static AbstractJdbcTask<Summary> withFilter(
+      String format,
+      String schemaName,
+      String zipEntryName,
+      Collection<String> whereConditions,
+      Class<? extends Enum<?>> header,
+      TaskOptions taskOptions) {
     String sql = String.format(format, schemaName, getWhereClause(whereConditions));
-    return new JdbcSelectTask(zipEntryName, sql).withHeaderClass(header);
+    return new JdbcSelectTask(zipEntryName, sql, TaskCategory.REQUIRED, taskOptions)
+        .withHeaderClass(header);
   }
 
   private static String getWhereClause(Collection<String> whereConditions) {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeTaskUtil.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeTaskUtil.java
@@ -33,17 +33,17 @@ import javax.annotation.ParametersAreNonnullByDefault;
 final class SnowflakeTaskUtil {
   private static final String EMPTY_WHERE_CLAUSE = "";
 
-  static AbstractJdbcTask<Summary> withFilter(
+  static AbstractJdbcTask<Summary> createJdbcSelectTask(
       String format,
       String schemaName,
       String zipEntryName,
       Collection<String> whereConditions,
       Class<? extends Enum<?>> header) {
-    return withFilter(
+    return createJdbcSelectTask(
         format, schemaName, zipEntryName, whereConditions, header, TaskOptions.DEFAULT);
   }
 
-  static AbstractJdbcTask<Summary> withFilter(
+  static AbstractJdbcTask<Summary> createJdbcSelectTask(
       String format,
       String schemaName,
       String zipEntryName,

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -234,7 +234,8 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
         actualSqls.get("schemata-au.csv"));
     assertEquals(
         ImmutableList.of(
-            "SELECT catalog_name, schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE SQL_OVERRIDE"),
+            "SELECT catalog_name, schema_name FROM db1.INFORMATION_SCHEMA.SCHEMATA WHERE SQL_OVERRIDE",
+            "SELECT catalog_name, schema_name FROM db2.INFORMATION_SCHEMA.SCHEMATA WHERE SQL_OVERRIDE"),
         actualSqls.get("schemata.csv"));
 
     // Two SHOW commands are executed and the result is appended to the same output file.

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeTaskUtilTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeTaskUtilTest.java
@@ -37,7 +37,7 @@ public class SnowflakeTaskUtilTest {
   }
 
   @Test
-  public void withFilter_whereConditions() {
+  public void createJdbcSelectTask_whereConditions() {
 
     assertEquals(
         "SELECT A, B, C FROM SCHEMA.TABLE", getSqlForWhereConditions(Lists.newArrayList()));
@@ -57,7 +57,7 @@ public class SnowflakeTaskUtilTest {
 
   private static String getSqlForWhereConditions(List<String> whereConditions) {
     AbstractJdbcTask<Summary> task =
-        SnowflakeTaskUtil.withFilter(
+        SnowflakeTaskUtil.createJdbcSelectTask(
             /* format= */ "SELECT A, B, C FROM %1$s.TABLE%2$s",
             /* schemaName= */ "SCHEMA",
             /* zipEntryName= */ "file.csv",


### PR DESCRIPTION
Generate a query for each database's info schema, allowing the --database flag to accept a list rather than just one at a time.

We are doing this to reduce customer toil. Previously if they wanted to use the database filter they could only use one at a time, meaning the metadata could not be extracted in a single run. This change makes that more feasible.