### PR TITLE
Fixing features.csv file logic for appending values

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/FeaturesQueryPath.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/FeaturesQueryPath.java
@@ -29,19 +29,19 @@ enum FeaturesQueryPath {
   SIMPLE("account-usage-simple.sql") {
     @Override
     TaskOptions taskOptions() {
-      return TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
+      return TaskOptions.DEFAULT;
     }
   },
   COMPLEX("account-usage-complex.sql") {
     @Override
     TaskOptions taskOptions() {
-      return TaskOptions.DEFAULT;
+      return TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
     }
   },
   SHOW_BASED("show-based.sql") {
     @Override
     TaskOptions taskOptions() {
-      return TaskOptions.DEFAULT;
+      return TaskOptions.DEFAULT.withWriteMode(WriteMode.APPEND_EXISTING);
     }
   };
 


### PR DESCRIPTION
Fixing b/534669263.

Fixed WriteMode for features sqls, which are used in features.csv. For the first sql:`SIMPLE("account-usage-simple.sql")` it should be default write mode, for the rest append to existing.