### PR TITLE
[Snowflake] Support schema filtering in Snowflake metadata connector

### DIFF
--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/ConnectorArguments.java
@@ -778,8 +778,11 @@ public class ConnectorArguments extends DefaultArguments {
   }
 
   @Nonnull
-  public List<String> getSchemata() {
-    return getOptions().valuesOf(optionSchema);
+  public ImmutableList<String> getSchemata() {
+    return getOptions().valuesOf(optionSchema).stream()
+        .map(String::trim)
+        .filter(StringUtils::isNotEmpty)
+        .collect(toImmutableList());
   }
 
   public boolean isAssessment() {

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -29,6 +29,7 @@ import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabaseForConnection;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentDatabasePredicate;
+import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentSchemaPredicate;
 import com.google.edwmigration.dumper.application.dumper.connector.Connector;
 import com.google.edwmigration.dumper.application.dumper.connector.ConnectorProperty;
 import com.google.edwmigration.dumper.application.dumper.connector.MetadataConnector;
@@ -57,6 +58,7 @@ import javax.annotation.Nonnull;
 @RespectsArgumentAssessment
 @RespectsArgumentDatabaseForConnection
 @RespectsArgumentDatabasePredicate
+@RespectsArgumentSchemaPredicate
 public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     implements MetadataConnector, SnowflakeMetadataDumpFormat {
 
@@ -133,7 +135,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   @Override
   protected void validateForConnector(@Nonnull ConnectorArguments arguments) {
     boolean hasDatabases = !arguments.getDatabases().isEmpty();
-    if (arguments.isAssessment() && hasDatabases) {
+    boolean hasSchemata = !arguments.getSchemata().isEmpty();
+    if (arguments.isAssessment() && (hasDatabases || hasSchemata)) {
       throw SnowflakeUsageException.unsupportedFilter();
     }
   }
@@ -146,17 +149,23 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       @Nonnull String accountUsageFileName,
       @Nonnull String accountUsageWhereCondition,
       @Nonnull ConnectorArguments arguments,
-      @Nonnull String databaseFilterColumnName) {
+      @Nonnull String databaseFilterColumnName,
+      @Nonnull String schemaFilterColumnName) {
     ImmutableList<String> databases = arguments.getDatabases();
+    List<String> schemata = arguments.getSchemata();
     boolean isAssessment = arguments.isAssessment();
     String globalDatabaseFilter =
         getInformationSchemaWhereCondition(databaseFilterColumnName, databases);
+    String globalSchemaFilter =
+        schemaFilterColumnName.equals(EMPTY_WHERE_CONDITION)
+            ? EMPTY_WHERE_CONDITION
+            : getInformationSchemaWhereCondition(schemaFilterColumnName, schemata);
     AbstractJdbcTask<Summary> usageTask =
         SnowflakeTaskUtil.createJdbcSelectTask(
             format,
             ACCOUNT_USAGE_SCHEMA_NAME,
             accountUsageFileName,
-            ImmutableList.of(accountUsageWhereCondition, globalDatabaseFilter),
+            ImmutableList.of(accountUsageWhereCondition, globalDatabaseFilter, globalSchemaFilter),
             header);
     if (isAssessment) {
       out.add(usageTask);
@@ -169,7 +178,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
               format,
               "INFORMATION_SCHEMA",
               informationSchemaFileName,
-              ImmutableList.of(""),
+              ImmutableList.of(globalSchemaFilter),
               header);
       out.addAll(inputSource.sqlTasks(schemaTask, usageTask));
       return;
@@ -193,15 +202,12 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       TaskOptions taskOptions = TaskOptions.DEFAULT;
       for (String database : databases) {
         String schemaPrefix = sanitizeDatabaseName(database) + ".INFORMATION_SCHEMA";
-        String databaseFilter =
-            getInformationSchemaWhereCondition(
-                databaseFilterColumnName, ImmutableList.of(database));
         AbstractJdbcTask<Summary> schemaTask =
             SnowflakeTaskUtil.createJdbcSelectTask(
                 format,
                 schemaPrefix,
                 informationSchemaFileName,
-                ImmutableList.of(databaseFilter),
+                ImmutableList.of(globalSchemaFilter),
                 header,
                 taskOptions);
         if (inputSource == SnowflakeInput.USAGE_THEN_SCHEMA_SOURCE) {
@@ -233,7 +239,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         DatabasesFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         arguments,
-        "database_name");
+        "database_name",
+        EMPTY_WHERE_CONDITION); // Changed to EMPTY_WHERE_CONDITION
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -246,7 +253,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         SchemataFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         arguments,
-        "catalog_name");
+        "catalog_name",
+        "schema_name");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -260,7 +268,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         TablesFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         arguments,
-        "table_catalog");
+        "table_catalog",
+        "table_schema");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -275,7 +284,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ColumnsFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         arguments,
-        "table_catalog");
+        "table_catalog",
+        "table_schema");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -288,7 +298,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         ViewsFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         arguments,
-        "table_catalog");
+        "table_catalog",
+        "table_schema");
 
     addSqlTasksWithInfoSchemaFallback(
         out,
@@ -302,7 +313,8 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
         FunctionsFormat.AU_ZIP_ENTRY_NAME,
         ACCOUNT_USAGE_WHERE_CONDITION,
         arguments,
-        "function_catalog");
+        "function_catalog",
+        "function_schema");
 
     if (isAssessment) {
       out.addAll(featuresTasks());
@@ -317,8 +329,9 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       return;
     }
     ImmutableList<String> databases = arguments.getDatabases();
