### PR TITLE
Fix: Exclude custom queries from metadata

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -1157,6 +1157,15 @@ public class ConnectorArguments extends DefaultArguments {
   @Override
   @Nonnull
   public String toString() {
+    return buildToString(/* excludeQueries= */ false);
+  }
+
+  @Nonnull
+  public String toStringWithoutCustomQueries() {
+    return buildToString(/* excludeQueries= */ true);
+  }
+
+  private String buildToString(boolean excludeQueries) {
     // We do not include password here b/c as of this writing,
     // this string representation is logged out to file by ArgumentsTask.
     ToStringHelper toStringHelper =
@@ -1178,7 +1187,9 @@ public class ConnectorArguments extends DefaultArguments {
             .add(OPT_SPARK_HISTORY_SERVICE_NAMES, getSparkHistoryServiceNames())
             .add(OPT_ASSESSMENT, isAssessment())
             .add(OPT_TELEMETRY, isTelemetryOn());
-    getConnectorProperties().getDefinitionMap().forEach(toStringHelper::add);
+    getConnectorProperties().getDefinitionMap().entrySet().stream()
+        .filter(entry -> !excludeQueries || !entry.getKey().contains(".query"))
+        .forEach(entry -> toStringHelper.add(entry.getKey(), entry.getValue()));
     return toStringHelper.toString();
   }
 

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/DumpMetadataTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/DumpMetadataTask.java
@@ -58,7 +58,8 @@ public class DumpMetadataTask extends AbstractTask<Void>
     {
       Product product = new Product();
       product.version = String.valueOf(new ProductMetadata());
-      product.arguments = String.valueOf(getArguments(context));
+      ConnectorArguments args = getArguments(context);
+      product.arguments = args != null ? args.toStringWithoutCustomQueries() : "null";
       root.product = product;
     }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/ConnectorArgumentsTest.java
@@ -156,6 +156,35 @@ public class ConnectorArgumentsTest {
     assertEquals(expectedName, actualName);
   }
 
+  @Test
+  public void toString_excludesQueryProperties() throws IOException {
+    ConnectorArguments arguments =
+        new ConnectorArguments(
+            "--connector",
+            "snowflake-logs",
+            "-D",
+            "snowflake.logs.query=SELECT * FROM logs",
+            "-D",
+            "snowflake.logs.where=id = 123",
+            "-D",
+            "snowflake.warehouse_events_history.query=SELECT * FROM warehouse_events");
+
+    String defaultToString = arguments.toString();
+    assertTrue(
+        "Should contain query definitions by default",
+        defaultToString.contains("SELECT * FROM logs"));
+    assertTrue(
+        "Should contain query definitions by default",
+        defaultToString.contains("SELECT * FROM warehouse_events"));
+
+    String result = arguments.toStringWithoutCustomQueries();
+
+    assertFalse("Should not contain query definitions", result.contains("SELECT * FROM logs"));
+    assertFalse(
+        "Should not contain query definitions", result.contains("SELECT * FROM warehouse_events"));
+    assertTrue("Should contain other definitions", result.contains("id = 123"));
+  }
+
   // helper method to suppress IOException
   private static ConnectorArguments arguments(String... terms) {
     try {


### PR DESCRIPTION
This change excludes custom queries from `compilerworks-metadata.yaml` file. Custom queries are not used now in the assessment pipeline.