+    List<String> schemata = arguments.getSchemata();
 
-    if (databases.isEmpty()) {
+    if (databases.isEmpty() && schemata.isEmpty()) {
       AssessmentQuery query = SnowflakePlanner.SHOW_EXTERNAL_TABLES;
       Task<?> task = convertAssessmentQuery(query, arguments, TaskOptions.DEFAULT);
       out.add(task);
@@ -327,16 +340,42 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
 
     TaskOptions taskOptions = TaskOptions.DEFAULT;
 
-    for (String item : databases) {
-      String quotedName = databaseNameQuoted(item);
-      AssessmentQuery query = planner.externalTablesInDatabase(quotedName);
-      Task<?> task =
-          new JdbcSelectTask(
-                  query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
-              .withHeaderTransformer(query.transformer());
-      out.add(task);
-      // Next tasks will append to the same file.
-      taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+    if (!databases.isEmpty() && schemata.isEmpty()) {
+      for (String item : databases) {
+        String quotedName = identifierNameQuoted(item);
+        AssessmentQuery query = planner.externalTablesInDatabase(quotedName);
+        Task<?> task =
+            new JdbcSelectTask(
+                    query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
+                .withHeaderTransformer(query.transformer());
+        out.add(task);
+        // Next tasks will append to the same file.
+        taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+      }
+    } else if (databases.isEmpty() && !schemata.isEmpty()) {
+      for (String schema : schemata) {
+        String quotedName = identifierNameQuoted(schema);
+        AssessmentQuery query = planner.externalTablesInSchema(quotedName);
+        Task<?> task =
+            new JdbcSelectTask(
+                    query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
+                .withHeaderTransformer(query.transformer());
+        out.add(task);
+        taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+      }
+    } else {
+      for (String db : databases) {
+        for (String schema : schemata) {
+          String quotedName = identifierNameQuoted(db) + "." + identifierNameQuoted(schema);
+          AssessmentQuery query = planner.externalTablesInSchema(quotedName);
+          Task<?> task =
+              new JdbcSelectTask(
+                      query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
+                  .withHeaderTransformer(query.transformer());
+          out.add(task);
+          taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+        }
+      }
     }
   }
 
@@ -430,20 +469,20 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   private static String getInformationSchemaWhereCondition(
-      @Nonnull String databaseNameColumn, @Nonnull ImmutableList<String> databaseNames) {
+      @Nonnull String databaseNameColumn, @Nonnull List<String> databaseNames) {
     if (databaseNames.isEmpty()) {
       return EMPTY_WHERE_CONDITION;
     }
     String quotedNames =
         databaseNames.stream()
-            .map(SnowflakeMetadataConnector::databaseNameStringLiteral)
+            .map(SnowflakeMetadataConnector::identifierNameStringLiteral)
             .collect(Collectors.joining(", "));
 
     return String.format("%s IN (%s)", databaseNameColumn, quotedNames);
   }
 
   @VisibleForTesting
-  public static String databaseNameStringLiteral(@Nonnull String databaseName) {
+  public static String identifierNameStringLiteral(@Nonnull String databaseName) {
     if (databaseName.startsWith("\"") && databaseName.endsWith("\"")) {
       // This is a quoted identifier, it should be matched case-sensitively
       databaseName = databaseName.substring(1, databaseName.length() - 1);
@@ -456,7 +495,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   @VisibleForTesting
-  public static String databaseNameQuoted(@Nonnull String databaseName) {
+  public static String identifierNameQuoted(@Nonnull String databaseName) {
     if (databaseName.startsWith("\"") && databaseName.endsWith("\"")) {
       // This is a quoted identifier, it should be matched case-sensitively
       databaseName = databaseName.substring(1, databaseName.length() - 1);

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnector.java
@@ -24,6 +24,8 @@ import static com.google.edwmigration.dumper.application.dumper.connector.snowfl
 
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.edwmigration.dumper.application.dumper.ConnectorArguments;
 import com.google.edwmigration.dumper.application.dumper.annotations.RespectsArgumentAssessment;
@@ -44,8 +46,11 @@ import com.google.edwmigration.dumper.application.dumper.task.Summary;
 import com.google.edwmigration.dumper.application.dumper.task.Task;
 import com.google.edwmigration.dumper.application.dumper.task.TaskCategory;
 import com.google.edwmigration.dumper.plugin.lib.dumper.spi.SnowflakeMetadataDumpFormat;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
@@ -152,7 +157,7 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
       @Nonnull String databaseFilterColumnName,
       @Nonnull String schemaFilterColumnName) {
     ImmutableList<String> databases = arguments.getDatabases();
-    List<String> schemata = arguments.getSchemata();
+    ImmutableList<String> schemata = arguments.getSchemata();
     boolean isAssessment = arguments.isAssessment();
     String globalDatabaseFilter =
         getInformationSchemaWhereCondition(databaseFilterColumnName, databases);
@@ -330,51 +335,27 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
     }
     ImmutableList<String> databases = arguments.getDatabases();
     List<String> schemata = arguments.getSchemata();
-
-    if (databases.isEmpty() && schemata.isEmpty()) {
-      AssessmentQuery query = SnowflakePlanner.SHOW_EXTERNAL_TABLES;
-      Task<?> task = convertAssessmentQuery(query, arguments, TaskOptions.DEFAULT);
-      out.add(task);
-      return;
-    }
-
     TaskOptions taskOptions = TaskOptions.DEFAULT;
-
-    if (!databases.isEmpty() && schemata.isEmpty()) {
-      for (String item : databases) {
-        String quotedName = identifierNameQuoted(item);
-        AssessmentQuery query = planner.externalTablesInDatabase(quotedName);
-        Task<?> task =
-            new JdbcSelectTask(
-                    query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
-                .withHeaderTransformer(query.transformer());
-        out.add(task);
-        // Next tasks will append to the same file.
-        taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+    if (databases.isEmpty()) {
+      AssessmentQuery query = SnowflakePlanner.SHOW_EXTERNAL_TABLES;
+      Task<?> task = convertAssessmentQuery(query, arguments, taskOptions);
+      if (!schemata.isEmpty() && task instanceof AbstractJdbcTask) {
+        ((AbstractJdbcTask<?>) task).withPredicate(createSchemaPredicate("schema_name", schemata));
       }
-    } else if (databases.isEmpty() && !schemata.isEmpty()) {
-      for (String schema : schemata) {
-        String quotedName = identifierNameQuoted(schema);
-        AssessmentQuery query = planner.externalTablesInSchema(quotedName);
-        Task<?> task =
-            new JdbcSelectTask(
-                    query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
-                .withHeaderTransformer(query.transformer());
-        out.add(task);
-        taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
-      }
+      out.add(task);
     } else {
-      for (String db : databases) {
-        for (String schema : schemata) {
-          String quotedName = identifierNameQuoted(db) + "." + identifierNameQuoted(schema);
-          AssessmentQuery query = planner.externalTablesInSchema(quotedName);
-          Task<?> task =
-              new JdbcSelectTask(
-                      query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
-                  .withHeaderTransformer(query.transformer());
-          out.add(task);
-          taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
+      for (String database : databases) {
+        String quotedName = identifierNameQuoted(database);
+        AssessmentQuery query = planner.externalTablesInDatabase(quotedName);
+        AbstractJdbcTask<?> task =
+            new JdbcSelectTask(
+                    query.zipEntryName, query.formatString, TaskCategory.REQUIRED, taskOptions)
+                .withHeaderTransformer(query.transformer());
+        if (!schemata.isEmpty()) {
+          task.withPredicate(createSchemaPredicate("schema_name", schemata));
         }
+        out.add(task);
+        taskOptions = taskOptions.withWriteMode(WriteMode.APPEND_EXISTING);
       }
     }
   }
@@ -469,41 +450,91 @@ public class SnowflakeMetadataConnector extends AbstractSnowflakeConnector
   }
 
   private static String getInformationSchemaWhereCondition(
-      @Nonnull String databaseNameColumn, @Nonnull List<String> databaseNames) {
-    if (databaseNames.isEmpty()) {
+      @Nonnull String columnName, @Nonnull ImmutableList<String> objectNames) {
+    if (objectNames.isEmpty()) {
       return EMPTY_WHERE_CONDITION;
     }
     String quotedNames =
-        databaseNames.stream()
+        objectNames.stream()
             .map(SnowflakeMetadataConnector::identifierNameStringLiteral)
             .collect(Collectors.joining(", "));
 
-    return String.format("%s IN (%s)", databaseNameColumn, quotedNames);
+    return String.format("%s IN (%s)", columnName, quotedNames);
   }
 
   @VisibleForTesting
-  public static String identifierNameStringLiteral(@Nonnull String databaseName) {
-    if (databaseName.startsWith("\"") && databaseName.endsWith("\"")) {
-      // This is a quoted identifier, it should be matched case-sensitively
-      databaseName = databaseName.substring(1, databaseName.length() - 1);
-    } else {
-      // Unquoted identifiers are stored uppercase, single quotes need to be escaped.
-      databaseName = databaseName.toUpperCase();
-    }
-    databaseName = databaseName.replace("'", "''");
-    return String.format("'%s'", databaseName);
+  public static String identifierNameStringLiteral(@Nonnull String identifierName) {
+    String rawIdentifierString = identifierNameStringRaw(identifierName);
+    String escapedIdentifierSqlLiteral = rawIdentifierString.replace("'", "''");
+    return String.format("'%s'", escapedIdentifierSqlLiteral);
   }
 
   @VisibleForTesting
-  public static String identifierNameQuoted(@Nonnull String databaseName) {
-    if (databaseName.startsWith("\"") && databaseName.endsWith("\"")) {
+  public static String identifierNameQuoted(@Nonnull String identifierName) {
+    String rawIdentifierString = identifierNameStringRaw(identifierName);
+    String escapedIdentifierName = rawIdentifierString.replace("\"", "\"\"");
+    return String.format("\"%s\"", escapedIdentifierName);
+  }
+
+  @Nonnull
+  public static Predicate<ResultSet> createSchemaPredicate(
+      @Nonnull String schemaColumnName, @Nonnull List<String> schemata) {
+    if (schemata.isEmpty()) {
+      return Predicates.alwaysTrue();
+    }
+    Predicate<String> schemaPredicate = createSchemaPredicate(schemata);
+    return new Predicate<ResultSet>() {
+      private int columnIndex = -1;
+
+      @Override
+      public boolean apply(ResultSet resultSet) {
+        try {
+          if (columnIndex == -1) {
+            columnIndex = findColumnIndex(resultSet, schemaColumnName);
+          }
+          if (columnIndex > 0) {
+            String schemaValue = resultSet.getString(columnIndex);
+            return schemaPredicate.apply(schemaValue);
+          }
+          return true;
+        } catch (SQLException e) {
+          return true;
+        }
+      }
+    };
+  }
+
+  @Nonnull
+  public static Predicate<String> createSchemaPredicate(@Nonnull List<String> schemata) {
+    if (schemata.isEmpty()) {
+      return Predicates.alwaysTrue();
+    }
+    Set<String> set =
+        schemata.stream()
+            .map(SnowflakeMetadataConnector::identifierNameStringRaw)
+            .collect(Collectors.toSet());
+    return input -> input != null && (set.contains(input));
+  }
+
+  private static int findColumnIndex(ResultSet resultSet, String columnName) throws SQLException {
+    int count = resultSet.getMetaData().getColumnCount();
+    for (int i = 1; i <= count; i++) {
+      if (columnName.equalsIgnoreCase(resultSet.getMetaData().getColumnLabel(i))
+          || columnName.equalsIgnoreCase(resultSet.getMetaData().getColumnName(i))) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static String identifierNameStringRaw(@Nonnull String identifierName) {
+    if (identifierName.startsWith("\"") && identifierName.endsWith("\"")) {
       // This is a quoted identifier, it should be matched case-sensitively
-      databaseName = databaseName.substring(1, databaseName.length() - 1);
+      identifierName = identifierName.substring(1, identifierName.length() - 1);
     } else {
       // Unquoted identifiers are stored uppercase, single quotes need to be escaped.
-      databaseName = databaseName.toUpperCase();
+      identifierName = identifierName.toUpperCase();
     }
-    databaseName = databaseName.replace("\"", "\"\"");
-    return String.format("\"%s\"", databaseName);
+    return identifierName;
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -107,6 +107,12 @@ final class SnowflakePlanner {
     return new AssessmentQuery(false, query, zipEntryName, LOWER_UNDERSCORE);
   }
 
+  AssessmentQuery externalTablesInSchema(String quotedSchemaName) {
+    String query = String.format("SHOW EXTERNAL TABLES IN SCHEMA %s", quotedSchemaName);
+    String zipEntryName = Format.EXTERNAL_TABLES.value;
+    return new AssessmentQuery(false, query, zipEntryName, LOWER_UNDERSCORE);
+  }
+
   ImmutableList<AssessmentQuery> generateAssessmentQueries() {
     return assessmentQueries;
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakePlanner.java
@@ -107,12 +107,6 @@ final class SnowflakePlanner {
     return new AssessmentQuery(false, query, zipEntryName, LOWER_UNDERSCORE);
   }
 
-  AssessmentQuery externalTablesInSchema(String quotedSchemaName) {
-    String query = String.format("SHOW EXTERNAL TABLES IN SCHEMA %s", quotedSchemaName);
-    String zipEntryName = Format.EXTERNAL_TABLES.value;
-    return new AssessmentQuery(false, query, zipEntryName, LOWER_UNDERSCORE);
-  }
-
   ImmutableList<AssessmentQuery> generateAssessmentQueries() {
     return assessmentQueries;
   }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeUsageException.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeUsageException.java
@@ -17,7 +17,6 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_ASSESSMENT;
-import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_DATABASE;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_PRIVATE_KEY_PASSWORD;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP;
 import static java.util.stream.Collectors.joining;
@@ -86,9 +85,11 @@ class SnowflakeUsageException extends MetadataDumperUsageException {
   static SnowflakeUsageException unsupportedFilter() {
     Stream<String> messages =
         Stream.of(
-            "Trying to filter by database with the --" + OPT_ASSESSMENT + " flag.",
+            "Trying to filter by database or schema with the --" + OPT_ASSESSMENT + " flag.",
             "This is unsupported in Assessment.",
-            "Remove either the --" + OPT_ASSESSMENT + " or the --" + OPT_DATABASE + " flag.");
+            "Remove either the --"
+                + OPT_ASSESSMENT
+                + " or the filter flags (--database/--schema).");
     return new SnowflakeUsageException(messages.collect(joining(" ")));
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeUsageException.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeUsageException.java
@@ -17,8 +17,10 @@
 package com.google.edwmigration.dumper.application.dumper.connector.snowflake;
 
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_ASSESSMENT;
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_DATABASE;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_PRIVATE_KEY_PASSWORD;
 import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_QUERY_LOG_EARLIEST_TIMESTAMP;
+import static com.google.edwmigration.dumper.application.dumper.ConnectorArguments.OPT_SCHEMA;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.collect.ImmutableList;
@@ -89,7 +91,11 @@ class SnowflakeUsageException extends MetadataDumperUsageException {
             "This is unsupported in Assessment.",
             "Remove either the --"
                 + OPT_ASSESSMENT
-                + " or the filter flags (--database/--schema).");
+                + " or the filter flags (--"
+                + OPT_DATABASE
+                + "/--"
+                + OPT_SCHEMA
+                + ").");
     return new SnowflakeUsageException(messages.collect(joining(" ")));
   }
 }

--- a/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
+++ b/dumper/app/src/main/java/com/google/edwmigration/dumper/application/dumper/task/AbstractJdbcTask.java
@@ -18,6 +18,7 @@ package com.google.edwmigration.dumper.application.dumper.task;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import com.google.common.base.Predicate;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.ByteSink;
 import com.google.edwmigration.dumper.application.dumper.MetadataDumperUsageException;
@@ -63,6 +64,7 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
 
   @CheckForNull private Class<? extends Enum<?>> headerClass;
   @CheckForNull private ResultSetTransformer<String[]> headerTransformer;
+  @CheckForNull private Predicate<ResultSet> predicate;
 
   public AbstractJdbcTask(@Nonnull String targetPath) {
     super(targetPath);
@@ -87,6 +89,12 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
   public AbstractJdbcTask<T> withHeaderTransformer(
       @Nonnull ResultSetTransformer<String[]> headerTransformer) {
     this.headerTransformer = headerTransformer;
+    return this;
+  }
+
+  @Nonnull
+  public AbstractJdbcTask<T> withPredicate(@Nonnull Predicate<ResultSet> predicate) {
+    this.predicate = predicate;
     return this;
   }
 
@@ -155,6 +163,9 @@ public abstract class AbstractJdbcTask<T> extends AbstractTask<T> {
         CSVPrinter printer = format.print(writer)) {
       int columnCount = resultSet.getMetaData().getColumnCount();
       while (resultSet.next()) {
+        if (predicate != null && !predicate.apply(resultSet)) {
+          continue;
+        }
         monitor.count();
         for (int i = 1; i <= columnCount; i++) {
           Object resultItem = resultSet.getObject(i);

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/AbstractSnowflakeConnectorTest.java
@@ -167,7 +167,23 @@ public class AbstractSnowflakeConnectorTest extends AbstractConnectorTest {
 
     assertTrue(
         e.getMessage(),
-        e.getMessage().contains("Trying to filter by database with the --assessment flag."));
+        e.getMessage()
+            .contains("Trying to filter by database or schema with the --assessment flag."));
+  }
+
+  @Test
+  public void validate_assessmentEnabledWithSchemaFilter_throwsUsageException() throws IOException {
+    ConnectorArguments arguments =
+        makeArguments("--connector", "snowflake", "--schema", "PUBLIC", "--assessment");
+
+    MetadataDumperUsageException e =
+        assertThrows(
+            MetadataDumperUsageException.class, () -> metadataConnector.validate(arguments));
+
+    assertTrue(
+        e.getMessage(),
+        e.getMessage()
+            .contains("Trying to filter by database or schema with the --assessment flag."));
   }
 
   @Test

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -273,7 +273,7 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
     assertEquals(
         "SELECT function_schema, function_name, data_type, argument_signature FROM INFORMATION_SCHEMA.FUNCTIONS WHERE function_schema IN ('SCHEMA1', 'SCHEMA2')",
         actualSqls.get("functions.csv"));
-
+    assertEquals("SHOW EXTERNAL TABLES", actualSqls.get("external_tables.csv"));
   }
 
   @Test
@@ -291,7 +291,8 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
             "SELECT catalog_name, schema_name FROM db2.INFORMATION_SCHEMA.SCHEMATA WHERE schema_name IN ('SCHEMA1', 'SCHEMA2')"),
         actualSqls.get("schemata.csv"));
     assertEquals(
-        ImmutableList.of("SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES WHERE DELETED IS NULL AND table_catalog IN ('DB1', 'DB2') AND table_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        ImmutableList.of(
+            "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES WHERE DELETED IS NULL AND table_catalog IN ('DB1', 'DB2') AND table_schema IN ('SCHEMA1', 'SCHEMA2')"),
         actualSqls.get("tables-au.csv"));
     assertEquals(
         ImmutableList.of(
@@ -318,10 +319,7 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
         actualSqls.get("functions.csv"));
     assertEquals(
         ImmutableList.of(
-            "SHOW EXTERNAL TABLES IN SCHEMA \"DB1\".\"SCHEMA1\"",
-            "SHOW EXTERNAL TABLES IN SCHEMA \"DB1\".\"SCHEMA2\"",
-            "SHOW EXTERNAL TABLES IN SCHEMA \"DB2\".\"SCHEMA1\"",
-            "SHOW EXTERNAL TABLES IN SCHEMA \"DB2\".\"SCHEMA2\""),
+            "SHOW EXTERNAL TABLES IN DATABASE \"DB1\"", "SHOW EXTERNAL TABLES IN DATABASE \"DB2\""),
         actualSqls.get("external_tables.csv"));
   }
 

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/connector/snowflake/SnowflakeMetadataConnectorTest.java
@@ -216,7 +216,7 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
         "SELECT catalog_name, schema_name FROM SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA WHERE DELETED IS NULL AND catalog_name IN ('DB1')",
         actualSqls.get("schemata-au.csv"));
     assertEquals(
-        "SELECT catalog_name, schema_name FROM db1.INFORMATION_SCHEMA.SCHEMATA WHERE catalog_name IN ('DB1')",
+        "SELECT catalog_name, schema_name FROM db1.INFORMATION_SCHEMA.SCHEMATA",
         actualSqls.get("schemata.csv"));
     assertEquals("SHOW EXTERNAL TABLES IN DATABASE \"DB1\"", actualSqls.get("external_tables.csv"));
   }
@@ -246,27 +246,107 @@ public class SnowflakeMetadataConnectorTest extends AbstractSnowflakeConnectorEx
   }
 
   @Test
-  public void databaseNameStringLiteral() {
-    assertEquals("'ABC'", SnowflakeMetadataConnector.databaseNameStringLiteral("abc"));
-    assertEquals("'abc'", SnowflakeMetadataConnector.databaseNameStringLiteral("\"abc\""));
+  public void connector_generatesExpectedSql_withSchemaFilter() throws IOException {
+    Map<String, String> actualSqls = collectSqlStatements("--schema", "schema1,schema2");
 
-    assertEquals("''''", SnowflakeMetadataConnector.databaseNameStringLiteral("'"));
-    assertEquals("''''", SnowflakeMetadataConnector.databaseNameStringLiteral("\"'\""));
+    assertEquals(
+        "SELECT catalog_name, schema_name FROM SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA WHERE DELETED IS NULL AND schema_name IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("schemata-au.csv"));
+    assertEquals(
+        "SELECT catalog_name, schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("schemata.csv"));
+    assertEquals(
+        "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES WHERE DELETED IS NULL AND table_schema IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("tables-au.csv"));
+    assertEquals(
+        "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM INFORMATION_SCHEMA.TABLES WHERE table_schema IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("tables.csv"));
+    assertEquals(
+        "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_scale, datetime_precision, comment FROM SNOWFLAKE.ACCOUNT_USAGE.COLUMNS WHERE DELETED IS NULL AND table_schema IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("columns-au.csv"));
+    assertEquals(
+        "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_scale, datetime_precision, comment FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("columns.csv"));
+    assertEquals(
+        "SELECT function_schema, function_name, data_type, argument_signature FROM SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS WHERE DELETED IS NULL AND function_schema IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("functions-au.csv"));
+    assertEquals(
+        "SELECT function_schema, function_name, data_type, argument_signature FROM INFORMATION_SCHEMA.FUNCTIONS WHERE function_schema IN ('SCHEMA1', 'SCHEMA2')",
+        actualSqls.get("functions.csv"));
 
-    assertEquals("'A''C\"'", SnowflakeMetadataConnector.databaseNameStringLiteral("a'c\""));
-    assertEquals("'a''c\"'", SnowflakeMetadataConnector.databaseNameStringLiteral("\"a'c\"\""));
   }
 
   @Test
-  public void databaseNameQuoted() {
-    assertEquals("\"ABC\"", SnowflakeMetadataConnector.databaseNameQuoted("abc"));
-    assertEquals("\"abc\"", SnowflakeMetadataConnector.databaseNameQuoted("\"abc\""));
+  public void connector_generatesExpectedSql_withDatabaseAndSchemaFilter() throws IOException {
+    ImmutableMultimap<String, String> actualSqls =
+        collectSqlStatementsAsMultimap("--database", "db1,db2", "--schema", "schema1,schema2");
 
-    assertEquals("\"'\"", SnowflakeMetadataConnector.databaseNameQuoted("'"));
-    assertEquals("\"'\"", SnowflakeMetadataConnector.databaseNameQuoted("\"'\""));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT catalog_name, schema_name FROM SNOWFLAKE.ACCOUNT_USAGE.SCHEMATA WHERE DELETED IS NULL AND catalog_name IN ('DB1', 'DB2') AND schema_name IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("schemata-au.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT catalog_name, schema_name FROM db1.INFORMATION_SCHEMA.SCHEMATA WHERE schema_name IN ('SCHEMA1', 'SCHEMA2')",
+            "SELECT catalog_name, schema_name FROM db2.INFORMATION_SCHEMA.SCHEMATA WHERE schema_name IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("schemata.csv"));
+    assertEquals(
+        ImmutableList.of("SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM SNOWFLAKE.ACCOUNT_USAGE.TABLES WHERE DELETED IS NULL AND table_catalog IN ('DB1', 'DB2') AND table_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("tables-au.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM db1.INFORMATION_SCHEMA.TABLES WHERE table_schema IN ('SCHEMA1', 'SCHEMA2')",
+            "SELECT table_catalog, table_schema, table_name, table_type, row_count, bytes, clustering_key FROM db2.INFORMATION_SCHEMA.TABLES WHERE table_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("tables.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_scale, datetime_precision, comment FROM SNOWFLAKE.ACCOUNT_USAGE.COLUMNS WHERE DELETED IS NULL AND table_catalog IN ('DB1', 'DB2') AND table_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("columns-au.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_scale, datetime_precision, comment FROM db1.INFORMATION_SCHEMA.COLUMNS WHERE table_schema IN ('SCHEMA1', 'SCHEMA2')",
+            "SELECT table_catalog, table_schema, table_name, ordinal_position, column_name, data_type, is_nullable, column_default, character_maximum_length, numeric_precision, numeric_scale, datetime_precision, comment FROM db2.INFORMATION_SCHEMA.COLUMNS WHERE table_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("columns.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT function_schema, function_name, data_type, argument_signature FROM SNOWFLAKE.ACCOUNT_USAGE.FUNCTIONS WHERE DELETED IS NULL AND function_catalog IN ('DB1', 'DB2') AND function_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("functions-au.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SELECT function_schema, function_name, data_type, argument_signature FROM db1.INFORMATION_SCHEMA.FUNCTIONS WHERE function_schema IN ('SCHEMA1', 'SCHEMA2')",
+            "SELECT function_schema, function_name, data_type, argument_signature FROM db2.INFORMATION_SCHEMA.FUNCTIONS WHERE function_schema IN ('SCHEMA1', 'SCHEMA2')"),
+        actualSqls.get("functions.csv"));
+    assertEquals(
+        ImmutableList.of(
+            "SHOW EXTERNAL TABLES IN SCHEMA \"DB1\".\"SCHEMA1\"",
+            "SHOW EXTERNAL TABLES IN SCHEMA \"DB1\".\"SCHEMA2\"",
+            "SHOW EXTERNAL TABLES IN SCHEMA \"DB2\".\"SCHEMA1\"",
+            "SHOW EXTERNAL TABLES IN SCHEMA \"DB2\".\"SCHEMA2\""),
+        actualSqls.get("external_tables.csv"));
+  }
 
-    assertEquals("\"A'C\"\"\"", SnowflakeMetadataConnector.databaseNameQuoted("a'c\""));
-    assertEquals("\"a'c\"\"\"", SnowflakeMetadataConnector.databaseNameQuoted("\"a'c\"\""));
+  @Test
+  public void identifierNameStringLiteral() {
+    assertEquals("'ABC'", SnowflakeMetadataConnector.identifierNameStringLiteral("abc"));
+    assertEquals("'abc'", SnowflakeMetadataConnector.identifierNameStringLiteral("\"abc\""));
+
+    assertEquals("''''", SnowflakeMetadataConnector.identifierNameStringLiteral("'"));
+    assertEquals("''''", SnowflakeMetadataConnector.identifierNameStringLiteral("\"'\""));
+
+    assertEquals("'A''C\"'", SnowflakeMetadataConnector.identifierNameStringLiteral("a'c\""));
+    assertEquals("'a''c\"'", SnowflakeMetadataConnector.identifierNameStringLiteral("\"a'c\"\""));
+  }
+
+  @Test
+  public void identifierNameQuoted() {
+    assertEquals("\"ABC\"", SnowflakeMetadataConnector.identifierNameQuoted("abc"));
+    assertEquals("\"abc\"", SnowflakeMetadataConnector.identifierNameQuoted("\"abc\""));
+
+    assertEquals("\"'\"", SnowflakeMetadataConnector.identifierNameQuoted("'"));
+    assertEquals("\"'\"", SnowflakeMetadataConnector.identifierNameQuoted("\"'\""));
+
+    assertEquals("\"A'C\"\"\"", SnowflakeMetadataConnector.identifierNameQuoted("a'c\""));
+    assertEquals("\"a'c\"\"\"", SnowflakeMetadataConnector.identifierNameQuoted("\"a'c\"\""));
   }
 
   private static ImmutableMultimap<String, String> collectSqlStatementsAsMultimap(

--- a/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectTaskTest.java
+++ b/dumper/app/src/test/java/com/google/edwmigration/dumper/application/dumper/task/JdbcSelectTaskTest.java
@@ -146,4 +146,25 @@ public class JdbcSelectTaskTest {
     String actualOutput = sink.openStream().toString();
     assertEquals("Foo,Bar,Baz\n,14,3\n,15,2\n", actualOutput);
   }
+
+  @Test
+  public void testWithPredicate() throws Exception {
+    String sql = "SELECT a, b, c FROM foo";
+    MemoryByteSink sink = new MemoryByteSink();
+    try (JdbcHandle handle = DumperTestUtils.newJdbcHandle(FILE)) {
+      AbstractJdbcTask<Summary> task =
+          new JdbcSelectTask("(memory)", sql)
+              .withPredicate(
+                  rs -> {
+                    try {
+                      return rs.getInt("a") > 1;
+                    } catch (SQLException e) {
+                      return false;
+                    }
+                  });
+      task.doRun(mockContext, sink, handle);
+    }
+    String actualOutput = sink.openStream().toString();
+    assertEquals("a,b,c\n", actualOutput);
+  }
 }


### PR DESCRIPTION
1. Add support for --schema "schema1, schema2"
2. Fix a minor issue that we add extra database where condition for information_schema query.